### PR TITLE
Van/colorupdate

### DIFF
--- a/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
+++ b/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
@@ -13,7 +13,7 @@ import {
   Label
 } from 'recharts';
 import { useAppDispatch, useAppSelector } from '../../../../stores/hooks';
-import { setDistributionGraphView, setgenotypesForFilterLength} from '../../../../stores/slices/graphSlice';
+import { setDistributionGraphView, setGenotypesForFilterLength} from '../../../../stores/slices/graphSlice';
 import { getColorForGenotype, hoverColor } from '../../../../util/colorHelper';
 import { useEffect, useState } from 'react';
 import { isTouchDevice } from '../../../../util/isTouchDevice';
@@ -66,8 +66,15 @@ export const DistributionGraph = () => {
 
       const slicedArray = mapArray.slice(0, genotypesForFilterLength).map(([key, value]) => key);
       setTopXGenotypes(slicedArray);
-    
   },[genotypesForFilter, genotypesYearData, genotypesForFilterLength]);
+  // useEffect(() =>{
+  //    if(genotypesForFilter.length<20){     
+  //     console.log("genotypesForFilter", genotypesForFilter.length);
+  //     dispatch(setGenotypesForFilterLength(genotypesForFilter.length));
+  //   }else{
+  //     dispatch(setGenotypesForFilterLength(20));
+  //   }
+  // },[]);
 
   function getData(){
     const exclusions = ['name', 'count'];

--- a/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
+++ b/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
@@ -63,17 +63,31 @@ export const DistributionGraph = () => {
       const mapArray = Array.from(mp);
       // Sort the array based on keys
       mapArray.sort((a, b) => b[1] - a[1]);
+
       const slicedArray = mapArray.slice(0, genotypesForFilterLength).map(([key, value]) => key);
       setTopXGenotypes(slicedArray);
     
   },[genotypesForFilter, genotypesYearData, genotypesForFilterLength]);
 
   function getData(){
-    
     const exclusions = ['name', 'count'];
+
     if (distributionGraphView === 'number') {
-        return genotypesYearData;
+      let newArray = []; // Create an empty array to store the new items
+      
+      newArray = genotypesYearData.map((item) => {
+        let count = 0;
+        for (const key in item) {     
+          if (!topXGenotypes.includes(key) && !exclusions.includes(key)) { 
+            count += item[key];
+          }  
+        }
+        const newItem = { ...item, Other: count };
+        return newItem;
+      });
+      return newArray;
     }
+
     let genotypeDataPercentage = structuredClone(genotypesYearData);
     return genotypeDataPercentage.map((item) => {
         for (const key in item) {      
@@ -89,7 +103,6 @@ export const DistributionGraph = () => {
       });
        return item;
     });
-    
   }
 
   function getGenotypeColor(genotype) {
@@ -135,6 +148,7 @@ export const DistributionGraph = () => {
             percentage += item.percentage;
         }
       })
+        
       value.genotypes = value.genotypes.filter((item) => topXGenotypes.includes(item.label));
       if (count !== 0 && percentage !== 0) {
         value.genotypes.push({
@@ -144,9 +158,14 @@ export const DistributionGraph = () => {
           color: '#969696' 
         });
       }
+      console.log("value: ", value);
       setCurrentTooltip(value);
     }
   }
+
+  console.log("getData()", getData());
+
+  {topXGenotypes.map((option, index) => (console.log("option", option)))}
 
   useEffect(() => {
     if (canGetData) {
@@ -205,7 +224,12 @@ export const DistributionGraph = () => {
                   fill={getGenotypeColor(option)}
                 />
               ))}
-              
+              <Bar
+                  dataKey={"Other"}
+                  stackId={0}
+                  fill={'#969696'}
+                />
+                
             </BarChart>
           </ResponsiveContainer>
         );

--- a/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
+++ b/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
@@ -158,14 +158,9 @@ export const DistributionGraph = () => {
           color: '#969696' 
         });
       }
-      console.log("value: ", value);
       setCurrentTooltip(value);
     }
   }
-
-  console.log("getData()", getData());
-
-  {topXGenotypes.map((option, index) => (console.log("option", option)))}
 
   useEffect(() => {
     if (canGetData) {

--- a/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
+++ b/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
@@ -13,10 +13,11 @@ import {
   Label
 } from 'recharts';
 import { useAppDispatch, useAppSelector } from '../../../../stores/hooks';
-import { setDistributionGraphView } from '../../../../stores/slices/graphSlice';
+import { setDistributionGraphView, setgenotypesForFilterLength} from '../../../../stores/slices/graphSlice';
 import { getColorForGenotype, hoverColor } from '../../../../util/colorHelper';
 import { useEffect, useState } from 'react';
 import { isTouchDevice } from '../../../../util/isTouchDevice';
+import {SliderSizes} from '../../Slider';
 
 const dataViewOptions = [
   { label: 'Number of genomes', value: 'number' },
@@ -35,7 +36,11 @@ export const DistributionGraph = () => {
   const organism = useAppSelector((state) => state.dashboard.organism);
   const colorPallete = useAppSelector((state) => state.dashboard.colorPallete);
   const canGetData = useAppSelector((state) => state.dashboard.canGetData);
+  const genotypesForFilterLength = useAppSelector((state) => state.graph.genotypesForFilterLength);
   const [topXGenotypes, setTopXGenotypes] = useState([]);
+  const [restXGenotypes, setRestXGenotypes] = useState([]);
+
+  // console.log("genotypesForFilterLength:", genotypesForFilterLength);
 
   useEffect(() => {
     setCurrentTooltip(null);
@@ -62,13 +67,18 @@ export const DistributionGraph = () => {
       const mapArray = Array.from(mp);
       // Sort the array based on keys
       mapArray.sort((a, b) => b[1] - a[1]);
-      const slicedArray = mapArray.slice(0, genotypesForFilter.length).map(([key, value]) => key);
+      // console.log("genotypesForFilterLength:", genotypesForFilterLength);
+      const slicedArray = mapArray.slice(0, genotypesForFilterLength).map(([key, value]) => key);
+      // const otherArray = mapArray.slice(10, genotypesForFilterLength).map(([key, value]) => key);
+      // console.log("otherArray", otherArray.length);
       // slicedArray.push('Unused');
       setTopXGenotypes(slicedArray);
-  },[genotypesForFilter, genotypesYearData]);
+      // setRestXGenotypes(otherArray);
+  },[genotypesForFilter, genotypesYearData, genotypesForFilterLength]);
 
   function getData(){
-    const exclusions = ['name', 'count', 'Unused'];
+    
+    const exclusions = ['name', 'count'];
     if (distributionGraphView === 'number') {
         return genotypesYearData;
     }
@@ -79,13 +89,18 @@ export const DistributionGraph = () => {
             item.count = item.count - item[key];
             delete item[key];
           }
+          // if (!restXGenotypes.includes(key) && !exclusions.includes(key) ) { 
+          //   item.count = item.count - item[key];
+          //   delete item[key];
+          // }
         }
-      const keys = Object.keys(item).filter((x) => !exclusions.includes(x));      
+      const keys = Object.keys(item).filter((x) => !exclusions.includes(x));    
+      // console.log("keys: ",keys);  
       keys.forEach((key) => {
         item[key] = Number(((item[key] / item.count) * 100).toFixed(2));
       });
-      const UnusedPercentage = 100 - keys.reduce((sum, key) => sum + item[key], 0);
-          item.Unused = Number(UnusedPercentage.toFixed(2));
+      // const UnusedPercentage = 100 - keys.reduce((sum, key) => sum + item[key], 0);
+      //     item.Unused = Number(UnusedPercentage.toFixed(2));
       return item;
     });
   }
@@ -116,6 +131,7 @@ export const DistributionGraph = () => {
       value.genotypes = Object.keys(currentData).map((key) => {
         const count = currentData[key];
         const activePayload = event.activePayload.find((x) => x.name === key);
+        // console.log("activePayload: ", event);
 
         return {
           label: key,
@@ -149,7 +165,6 @@ export const DistributionGraph = () => {
                 </Label>
               </YAxis>
               {genotypesYearData.length > 0 && <Brush dataKey="name" height={20} stroke={'rgb(31, 187, 211)'} />}
-
               <Legend
                 content={(props) => {
                   const { payload } = props;
@@ -216,6 +231,7 @@ export const DistributionGraph = () => {
           })}
         </Select>
       </div>
+      <SliderSizes/>
       <div className={classes.graphWrapper}>
         <div className={classes.graph} id="GD">
           {plotChart}

--- a/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraphMUI.js
+++ b/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraphMUI.js
@@ -74,15 +74,27 @@ const useStyles = makeStyles((theme) => ({
     minWidth: '10px'
   },
   tooltipWrapper: {
-    width: '30%',
+    width: '100%',
     borderRadius: '6px',
     backgroundColor: '#E5E5E5',
     overflowY: 'auto',
 
     '@media (max-width: 1000px)': {
       width: '100%',
-      height: '250px'
+      height: '250px',
+      overflowY: 'hidden',
     }
+  },
+  sliderCont:{
+    width: '30%',
+    overflowY: 'auto',
+    overflowX: 'hidden',
+    '@media (max-width: 1000px)': {
+      width: '100%',
+      overflowY: 'hidden',
+      overflowX: 'hidden',
+    }
+    
   },
   noYearSelected: {
     display: 'flex',
@@ -92,9 +104,24 @@ const useStyles = makeStyles((theme) => ({
   },
   tooltip: {
     width: '100%',
-    height: '100%',
+    height: '450px',
     display: 'flex',
-    flexDirection: 'column'
+    overflowY:'auto',
+    flexDirection: 'column',
+    '@media (max-width: 1000px)': {
+      width: '100%',
+      overflowY: 'hidden',
+      overflowX: 'hidden',
+    }
+  },
+  noYearSelected2: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    height: '450px',
+    '@media (max-width: 1000px)': {
+      height: '100%',
+    }
   },
   tooltipTitle: {
     display: 'flex',

--- a/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraphMUI.js
+++ b/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraphMUI.js
@@ -110,6 +110,7 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: 'column',
     '@media (max-width: 1000px)': {
       width: '100%',
+      height:'100%',
       overflowY: 'hidden',
       overflowX: 'hidden',
     }

--- a/client/src/components/Elements/Slider/SliderSizes.js
+++ b/client/src/components/Elements/Slider/SliderSizes.js
@@ -16,18 +16,19 @@ export const SliderSizes = () => {
   };
 
   return (
-    <Box width='100%'>
-      <Slider
-        value={genotypesForFilterLength}
-        onChange={handleDefaultSliderChange}
-        aria-label="Default"
-        valueLabelDisplay="auto"
-        min={1}
-        max={genotypesForFilter.length}
-      />
-
-      {/* Display the values of the sliders */}
-      <p>Selected Slider Value: {genotypesForFilterLength}</p>
-    </Box>
+    <div style={{ margin: '0px 10px' }}>
+      <Box >
+        <Slider
+          value={genotypesForFilterLength}
+          onChange={handleDefaultSliderChange}
+          aria-label="Default"
+          valueLabelDisplay="auto"
+          min={1}
+          max={genotypesForFilter.length}
+        />
+        {/* Display the values of the sliders */}
+        <p>Selected Slider Value: {genotypesForFilterLength}</p>
+      </Box>
+    </div>
   );
 }

--- a/client/src/components/Elements/Slider/SliderSizes.js
+++ b/client/src/components/Elements/Slider/SliderSizes.js
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Slider from '@mui/material/Slider';
+import { useAppDispatch, useAppSelector } from '../../../stores/hooks';
+import { setgenotypesForFilterLength } from '../../../stores/slices/graphSlice';
+
+export const SliderSizes = () => {
+  // const [defaultSliderValue, setDefaultSliderValue] = useState(50);
+
+  const dispatch = useAppDispatch();
+  const genotypesForFilterLength = useAppSelector((state) => state.graph.genotypesForFilterLength);
+  const genotypesForFilter = useAppSelector((state) => state.dashboard.genotypesForFilter);
+
+  const handleDefaultSliderChange = (event, newValue) => {
+    dispatch(setgenotypesForFilterLength(newValue));
+  };
+
+  return (
+    <Box width='100%'>
+      <Slider
+        value={genotypesForFilterLength}
+        onChange={handleDefaultSliderChange}
+        aria-label="Default"
+        valueLabelDisplay="auto"
+        min={1}
+        max={genotypesForFilter.length}
+      />
+
+      {/* Display the values of the sliders */}
+      <p>Selected Slider Value: {genotypesForFilterLength}</p>
+    </Box>
+  );
+}

--- a/client/src/components/Elements/Slider/SliderSizes.js
+++ b/client/src/components/Elements/Slider/SliderSizes.js
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import Box from '@mui/material/Box';
 import Slider from '@mui/material/Slider';
 import { useAppDispatch, useAppSelector } from '../../../stores/hooks';
-import { setgenotypesForFilterLength } from '../../../stores/slices/graphSlice';
+import { setGenotypesForFilterLength } from '../../../stores/slices/graphSlice';
 
 export const SliderSizes = () => {
   // const [defaultSliderValue, setDefaultSliderValue] = useState(50);
@@ -12,14 +12,14 @@ export const SliderSizes = () => {
   const genotypesForFilter = useAppSelector((state) => state.dashboard.genotypesForFilter);
 
   const handleDefaultSliderChange = (event, newValue) => {
-    dispatch(setgenotypesForFilterLength(newValue));
+    dispatch(setGenotypesForFilterLength(newValue));
   };
 
   return (
     <div style={{ margin: '0px 10px' }}>
       <Box >
         <Slider
-          value={genotypesForFilterLength}
+          value={genotypesForFilter.length >= genotypesForFilterLength ? genotypesForFilterLength :  genotypesForFilter.length }
           onChange={handleDefaultSliderChange}
           aria-label="Default"
           valueLabelDisplay="auto"
@@ -27,7 +27,7 @@ export const SliderSizes = () => {
           max={genotypesForFilter.length}
         />
         {/* Display the values of the sliders */}
-        <p>Selected Slider Value: {genotypesForFilterLength}</p>
+        <p>Selected Slider Value: {genotypesForFilter.length >= genotypesForFilterLength ? genotypesForFilterLength :  genotypesForFilter.length}</p>
       </Box>
     </div>
   );

--- a/client/src/components/Elements/Slider/index.js
+++ b/client/src/components/Elements/Slider/index.js
@@ -1,0 +1,1 @@
+export * from './SliderSizes';

--- a/client/src/stores/slices/graphSlice.ts
+++ b/client/src/stores/slices/graphSlice.ts
@@ -29,8 +29,9 @@ interface GraphState {
   KODiversityGraphView: string;
   convergenceData: Array<any>;
   convergenceGroupVariable: string;
-  convergenceColourVariable: string
-  convergenceColourPallete: Object
+  convergenceColourVariable: string;
+  convergenceColourPallete: Object;
+  genotypesForFilterLength: number;
 }
 
 const initialState: GraphState = {
@@ -62,7 +63,8 @@ const initialState: GraphState = {
   convergenceData: [],
   convergenceGroupVariable: 'COUNTRY_ONLY',
   convergenceColourVariable: 'DATE',
-  convergenceColourPallete: {}
+  convergenceColourPallete: {},
+  genotypesForFilterLength:20,
 };
 
 export const graphSlice = createSlice({
@@ -135,6 +137,9 @@ export const graphSlice = createSlice({
     setConvergenceColourPallete: (state, action: PayloadAction<Object>) => {
       state.convergenceColourPallete = action.payload;
     },
+     setgenotypesForFilterLength: (state, action: PayloadAction<number>) => {
+      state.genotypesForFilterLength = action.payload;
+    },
   }
 });
 
@@ -160,7 +165,8 @@ export const {
   setConvergenceData,
   setConvergenceGroupVariable,
   setConvergenceColourVariable,
-  setConvergenceColourPallete
+  setConvergenceColourPallete,
+  setgenotypesForFilterLength,
 } = graphSlice.actions;
 
 export default graphSlice.reducer;

--- a/client/src/stores/slices/graphSlice.ts
+++ b/client/src/stores/slices/graphSlice.ts
@@ -137,7 +137,7 @@ export const graphSlice = createSlice({
     setConvergenceColourPallete: (state, action: PayloadAction<Object>) => {
       state.convergenceColourPallete = action.payload;
     },
-     setgenotypesForFilterLength: (state, action: PayloadAction<number>) => {
+     setGenotypesForFilterLength: (state, action: PayloadAction<number>) => {
       state.genotypesForFilterLength = action.payload;
     },
   }
@@ -166,7 +166,7 @@ export const {
   setConvergenceGroupVariable,
   setConvergenceColourVariable,
   setConvergenceColourPallete,
-  setgenotypesForFilterLength,
+  setGenotypesForFilterLength,
 } = graphSlice.actions;
 
 export default graphSlice.reducer;


### PR DESCRIPTION
-  added slider component to change the visibility of top X number of genotypes in the genotype distribution graph
- Position slider at the top of Tooltip
- Add all other than top X genotypes, to OTHER in tooltip and show them on plot as well in a single colour
- Set slider default value to 20
- if number of genotypes is < 20 then, default slider is number of genotype.