### PR TITLE
Van/colorupdateold

### DIFF
--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -47,7 +47,7 @@ import {
   setKODiversityGraphView,
   setTrendsKPGraphDrugClass,
   setTrendsKPGraphView,
-  setGenotypesForFilterLength
+  setCurrentSliderValue
 } from '../../stores/slices/graphSlice.ts';
 import {
   filterData,
@@ -224,7 +224,7 @@ export const DashboardPage = () => {
       dispatch(setDeterminantsGraphView('percentage'));
       dispatch(setDistributionGraphView('number'));
       dispatch(setConvergenceColourPallete({}));
-      dispatch(setGenotypesForFilterLength(20));
+      dispatch(setCurrentSliderValue(20));
 
       switch (organism) {
         case 'typhi':

--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -46,7 +46,8 @@ import {
   setKODiversityData,
   setKODiversityGraphView,
   setTrendsKPGraphDrugClass,
-  setTrendsKPGraphView
+  setTrendsKPGraphView,
+  setGenotypesForFilterLength
 } from '../../stores/slices/graphSlice.ts';
 import {
   filterData,
@@ -222,6 +223,7 @@ export const DashboardPage = () => {
       dispatch(setDeterminantsGraphView('percentage'));
       dispatch(setDistributionGraphView('number'));
       dispatch(setConvergenceColourPallete({}));
+      dispatch(setGenotypesForFilterLength(20));
 
       switch (organism) {
         case 'typhi':

--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -124,7 +124,8 @@ export const DashboardPage = () => {
     });
 
     if (organism === 'klebe') {
-      dispatch(setColorPallete(generatePalleteForGenotypes(yearsData.uniqueGenotypes)));
+      console.log("yearsData.uniqueGenotypes", yearsData.uniqueGenotypes)
+      // dispatch(setColorPallete(generatePalleteForGenotypes(yearsData.uniqueGenotypes)));
       dispatch(setGenotypesForFilter(yearsData.uniqueGenotypes));
 
       const KODiversityData = getKODiversityData({ data: responseData });

--- a/client/src/components/Dashboard/filters.js
+++ b/client/src/components/Dashboard/filters.js
@@ -245,7 +245,7 @@ export function getYearsData({ data, years, organism, getUniqueGenotypes = false
       const sortedStats = Object.fromEntries(
         Object.entries(stats)
           .sort(([, a], [, b]) => b - a)
-          .slice(0, 20)
+          // .slice(0, 20)
       );
       uniqueGenotypes = uniqueGenotypes.concat(Object.keys(sortedStats));
 

--- a/client/src/components/Elements/Graphs/ConvergenceGraph/ConvergenceGraph.js
+++ b/client/src/components/Elements/Graphs/ConvergenceGraph/ConvergenceGraph.js
@@ -230,7 +230,7 @@ export const ConvergenceGraph = () => {
               </div>
             </div>
           ) : (
-            <div className={classes.noBubbleSelected}>No bubble selected</div>
+            <div className={classes.noBubbleSelected}>Click on a bubble to see the details</div>
           )}
         </div>
       </div>

--- a/client/src/components/Elements/Graphs/ConvergenceGraph/ConvergenceGraph.js
+++ b/client/src/components/Elements/Graphs/ConvergenceGraph/ConvergenceGraph.js
@@ -15,7 +15,7 @@ import {
   Cell
 } from 'recharts';
 import { useAppDispatch, useAppSelector } from '../../../../stores/hooks';
-import { /*setConvergenceColourVariable,*/ setConvergenceGroupVariable } from '../../../../stores/slices/graphSlice';
+import { /*setConvergenceColourVariable,*/ setConvergenceGroupVariable, setResetBool } from '../../../../stores/slices/graphSlice';
 import { useEffect, useState } from 'react';
 import { hoverColor } from '../../../../util/colorHelper';
 import { isTouchDevice } from '../../../../util/isTouchDevice';
@@ -33,8 +33,9 @@ export const ConvergenceGraph = () => {
   const convergenceGroupVariable = useAppSelector((state) => state.graph.convergenceGroupVariable);
   // const convergenceColourVariable = useAppSelector((state) => state.graph.convergenceColourVariable);
   const convergenceColourPallete = useAppSelector((state) => state.graph.convergenceColourPallete);
-
+  const resetBool = useAppSelector((state) => state.graph.resetBool);
   useEffect(() => {
+    dispatch(setResetBool(true));
     setCurrentTooltip(null);
   }, [convergenceData]);
 
@@ -47,13 +48,19 @@ export const ConvergenceGraph = () => {
   //   setCurrentTooltip(null);
   //   dispatch(setConvergenceColourVariable(event.target.value));
   // }
-
+useEffect(()=>{
+    if(resetBool){
+      setCurrentTooltip(null);
+      dispatch(setResetBool(true));
+    }
+  });
   function handleClickChart(name) {
     const data = convergenceData.find((item) => item.name === name);
 
     if (data) {
       const currentData = structuredClone(data);
       setCurrentTooltip({ ...currentData });
+      dispatch(setResetBool(false));
     }
   }
 

--- a/client/src/components/Elements/Graphs/DeterminantsGraph/DeterminantsGraph.js
+++ b/client/src/components/Elements/Graphs/DeterminantsGraph/DeterminantsGraph.js
@@ -14,7 +14,7 @@ import {
   Brush
 } from 'recharts';
 import { useAppDispatch, useAppSelector } from '../../../../stores/hooks';
-import { setDeterminantsGraphDrugClass, setDeterminantsGraphView } from '../../../../stores/slices/graphSlice';
+import { setDeterminantsGraphDrugClass, setDeterminantsGraphView, setResetBool } from '../../../../stores/slices/graphSlice';
 import { drugClassesST, drugClassesKP } from '../../../../util/drugs';
 import { useEffect, useState } from 'react';
 import { colorForDrugClassesKP, colorForDrugClassesST, hoverColor } from '../../../../util/colorHelper';
@@ -36,8 +36,10 @@ export const DeterminantsGraph = () => {
   const genotypesDrugClassesData = useAppSelector((state) => state.graph.genotypesDrugClassesData);
   const determinantsGraphView = useAppSelector((state) => state.graph.determinantsGraphView);
   const determinantsGraphDrugClass = useAppSelector((state) => state.graph.determinantsGraphDrugClass);
+  const resetBool = useAppSelector((state) => state.graph.resetBool);
 
   useEffect(() => {
+    dispatch(setResetBool(true));
     setCurrentTooltip(null);
   }, [genotypesDrugClassesData]);
 
@@ -127,8 +129,16 @@ export const DeterminantsGraph = () => {
       });
 
       setCurrentTooltip(value);
+      dispatch(setResetBool(false));
     }
   }
+
+  useEffect(()=>{
+    if(resetBool){
+      setCurrentTooltip(null);
+      dispatch(setResetBool(true));
+    }
+  });
 
   useEffect(() => {
     if (canGetData) {

--- a/client/src/components/Elements/Graphs/DeterminantsGraph/DeterminantsGraph.js
+++ b/client/src/components/Elements/Graphs/DeterminantsGraph/DeterminantsGraph.js
@@ -274,7 +274,7 @@ export const DeterminantsGraph = () => {
               </div>
             </div>
           ) : (
-            <div className={classes.noGenotypeSelected}>No genotype selected</div>
+            <div className={classes.noGenotypeSelected}>Click on a genotype to see detail</div>
           )}
         </div>
       </div>

--- a/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
+++ b/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
@@ -67,14 +67,6 @@ export const DistributionGraph = () => {
       const slicedArray = mapArray.slice(0, genotypesForFilterLength).map(([key, value]) => key);
       setTopXGenotypes(slicedArray);
   },[genotypesForFilter, genotypesYearData, genotypesForFilterLength]);
-  // useEffect(() =>{
-  //    if(genotypesForFilter.length<20){     
-  //     console.log("genotypesForFilter", genotypesForFilter.length);
-  //     dispatch(setGenotypesForFilterLength(genotypesForFilter.length));
-  //   }else{
-  //     dispatch(setGenotypesForFilterLength(20));
-  //   }
-  // },[]);
 
   function getData(){
     const exclusions = ['name', 'count'];

--- a/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
+++ b/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
@@ -14,7 +14,7 @@ import {
 } from 'recharts';
 import { useAppDispatch, useAppSelector } from '../../../../stores/hooks';
 import { setColorPallete } from '../../../../stores/slices/dashboardSlice';
-import { setDistributionGraphView, setCurrentSliderValue, setTopXGenotypes} from '../../../../stores/slices/graphSlice';
+import { setDistributionGraphView, setCurrentSliderValue, setTopXGenotypes, setResetBool} from '../../../../stores/slices/graphSlice';
 import { getColorForGenotype, hoverColor, generatePalleteForGenotypes } from '../../../../util/colorHelper';
 import { useEffect, useState } from 'react';
 import { isTouchDevice } from '../../../../util/isTouchDevice';
@@ -40,10 +40,12 @@ export const DistributionGraph = () => {
   const canGetData = useAppSelector((state) => state.dashboard.canGetData);
   const currentSliderValue = useAppSelector((state) => state.graph.currentSliderValue);
   const maxSliderValue = useAppSelector((state) => state.graph.maxSliderValue);
-  const currentTooltipBool = useAppSelector((state) => state.graph.currentTooltipBool);
+  const resetBool = useAppSelector((state) => state.graph.resetBool);
   const [topXGenotypes, setTopXGenotypes] = useState([]);
   const [currentEventSelected, setCurrentEventSelected] = useState([]);
+  
   useEffect(() => {
+    dispatch(setResetBool(true));
     setCurrentTooltip(null);
   }, [genotypesYearData]);
 
@@ -145,16 +147,19 @@ export const DistributionGraph = () => {
           // console.log("value.genotypes", value.genotypes);
           value.genotypes = value.genotypes.filter((item) => topXGenotypes.includes(item.label) || item.label === "Other");
           console.log("value", value);
-          if(value.name != undefined)
-            setCurrentTooltip(value);
+          setCurrentTooltip(value);
+          dispatch(setResetBool(false));
         }
   }
   // console.log("currentTooltip", currentTooltip);
   useEffect(()=>{
-    console.log("currentSliderValue", currentSliderValue);
-    handleClickChart(currentEventSelected);
-  },[currentSliderValue, ]);
-  
+    if(!resetBool)
+      handleClickChart(currentEventSelected);
+    else{
+      setCurrentTooltip(null);
+      dispatch(setResetBool(true));
+  }
+  },[topXGenotypes]);
 
   useEffect(() => {
     if (canGetData) {

--- a/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
+++ b/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
@@ -13,8 +13,9 @@ import {
   Label
 } from 'recharts';
 import { useAppDispatch, useAppSelector } from '../../../../stores/hooks';
+import { setColorPallete } from '../../../../stores/slices/dashboardSlice';
 import { setDistributionGraphView, setGenotypesForFilterLength} from '../../../../stores/slices/graphSlice';
-import { getColorForGenotype, hoverColor } from '../../../../util/colorHelper';
+import { getColorForGenotype, hoverColor, generatePalleteForGenotypes } from '../../../../util/colorHelper';
 import { useEffect, useState } from 'react';
 import { isTouchDevice } from '../../../../util/isTouchDevice';
 import {SliderSizes} from '../../Slider';
@@ -66,6 +67,7 @@ export const DistributionGraph = () => {
 
       const slicedArray = mapArray.slice(0, genotypesForFilterLength).map(([key, value]) => key);
       setTopXGenotypes(slicedArray);
+      dispatch(setColorPallete(generatePalleteForGenotypes(slicedArray)));
   },[genotypesForFilter, genotypesYearData, genotypesForFilterLength]);
 
   function getData(){
@@ -89,7 +91,7 @@ export const DistributionGraph = () => {
     return newArray;
     }
 
-    let genotypeDataPercentage = structuredClone(genotypesYearData);
+    // let genotypeDataPercentage = structuredClone(genotypesYearData);
     return newArray.map((item) => {
         for (const key in item) {      
           if (!topXGenotypes.includes(key) && !exclusions.includes(key) && key != 'Other' ) { 
@@ -158,7 +160,7 @@ export const DistributionGraph = () => {
           label: 'Other',
           count: count,
           percentage: percentage.toFixed(2),
-          color: '#969696' 
+          color: '#E5E4E2' 
         });
       }
       setCurrentTooltip(value);
@@ -225,7 +227,7 @@ export const DistributionGraph = () => {
               <Bar
                   dataKey={"Other"}
                   stackId={0}
-                  fill={'#969696'}
+                  fill={'#E5E4E2'}
                 />
                 
             </BarChart>
@@ -294,7 +296,7 @@ export const DistributionGraph = () => {
                 </div>
               </div>
             ) : (
-              <div className={classes.noYearSelected2}>No year selected</div>
+              <div className={classes.noYearSelected2}>Click on a year to see detail</div>
             )}
           </div>
         </div>

--- a/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
+++ b/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
@@ -13,7 +13,7 @@ import {
   Label
 } from 'recharts';
 import { useAppDispatch, useAppSelector } from '../../../../stores/hooks';
-import { setDistributionGraphView, setgenotypesForFilterLength} from '../../../../stores/slices/graphSlice';
+import { setDistributionGraphView, setGenotypesForFilterLength} from '../../../../stores/slices/graphSlice';
 import { getColorForGenotype, hoverColor } from '../../../../util/colorHelper';
 import { useEffect, useState } from 'react';
 import { isTouchDevice } from '../../../../util/isTouchDevice';
@@ -66,8 +66,15 @@ export const DistributionGraph = () => {
 
       const slicedArray = mapArray.slice(0, genotypesForFilterLength).map(([key, value]) => key);
       setTopXGenotypes(slicedArray);
-    
   },[genotypesForFilter, genotypesYearData, genotypesForFilterLength]);
+  // useEffect(() =>{
+  //    if(genotypesForFilter.length<20){     
+  //     console.log("genotypesForFilter", genotypesForFilter.length);
+  //     dispatch(setGenotypesForFilterLength(genotypesForFilter.length));
+  //   }else{
+  //     dispatch(setGenotypesForFilterLength(20));
+  //   }
+  // },[]);
 
   function getData(){
     const exclusions = ['name', 'count'];

--- a/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
+++ b/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
@@ -63,17 +63,31 @@ export const DistributionGraph = () => {
       const mapArray = Array.from(mp);
       // Sort the array based on keys
       mapArray.sort((a, b) => b[1] - a[1]);
+
       const slicedArray = mapArray.slice(0, genotypesForFilterLength).map(([key, value]) => key);
       setTopXGenotypes(slicedArray);
     
   },[genotypesForFilter, genotypesYearData, genotypesForFilterLength]);
 
   function getData(){
-    
     const exclusions = ['name', 'count'];
+
     if (distributionGraphView === 'number') {
-        return genotypesYearData;
+      let newArray = []; // Create an empty array to store the new items
+      
+      newArray = genotypesYearData.map((item) => {
+        let count = 0;
+        for (const key in item) {     
+          if (!topXGenotypes.includes(key) && !exclusions.includes(key)) { 
+            count += item[key];
+          }  
+        }
+        const newItem = { ...item, Other: count };
+        return newItem;
+      });
+      return newArray;
     }
+
     let genotypeDataPercentage = structuredClone(genotypesYearData);
     return genotypeDataPercentage.map((item) => {
         for (const key in item) {      
@@ -89,7 +103,6 @@ export const DistributionGraph = () => {
       });
        return item;
     });
-    
   }
 
   function getGenotypeColor(genotype) {
@@ -135,6 +148,7 @@ export const DistributionGraph = () => {
             percentage += item.percentage;
         }
       })
+        
       value.genotypes = value.genotypes.filter((item) => topXGenotypes.includes(item.label));
       if (count !== 0 && percentage !== 0) {
         value.genotypes.push({
@@ -144,9 +158,14 @@ export const DistributionGraph = () => {
           color: '#969696' 
         });
       }
+      console.log("value: ", value);
       setCurrentTooltip(value);
     }
   }
+
+  console.log("getData()", getData());
+
+  {topXGenotypes.map((option, index) => (console.log("option", option)))}
 
   useEffect(() => {
     if (canGetData) {
@@ -205,7 +224,12 @@ export const DistributionGraph = () => {
                   fill={getGenotypeColor(option)}
                 />
               ))}
-              
+              <Bar
+                  dataKey={"Other"}
+                  stackId={0}
+                  fill={'#969696'}
+                />
+                
             </BarChart>
           </ResponsiveContainer>
         );

--- a/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
+++ b/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
@@ -158,14 +158,9 @@ export const DistributionGraph = () => {
           color: '#969696' 
         });
       }
-      console.log("value: ", value);
       setCurrentTooltip(value);
     }
   }
-
-  console.log("getData()", getData());
-
-  {topXGenotypes.map((option, index) => (console.log("option", option)))}
 
   useEffect(() => {
     if (canGetData) {

--- a/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
+++ b/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
@@ -28,6 +28,7 @@ const dataViewOptions = [
 export const DistributionGraph = () => {
   const classes = useStyles();
   const [currentTooltip, setCurrentTooltip] = useState(null);
+  // const [currentSliderValue, setCurrentSliderValue] = useState(20);
   const [plotChart, setPlotChart] = useState(() => {});
 
   const dispatch = useAppDispatch();
@@ -39,6 +40,7 @@ export const DistributionGraph = () => {
   const canGetData = useAppSelector((state) => state.dashboard.canGetData);
   const currentSliderValue = useAppSelector((state) => state.graph.currentSliderValue);
   const maxSliderValue = useAppSelector((state) => state.graph.maxSliderValue);
+  const currentTooltipBool = useAppSelector((state) => state.graph.currentTooltipBool);
   const [topXGenotypes, setTopXGenotypes] = useState([]);
   const [currentEventSelected, setCurrentEventSelected] = useState([]);
   useEffect(() => {
@@ -48,6 +50,10 @@ export const DistributionGraph = () => {
   function getDomain() {
     return distributionGraphView === 'number' ? undefined : [0, 100];
   }
+  
+//  const updateSlider = (value) =>{
+//   setCurrentSliderValue(value);
+//  };
 
   useEffect(() =>{
       let mp = new Map(); //mp = total count of a genotype in database(including all years)
@@ -138,15 +144,16 @@ export const DistributionGraph = () => {
           });
           // console.log("value.genotypes", value.genotypes);
           value.genotypes = value.genotypes.filter((item) => topXGenotypes.includes(item.label) || item.label === "Other");
-          // console.log("value", value);
-          setCurrentTooltip(value);
+          console.log("value", value);
+          if(value.name != undefined)
+            setCurrentTooltip(value);
         }
   }
   // console.log("currentTooltip", currentTooltip);
   useEffect(()=>{
     console.log("currentSliderValue", currentSliderValue);
     handleClickChart(currentEventSelected);
-  },[currentSliderValue, topXGenotypes]);
+  },[currentSliderValue, ]);
   
 
   useEffect(() => {
@@ -244,7 +251,8 @@ export const DistributionGraph = () => {
           {plotChart}
         </div>
         <div className={classes.sliderCont} >
-          <SliderSizes sx={{margin: '0px 10px 0px 10px'}}/>
+          {/* <SliderSizes callBackValue={ updateSlider} sx={{margin: '0px 10px 0px 10px'}}/> */}
+           <SliderSizes sx={{margin: '0px 10px 0px 10px'}}/>
           <div className={classes.tooltipWrapper}>
             {currentTooltip ? (
               <div className={classes.tooltip}>

--- a/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
+++ b/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
@@ -13,10 +13,11 @@ import {
   Label
 } from 'recharts';
 import { useAppDispatch, useAppSelector } from '../../../../stores/hooks';
-import { setDistributionGraphView } from '../../../../stores/slices/graphSlice';
+import { setDistributionGraphView, setgenotypesForFilterLength} from '../../../../stores/slices/graphSlice';
 import { getColorForGenotype, hoverColor } from '../../../../util/colorHelper';
 import { useEffect, useState } from 'react';
 import { isTouchDevice } from '../../../../util/isTouchDevice';
+import {SliderSizes} from '../../Slider';
 
 const dataViewOptions = [
   { label: 'Number of genomes', value: 'number' },
@@ -35,7 +36,11 @@ export const DistributionGraph = () => {
   const organism = useAppSelector((state) => state.dashboard.organism);
   const colorPallete = useAppSelector((state) => state.dashboard.colorPallete);
   const canGetData = useAppSelector((state) => state.dashboard.canGetData);
+  const genotypesForFilterLength = useAppSelector((state) => state.graph.genotypesForFilterLength);
   const [topXGenotypes, setTopXGenotypes] = useState([]);
+  const [restXGenotypes, setRestXGenotypes] = useState([]);
+
+  // console.log("genotypesForFilterLength:", genotypesForFilterLength);
 
   useEffect(() => {
     setCurrentTooltip(null);
@@ -62,13 +67,18 @@ export const DistributionGraph = () => {
       const mapArray = Array.from(mp);
       // Sort the array based on keys
       mapArray.sort((a, b) => b[1] - a[1]);
-      const slicedArray = mapArray.slice(0, genotypesForFilter.length).map(([key, value]) => key);
+      // console.log("genotypesForFilterLength:", genotypesForFilterLength);
+      const slicedArray = mapArray.slice(0, genotypesForFilterLength).map(([key, value]) => key);
+      // const otherArray = mapArray.slice(10, genotypesForFilterLength).map(([key, value]) => key);
+      // console.log("otherArray", otherArray.length);
       // slicedArray.push('Unused');
       setTopXGenotypes(slicedArray);
-  },[genotypesForFilter, genotypesYearData]);
+      // setRestXGenotypes(otherArray);
+  },[genotypesForFilter, genotypesYearData, genotypesForFilterLength]);
 
   function getData(){
-    const exclusions = ['name', 'count', 'Unused'];
+    
+    const exclusions = ['name', 'count'];
     if (distributionGraphView === 'number') {
         return genotypesYearData;
     }
@@ -79,13 +89,18 @@ export const DistributionGraph = () => {
             item.count = item.count - item[key];
             delete item[key];
           }
+          // if (!restXGenotypes.includes(key) && !exclusions.includes(key) ) { 
+          //   item.count = item.count - item[key];
+          //   delete item[key];
+          // }
         }
-      const keys = Object.keys(item).filter((x) => !exclusions.includes(x));      
+      const keys = Object.keys(item).filter((x) => !exclusions.includes(x));    
+      // console.log("keys: ",keys);  
       keys.forEach((key) => {
         item[key] = Number(((item[key] / item.count) * 100).toFixed(2));
       });
-      const UnusedPercentage = 100 - keys.reduce((sum, key) => sum + item[key], 0);
-          item.Unused = Number(UnusedPercentage.toFixed(2));
+      // const UnusedPercentage = 100 - keys.reduce((sum, key) => sum + item[key], 0);
+      //     item.Unused = Number(UnusedPercentage.toFixed(2));
       return item;
     });
   }
@@ -116,6 +131,7 @@ export const DistributionGraph = () => {
       value.genotypes = Object.keys(currentData).map((key) => {
         const count = currentData[key];
         const activePayload = event.activePayload.find((x) => x.name === key);
+        // console.log("activePayload: ", event);
 
         return {
           label: key,
@@ -149,7 +165,6 @@ export const DistributionGraph = () => {
                 </Label>
               </YAxis>
               {genotypesYearData.length > 0 && <Brush dataKey="name" height={20} stroke={'rgb(31, 187, 211)'} />}
-
               <Legend
                 content={(props) => {
                   const { payload } = props;
@@ -216,6 +231,7 @@ export const DistributionGraph = () => {
           })}
         </Select>
       </div>
+      <SliderSizes/>
       <div className={classes.graphWrapper}>
         <div className={classes.graph} id="GD">
           {plotChart}

--- a/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
+++ b/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
@@ -70,28 +70,31 @@ export const DistributionGraph = () => {
 
   function getData(){
     const exclusions = ['name', 'count'];
+        console.log("genotypesYearData", genotypesYearData);
+    
+    let newArray = [];
+    newArray = genotypesYearData.map((item) => {
+      let count = 0;
+      for (const key in item) {     
+        if (!topXGenotypes.includes(key) && !exclusions.includes(key)) { 
+          count += item[key];
+        }  
+      }
+      const newItem = { ...item, Other: count };
+      return newItem;
+    });
+     console.log("newArray", newArray);
 
     if (distributionGraphView === 'number') {
-      let newArray = []; // Create an empty array to store the new items
-      
-      newArray = genotypesYearData.map((item) => {
-        let count = 0;
-        for (const key in item) {     
-          if (!topXGenotypes.includes(key) && !exclusions.includes(key)) { 
-            count += item[key];
-          }  
-        }
-        const newItem = { ...item, Other: count };
-        return newItem;
-      });
-      return newArray;
+    return newArray;
     }
 
     let genotypeDataPercentage = structuredClone(genotypesYearData);
-    return genotypeDataPercentage.map((item) => {
+    return newArray.map((item) => {
         for (const key in item) {      
-          if (!topXGenotypes.includes(key) && !exclusions.includes(key) ) { 
-            item.count = item.count - item[key];
+          if (!topXGenotypes.includes(key) && !exclusions.includes(key) && key != 'Other' ) { 
+            console.log("item[key]", item[key]);
+            // item.count = item.count - item[key];
             delete item[key];
           }  
         }
@@ -100,6 +103,7 @@ export const DistributionGraph = () => {
       keys.forEach((key) => {
         item[key] = Number(((item[key] / item.count) * 100).toFixed(2));
       });
+      console.log("item", item);
        return item;
     });
   }

--- a/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraphMUI.js
+++ b/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraphMUI.js
@@ -74,15 +74,27 @@ const useStyles = makeStyles((theme) => ({
     minWidth: '10px'
   },
   tooltipWrapper: {
-    width: '30%',
+    width: '100%',
     borderRadius: '6px',
     backgroundColor: '#E5E5E5',
     overflowY: 'auto',
 
     '@media (max-width: 1000px)': {
       width: '100%',
-      height: '250px'
+      height: '250px',
+      overflowY: 'hidden',
     }
+  },
+  sliderCont:{
+    width: '30%',
+    overflowY: 'auto',
+    overflowX: 'hidden',
+    '@media (max-width: 1000px)': {
+      width: '100%',
+      overflowY: 'hidden',
+      overflowX: 'hidden',
+    }
+    
   },
   noYearSelected: {
     display: 'flex',
@@ -92,9 +104,24 @@ const useStyles = makeStyles((theme) => ({
   },
   tooltip: {
     width: '100%',
-    height: '100%',
+    height: '450px',
     display: 'flex',
-    flexDirection: 'column'
+    overflowY:'auto',
+    flexDirection: 'column',
+    '@media (max-width: 1000px)': {
+      width: '100%',
+      overflowY: 'hidden',
+      overflowX: 'hidden',
+    }
+  },
+  noYearSelected2: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    height: '450px',
+    '@media (max-width: 1000px)': {
+      height: '100%',
+    }
   },
   tooltipTitle: {
     display: 'flex',

--- a/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraphMUI.js
+++ b/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraphMUI.js
@@ -110,6 +110,7 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: 'column',
     '@media (max-width: 1000px)': {
       width: '100%',
+      height:'100%',
       overflowY: 'hidden',
       overflowX: 'hidden',
     }

--- a/client/src/components/Elements/Graphs/DrugResistanceGraph/DrugResistanceGraph.js
+++ b/client/src/components/Elements/Graphs/DrugResistanceGraph/DrugResistanceGraph.js
@@ -14,7 +14,7 @@ import {
   Label
 } from 'recharts';
 import { useAppDispatch, useAppSelector } from '../../../../stores/hooks';
-import { setDrugResistanceGraphView } from '../../../../stores/slices/graphSlice';
+import { setDrugResistanceGraphView, setResetBool } from '../../../../stores/slices/graphSlice';
 import { drugsKP, drugsForDrugResistanceGraphST } from '../../../../util/drugs';
 import { useEffect, useState } from 'react';
 import { hoverColor } from '../../../../util/colorHelper';
@@ -34,8 +34,10 @@ export const DrugResistanceGraph = () => {
   const timeInitial = useAppSelector((state) => state.dashboard.timeInitial);
   const timeFinal = useAppSelector((state) => state.dashboard.timeFinal);
   const organism = useAppSelector((state) => state.dashboard.organism);
+  const resetBool = useAppSelector((state) => state.graph.resetBool);
 
   useEffect(() => {
+    dispatch(setResetBool(true));
     setCurrentTooltip(null);
   }, [drugsYearData]);
 
@@ -122,8 +124,16 @@ export const DrugResistanceGraph = () => {
       });
 
       setCurrentTooltip(value);
+      dispatch(setResetBool(false));
     }
   }
+
+  useEffect(()=>{
+    if(resetBool){
+      setCurrentTooltip(null);
+      dispatch(setResetBool(true));
+    }
+  });
 
   useEffect(() => {
     if (canGetData) {

--- a/client/src/components/Elements/Graphs/DrugResistanceGraph/DrugResistanceGraph.js
+++ b/client/src/components/Elements/Graphs/DrugResistanceGraph/DrugResistanceGraph.js
@@ -284,7 +284,7 @@ export const DrugResistanceGraph = () => {
             </div>
           ) : (
             <div className={classes.noYearSelected}>
-              {drugResistanceGraphView.length === 0 ? 'No drug selected' : 'No year selected'}{' '}
+              {drugResistanceGraphView.length === 0 ? 'Select a drug to see detail' : 'Click on a year to see detail'}{' '}
             </div>
           )}
         </div>

--- a/client/src/components/Elements/Graphs/FrequenciesGraph/FrequenciesGraph.js
+++ b/client/src/components/Elements/Graphs/FrequenciesGraph/FrequenciesGraph.js
@@ -15,7 +15,7 @@ import {
   Brush
 } from 'recharts';
 import { useAppDispatch, useAppSelector } from '../../../../stores/hooks';
-import { setFrequenciesGraphSelectedGenotypes, setFrequenciesGraphView } from '../../../../stores/slices/graphSlice';
+import { setFrequenciesGraphSelectedGenotypes, setFrequenciesGraphView, setResetBool} from '../../../../stores/slices/graphSlice';
 import { useEffect, useState } from 'react';
 import { hoverColor } from '../../../../util/colorHelper';
 import { getColorForDrug } from '../graphColorHelper';
@@ -38,8 +38,10 @@ export const FrequenciesGraph = () => {
   const genotypesDrugsData = useAppSelector((state) => state.graph.genotypesDrugsData);
   const frequenciesGraphView = useAppSelector((state) => state.graph.frequenciesGraphView);
   const frequenciesGraphSelectedGenotypes = useAppSelector((state) => state.graph.frequenciesGraphSelectedGenotypes);
+  const resetBool = useAppSelector((state) => state.graph.resetBool);
 
   useEffect(() => {
+    dispatch(setResetBool(true));
     setCurrentTooltip(null);
   }, [genotypesDrugsData]);
 
@@ -126,8 +128,16 @@ export const FrequenciesGraph = () => {
       });
 
       setCurrentTooltip(value);
+      dispatch(setResetBool(false));
     }
   }
+
+  useEffect(()=>{
+    if(resetBool){
+      setCurrentTooltip(null);
+      dispatch(setResetBool(true));
+    }
+  });
 
   function handleChangeDataView(event) {
     dispatch(setFrequenciesGraphView(event.target.value));

--- a/client/src/components/Elements/Graphs/FrequenciesGraph/FrequenciesGraph.js
+++ b/client/src/components/Elements/Graphs/FrequenciesGraph/FrequenciesGraph.js
@@ -302,7 +302,7 @@ export const FrequenciesGraph = () => {
               </div>
             </div>
           ) : (
-            <div className={classes.noGenotypeSelected}>No genotype selected</div>
+            <div className={classes.noGenotypeSelected}>Click on a genotype to see detail</div>
           )}
         </div>
       </div>

--- a/client/src/components/Elements/Graphs/KODiversityGraph/KODiversityGraph.js
+++ b/client/src/components/Elements/Graphs/KODiversityGraph/KODiversityGraph.js
@@ -13,7 +13,7 @@ import {
   Label
 } from 'recharts';
 import { useAppDispatch, useAppSelector } from '../../../../stores/hooks';
-import { setKODiversityGraphView } from '../../../../stores/slices/graphSlice';
+import { setKODiversityGraphView, setResetBool } from '../../../../stores/slices/graphSlice';
 import { hoverColor } from '../../../../util/colorHelper';
 import { useEffect, useState } from 'react';
 import { isTouchDevice } from '../../../../util/isTouchDevice';
@@ -34,8 +34,10 @@ export const KODiversityGraph = () => {
   const KODiversityGraphView = useAppSelector((state) => state.graph.KODiversityGraphView);
   const organism = useAppSelector((state) => state.dashboard.organism);
   const canGetData = useAppSelector((state) => state.dashboard.canGetData);
+  const resetBool = useAppSelector((state) => state.graph.resetBool);
 
   useEffect(() => {
+    dispatch(setResetBool(true));
     setCurrentTooltip(null);
   }, [KODiversityData]);
 
@@ -77,8 +79,17 @@ export const KODiversityGraph = () => {
       });
 
       setCurrentTooltip(value);
+      dispatch(setResetBool(false));
+
     }
   }
+
+  useEffect(()=>{
+    if(resetBool){
+      setCurrentTooltip(null);
+      dispatch(setResetBool(true));
+    }
+  });
 
   useEffect(() => {
     if (canGetData) {

--- a/client/src/components/Elements/Graphs/KODiversityGraph/KODiversityGraph.js
+++ b/client/src/components/Elements/Graphs/KODiversityGraph/KODiversityGraph.js
@@ -205,7 +205,7 @@ export const KODiversityGraph = () => {
               </div>
             </div>
           ) : (
-            <div className={classes.noYearSelected}>No item selected</div>
+            <div className={classes.noYearSelected}>Click on a item to see the details</div>
           )}
         </div>
       </div>

--- a/client/src/components/Elements/Graphs/TrendsKPGraph/TrendsKPGraph.js
+++ b/client/src/components/Elements/Graphs/TrendsKPGraph/TrendsKPGraph.js
@@ -18,7 +18,7 @@ import React, { useEffect, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../../../../stores/hooks';
 import { isTouchDevice } from '../../../../util/isTouchDevice';
 import { colorForDrugClassesKP, hoverColor } from '../../../../util/colorHelper';
-import { setTrendsKPGraphDrugClass, setTrendsKPGraphView } from '../../../../stores/slices/graphSlice';
+import { setTrendsKPGraphDrugClass, setTrendsKPGraphView, setResetBool } from '../../../../stores/slices/graphSlice';
 import { drugClassesKP } from '../../../../util/drugs';
 
 const dataViewOptions = [
@@ -42,8 +42,10 @@ export const TrendsKPGraph = () => {
   const genotypesAndDrugsYearData = useAppSelector((state) => state.graph.genotypesAndDrugsYearData);
   const trendsKPGraphView = useAppSelector((state) => state.graph.trendsKPGraphView);
   const trendsKPGraphDrugClass = useAppSelector((state) => state.graph.trendsKPGraphDrugClass);
+  const resetBool = useAppSelector((state) => state.graph.resetBool);
 
   useEffect(() => {
+    dispatch(setResetBool(true));
     setCurrentTooltip(null);
   }, [genotypesAndDrugsYearData]);
 
@@ -132,9 +134,16 @@ export const TrendsKPGraph = () => {
       });
 
       setCurrentTooltip(value);
+      dispatch(setResetBool(false));
     }
   }
 
+  useEffect(()=>{
+    if(resetBool){
+      setCurrentTooltip(null);
+      dispatch(setResetBool(true));
+    }
+  });
   useEffect(() => {
     if (canGetData) {
       setPlotChart(() => {

--- a/client/src/components/Elements/Graphs/TrendsKPGraph/TrendsKPGraph.js
+++ b/client/src/components/Elements/Graphs/TrendsKPGraph/TrendsKPGraph.js
@@ -326,7 +326,7 @@ export const TrendsKPGraph = () => {
               </div>
             </div>
           ) : (
-            <div className={classes.noYearSelected}>No year selected</div>
+            <div className={classes.noYearSelected}>Click on a year to see detail</div>
           )}
         </div>
       </div>

--- a/client/src/components/Elements/ResetButton/ResetButton.js
+++ b/client/src/components/Elements/ResetButton/ResetButton.js
@@ -18,7 +18,8 @@ import {
   setKODiversityGraphView,
   setTrendsKPGraphDrugClass,
   setTrendsKPGraphView,
-  setCurrentSliderValue
+  setCurrentSliderValue,
+  setResetBool,
 } from '../../../stores/slices/graphSlice';
 import { drugsKP, defaultDrugsForDrugResistanceGraphST } from '../../../util/drugs';
 
@@ -72,6 +73,7 @@ export const ResetButton = () => {
     dispatch(setDistributionGraphView('number'));
     dispatch(setCanGetData(true));
     dispatch(setCurrentSliderValue(20));
+    dispatch(setResetBool(true));
     // dispatch(setGenotypesForFilter(true))
   }
 

--- a/client/src/components/Elements/ResetButton/ResetButton.js
+++ b/client/src/components/Elements/ResetButton/ResetButton.js
@@ -18,7 +18,7 @@ import {
   setKODiversityGraphView,
   setTrendsKPGraphDrugClass,
   setTrendsKPGraphView,
-  setGenotypesForFilterLength
+  setCurrentSliderValue
 } from '../../../stores/slices/graphSlice';
 import { drugsKP, defaultDrugsForDrugResistanceGraphST } from '../../../util/drugs';
 
@@ -71,7 +71,7 @@ export const ResetButton = () => {
     dispatch(setDeterminantsGraphView('percentage'));
     dispatch(setDistributionGraphView('number'));
     dispatch(setCanGetData(true));
-    dispatch(setGenotypesForFilterLength(20));
+    dispatch(setCurrentSliderValue(20));
     // dispatch(setGenotypesForFilter(true))
   }
 

--- a/client/src/components/Elements/ResetButton/ResetButton.js
+++ b/client/src/components/Elements/ResetButton/ResetButton.js
@@ -17,7 +17,8 @@ import {
   setFrequenciesGraphView,
   setKODiversityGraphView,
   setTrendsKPGraphDrugClass,
-  setTrendsKPGraphView
+  setTrendsKPGraphView,
+  setGenotypesForFilterLength
 } from '../../../stores/slices/graphSlice';
 import { drugsKP, defaultDrugsForDrugResistanceGraphST } from '../../../util/drugs';
 
@@ -70,6 +71,8 @@ export const ResetButton = () => {
     dispatch(setDeterminantsGraphView('percentage'));
     dispatch(setDistributionGraphView('number'));
     dispatch(setCanGetData(true));
+    dispatch(setGenotypesForFilterLength(20));
+    // dispatch(setGenotypesForFilter(true))
   }
 
   return (

--- a/client/src/components/Elements/Slider/SliderSizes.js
+++ b/client/src/components/Elements/Slider/SliderSizes.js
@@ -16,18 +16,19 @@ export const SliderSizes = () => {
   };
 
   return (
-    <Box width='100%'>
-      <Slider
-        value={genotypesForFilterLength}
-        onChange={handleDefaultSliderChange}
-        aria-label="Default"
-        valueLabelDisplay="auto"
-        min={1}
-        max={genotypesForFilter.length}
-      />
-
-      {/* Display the values of the sliders */}
-      <p>Selected Slider Value: {genotypesForFilterLength}</p>
-    </Box>
+    <div style={{ margin: '0px 10px' }}>
+      <Box >
+        <Slider
+          value={genotypesForFilterLength}
+          onChange={handleDefaultSliderChange}
+          aria-label="Default"
+          valueLabelDisplay="auto"
+          min={1}
+          max={genotypesForFilter.length}
+        />
+        {/* Display the values of the sliders */}
+        <p>Selected Slider Value: {genotypesForFilterLength}</p>
+      </Box>
+    </div>
   );
 }

--- a/client/src/components/Elements/Slider/SliderSizes.js
+++ b/client/src/components/Elements/Slider/SliderSizes.js
@@ -5,7 +5,6 @@ import { useAppDispatch, useAppSelector } from '../../../stores/hooks';
 import { setGenotypesForFilterLength } from '../../../stores/slices/graphSlice';
 
 export const SliderSizes = () => {
-  // const [defaultSliderValue, setDefaultSliderValue] = useState(50);
 
   const dispatch = useAppDispatch();
   const genotypesForFilterLength = useAppSelector((state) => state.graph.genotypesForFilterLength);

--- a/client/src/components/Elements/Slider/SliderSizes.js
+++ b/client/src/components/Elements/Slider/SliderSizes.js
@@ -23,7 +23,7 @@ export const SliderSizes = () => {
           aria-label="Default"
           valueLabelDisplay="auto"
           min={1}
-          max={genotypesForFilter.length}
+          max={133}
         />
         {/* Display the values of the sliders */}
         <p>Selected Slider Value: {genotypesForFilter.length >= genotypesForFilterLength ? genotypesForFilterLength :  genotypesForFilter.length}</p>

--- a/client/src/components/Elements/Slider/SliderSizes.js
+++ b/client/src/components/Elements/Slider/SliderSizes.js
@@ -26,7 +26,10 @@ export const SliderSizes = () => {
           max={genotypesForFilter.length <= 133 ? genotypesForFilter.length : 133 }
         />
         {/* Display the values of the sliders */}
-        <p>Selected Slider Value: {genotypesForFilter.length >= genotypesForFilterLength ? genotypesForFilterLength :  genotypesForFilter.length}</p>
+        <div style= {{display:'flex'}}>
+        <p>Number of genotypes to colour individually:</p>
+        <p>{genotypesForFilter.length >= genotypesForFilterLength ? genotypesForFilterLength :  genotypesForFilter.length}</p>
+        </div>
       </Box>
     </div>
   );

--- a/client/src/components/Elements/Slider/SliderSizes.js
+++ b/client/src/components/Elements/Slider/SliderSizes.js
@@ -10,8 +10,11 @@ export const SliderSizes = () => {
   const currentSliderValue = useAppSelector((state) => state.graph.currentSliderValue);
   const genotypesForFilter = useAppSelector((state) => state.dashboard.genotypesForFilter);
   const maxSliderValue = useAppSelector((state) => state.graph.maxSliderValue);
+  // const [currentSliderValue, setCurrentSliderValue] = useState(20);
+
   const handleDefaultSliderChange = (event, newValue) => {
     dispatch(setCurrentSliderValue(newValue));
+    // callBackValue(newValue);
   };
 
   useEffect(()=>{

--- a/client/src/components/Elements/Slider/SliderSizes.js
+++ b/client/src/components/Elements/Slider/SliderSizes.js
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Slider from '@mui/material/Slider';
+import { useAppDispatch, useAppSelector } from '../../../stores/hooks';
+import { setgenotypesForFilterLength } from '../../../stores/slices/graphSlice';
+
+export const SliderSizes = () => {
+  // const [defaultSliderValue, setDefaultSliderValue] = useState(50);
+
+  const dispatch = useAppDispatch();
+  const genotypesForFilterLength = useAppSelector((state) => state.graph.genotypesForFilterLength);
+  const genotypesForFilter = useAppSelector((state) => state.dashboard.genotypesForFilter);
+
+  const handleDefaultSliderChange = (event, newValue) => {
+    dispatch(setgenotypesForFilterLength(newValue));
+  };
+
+  return (
+    <Box width='100%'>
+      <Slider
+        value={genotypesForFilterLength}
+        onChange={handleDefaultSliderChange}
+        aria-label="Default"
+        valueLabelDisplay="auto"
+        min={1}
+        max={genotypesForFilter.length}
+      />
+
+      {/* Display the values of the sliders */}
+      <p>Selected Slider Value: {genotypesForFilterLength}</p>
+    </Box>
+  );
+}

--- a/client/src/components/Elements/Slider/SliderSizes.js
+++ b/client/src/components/Elements/Slider/SliderSizes.js
@@ -1,34 +1,39 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Box from '@mui/material/Box';
 import Slider from '@mui/material/Slider';
 import { useAppDispatch, useAppSelector } from '../../../stores/hooks';
-import { setGenotypesForFilterLength } from '../../../stores/slices/graphSlice';
+import { setCurrentSliderValue,setMaxSliderValue } from '../../../stores/slices/graphSlice';
 
 export const SliderSizes = () => {
 
   const dispatch = useAppDispatch();
-  const genotypesForFilterLength = useAppSelector((state) => state.graph.genotypesForFilterLength);
+  const currentSliderValue = useAppSelector((state) => state.graph.currentSliderValue);
   const genotypesForFilter = useAppSelector((state) => state.dashboard.genotypesForFilter);
-
+  const maxSliderValue = useAppSelector((state) => state.graph.maxSliderValue);
   const handleDefaultSliderChange = (event, newValue) => {
-    dispatch(setGenotypesForFilterLength(newValue));
+    dispatch(setCurrentSliderValue(newValue));
   };
+
+  useEffect(()=>{
+    const max = genotypesForFilter.length <= 133 ? genotypesForFilter.length : 133;
+    dispatch(setMaxSliderValue(max));
+  });
 
   return (
     <div style={{ margin: '0px 10px' }}>
       <Box >
         <Slider
-          value={genotypesForFilter.length >= genotypesForFilterLength ? genotypesForFilterLength :  genotypesForFilter.length }
+          value={currentSliderValue }
           onChange={handleDefaultSliderChange}
           aria-label="Default"
           valueLabelDisplay="auto"
           min={1}
-          max={genotypesForFilter.length <= 133 ? genotypesForFilter.length : 133 }
+          max={maxSliderValue}
         />
         {/* Display the values of the sliders */}
         <div style= {{display:'flex'}}>
         <p>Number of genotypes to colour individually:</p>
-        <p>{genotypesForFilter.length >= genotypesForFilterLength ? genotypesForFilterLength :  genotypesForFilter.length}</p>
+        <p>{currentSliderValue}</p>
         </div>
       </Box>
     </div>

--- a/client/src/components/Elements/Slider/SliderSizes.js
+++ b/client/src/components/Elements/Slider/SliderSizes.js
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import Box from '@mui/material/Box';
 import Slider from '@mui/material/Slider';
 import { useAppDispatch, useAppSelector } from '../../../stores/hooks';
-import { setgenotypesForFilterLength } from '../../../stores/slices/graphSlice';
+import { setGenotypesForFilterLength } from '../../../stores/slices/graphSlice';
 
 export const SliderSizes = () => {
   // const [defaultSliderValue, setDefaultSliderValue] = useState(50);
@@ -12,14 +12,14 @@ export const SliderSizes = () => {
   const genotypesForFilter = useAppSelector((state) => state.dashboard.genotypesForFilter);
 
   const handleDefaultSliderChange = (event, newValue) => {
-    dispatch(setgenotypesForFilterLength(newValue));
+    dispatch(setGenotypesForFilterLength(newValue));
   };
 
   return (
     <div style={{ margin: '0px 10px' }}>
       <Box >
         <Slider
-          value={genotypesForFilterLength}
+          value={genotypesForFilter.length >= genotypesForFilterLength ? genotypesForFilterLength :  genotypesForFilter.length }
           onChange={handleDefaultSliderChange}
           aria-label="Default"
           valueLabelDisplay="auto"
@@ -27,7 +27,7 @@ export const SliderSizes = () => {
           max={genotypesForFilter.length}
         />
         {/* Display the values of the sliders */}
-        <p>Selected Slider Value: {genotypesForFilterLength}</p>
+        <p>Selected Slider Value: {genotypesForFilter.length >= genotypesForFilterLength ? genotypesForFilterLength :  genotypesForFilter.length}</p>
       </Box>
     </div>
   );

--- a/client/src/components/Elements/Slider/SliderSizes.js
+++ b/client/src/components/Elements/Slider/SliderSizes.js
@@ -23,7 +23,7 @@ export const SliderSizes = () => {
           aria-label="Default"
           valueLabelDisplay="auto"
           min={1}
-          max={133}
+          max={genotypesForFilter.length <= 133 ? genotypesForFilter.length : 133 }
         />
         {/* Display the values of the sliders */}
         <p>Selected Slider Value: {genotypesForFilter.length >= genotypesForFilterLength ? genotypesForFilterLength :  genotypesForFilter.length}</p>

--- a/client/src/components/Elements/Slider/index.js
+++ b/client/src/components/Elements/Slider/index.js
@@ -1,0 +1,1 @@
+export * from './SliderSizes';

--- a/client/src/stores/slices/graphSlice.ts
+++ b/client/src/stores/slices/graphSlice.ts
@@ -32,7 +32,7 @@ interface GraphState {
   convergenceColourVariable: string;
   convergenceColourPallete: Object;
   currentSliderValue: number;
-  currentTooltipBool: boolean;
+  resetBool: boolean;
   maxSliderValue:number;
 }
 
@@ -67,7 +67,7 @@ const initialState: GraphState = {
   convergenceColourVariable: 'DATE',
   convergenceColourPallete: {},
   currentSliderValue:20,
-  currentTooltipBool:false,
+  resetBool: false,
   maxSliderValue:0,
 };
 
@@ -144,8 +144,8 @@ export const graphSlice = createSlice({
      setCurrentSliderValue: (state, action: PayloadAction<number>) => {
       state.currentSliderValue = action.payload;
     },
-    setCurrentTooltipBool: (state, action: PayloadAction<boolean>) => {
-      state.currentTooltipBool = action.payload;
+    setResetBool: (state, action: PayloadAction<boolean>) => {
+      state.resetBool = action.payload;
     },
     setMaxSliderValue: (state, action: PayloadAction<number>) => {
       state.maxSliderValue = action.payload;
@@ -177,7 +177,7 @@ export const {
   setConvergenceColourVariable,
   setConvergenceColourPallete,
   setCurrentSliderValue,
-  setCurrentTooltipBool,
+  setResetBool,
   setMaxSliderValue,
 } = graphSlice.actions;
 

--- a/client/src/stores/slices/graphSlice.ts
+++ b/client/src/stores/slices/graphSlice.ts
@@ -31,8 +31,9 @@ interface GraphState {
   convergenceGroupVariable: string;
   convergenceColourVariable: string;
   convergenceColourPallete: Object;
-  genotypesForFilterLength: number;
+  currentSliderValue: number;
   currentTooltipBool: boolean;
+  maxSliderValue:number;
 }
 
 const initialState: GraphState = {
@@ -65,8 +66,9 @@ const initialState: GraphState = {
   convergenceGroupVariable: 'COUNTRY_ONLY',
   convergenceColourVariable: 'DATE',
   convergenceColourPallete: {},
-  genotypesForFilterLength:20,
+  currentSliderValue:20,
   currentTooltipBool:false,
+  maxSliderValue:0,
 };
 
 export const graphSlice = createSlice({
@@ -139,11 +141,14 @@ export const graphSlice = createSlice({
     setConvergenceColourPallete: (state, action: PayloadAction<Object>) => {
       state.convergenceColourPallete = action.payload;
     },
-     setGenotypesForFilterLength: (state, action: PayloadAction<number>) => {
-      state.genotypesForFilterLength = action.payload;
+     setCurrentSliderValue: (state, action: PayloadAction<number>) => {
+      state.currentSliderValue = action.payload;
     },
     setCurrentTooltipBool: (state, action: PayloadAction<boolean>) => {
       state.currentTooltipBool = action.payload;
+    },
+    setMaxSliderValue: (state, action: PayloadAction<number>) => {
+      state.maxSliderValue = action.payload;
     },
   }
 });
@@ -171,8 +176,9 @@ export const {
   setConvergenceGroupVariable,
   setConvergenceColourVariable,
   setConvergenceColourPallete,
-  setGenotypesForFilterLength,
+  setCurrentSliderValue,
   setCurrentTooltipBool,
+  setMaxSliderValue,
 } = graphSlice.actions;
 
 export default graphSlice.reducer;

--- a/client/src/stores/slices/graphSlice.ts
+++ b/client/src/stores/slices/graphSlice.ts
@@ -29,8 +29,9 @@ interface GraphState {
   KODiversityGraphView: string;
   convergenceData: Array<any>;
   convergenceGroupVariable: string;
-  convergenceColourVariable: string
-  convergenceColourPallete: Object
+  convergenceColourVariable: string;
+  convergenceColourPallete: Object;
+  genotypesForFilterLength: number;
 }
 
 const initialState: GraphState = {
@@ -62,7 +63,8 @@ const initialState: GraphState = {
   convergenceData: [],
   convergenceGroupVariable: 'COUNTRY_ONLY',
   convergenceColourVariable: 'DATE',
-  convergenceColourPallete: {}
+  convergenceColourPallete: {},
+  genotypesForFilterLength:20,
 };
 
 export const graphSlice = createSlice({
@@ -135,6 +137,9 @@ export const graphSlice = createSlice({
     setConvergenceColourPallete: (state, action: PayloadAction<Object>) => {
       state.convergenceColourPallete = action.payload;
     },
+     setgenotypesForFilterLength: (state, action: PayloadAction<number>) => {
+      state.genotypesForFilterLength = action.payload;
+    },
   }
 });
 
@@ -160,7 +165,8 @@ export const {
   setConvergenceData,
   setConvergenceGroupVariable,
   setConvergenceColourVariable,
-  setConvergenceColourPallete
+  setConvergenceColourPallete,
+  setgenotypesForFilterLength,
 } = graphSlice.actions;
 
 export default graphSlice.reducer;

--- a/client/src/stores/slices/graphSlice.ts
+++ b/client/src/stores/slices/graphSlice.ts
@@ -137,7 +137,7 @@ export const graphSlice = createSlice({
     setConvergenceColourPallete: (state, action: PayloadAction<Object>) => {
       state.convergenceColourPallete = action.payload;
     },
-     setgenotypesForFilterLength: (state, action: PayloadAction<number>) => {
+     setGenotypesForFilterLength: (state, action: PayloadAction<number>) => {
       state.genotypesForFilterLength = action.payload;
     },
   }
@@ -166,7 +166,7 @@ export const {
   setConvergenceGroupVariable,
   setConvergenceColourVariable,
   setConvergenceColourPallete,
-  setgenotypesForFilterLength,
+  setGenotypesForFilterLength,
 } = graphSlice.actions;
 
 export default graphSlice.reducer;

--- a/client/src/stores/slices/graphSlice.ts
+++ b/client/src/stores/slices/graphSlice.ts
@@ -32,6 +32,7 @@ interface GraphState {
   convergenceColourVariable: string;
   convergenceColourPallete: Object;
   genotypesForFilterLength: number;
+  currentTooltipBool: boolean;
 }
 
 const initialState: GraphState = {
@@ -65,6 +66,7 @@ const initialState: GraphState = {
   convergenceColourVariable: 'DATE',
   convergenceColourPallete: {},
   genotypesForFilterLength:20,
+  currentTooltipBool:false,
 };
 
 export const graphSlice = createSlice({
@@ -140,6 +142,9 @@ export const graphSlice = createSlice({
      setGenotypesForFilterLength: (state, action: PayloadAction<number>) => {
       state.genotypesForFilterLength = action.payload;
     },
+    setCurrentTooltipBool: (state, action: PayloadAction<boolean>) => {
+      state.currentTooltipBool = action.payload;
+    },
   }
 });
 
@@ -167,6 +172,7 @@ export const {
   setConvergenceColourVariable,
   setConvergenceColourPallete,
   setGenotypesForFilterLength,
+  setCurrentTooltipBool,
 } = graphSlice.actions;
 
 export default graphSlice.reducer;

--- a/client/src/util/colorHelper.js
+++ b/client/src/util/colorHelper.js
@@ -132,6 +132,7 @@ export const getColorForGenotype = (genotype) => {
 // Generate color pallete for Klebsiella genotypes
 let iwanthue = require('iwanthue');
 export const generatePalleteForGenotypes = (genotypes) => {
+  console.log("genotypes.length", genotypes.length);
   if (genotypes.length === 0) {
     return {};
   }


### PR DESCRIPTION
- A new color palette has been carefully selected to improve the clarity and coherence of the Genotype Distribution Plot. The new colors ensure better differentiation of genotype categories, enhancing data interpretation.

-  **Genotype distribution** The plot now displays the genotype counts for Klebsiella (1773 genotypes) and Salmonella (80 genotypes), providing valuable insights into the distribution of these organisms.

- The TopXGenotypes for the **Genotype distribution**  Plot are now calculated to show limited X numbers of Genotype data on the plot

- To improve plot readability, the maximum display limit for TopXGenotypes has been set to 133

- A slider has been added to the **Genotype distribution** Plot, allowing users to control the number of visible TopXGenotypes dynamically.

- If the number of genotypes exceeds the slider value, the plot now aggregates the count of all other genotypes for each year and presents it as the "Other" value, providing a comprehensive view of the remaining genotypes.

-  The tooltip on the **Genotype distribution**  Plot now dynamically updates as the slider value changes, allowing users to see detailed year data on each genotype.

-  The tooltip on the **Genotype distribution**  Plot now resets on changes to the organism and the reset button

- **All other plots** in the application now feature tooltip resets on changes to the organism and reset button
