### PR TITLE
Read docs updates based on Feedback 

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -3,91 +3,91 @@ Data access
 
 The full sample-level data for each organism can be downloaded from the AMRnet dashboard itself, using the ‘Download database (CSV) format’ button at the bottom of the page. In addition, you can access AMRnet data via the API described below.
 
-**Architetures**: The API architectures have 3 options developed for the project which includes:
+**Architectures**: The API architectures have 3 options developed for the project which includes:
 
-**OPTION 1:**
+.. **OPTION 1:**
 
-.. figure:: assets/apiauth1.png
-   :width: 100%
-   :align: center
-   :alt: api
+.. .. figure:: assets/apiauth1.png
+..    :width: 100%
+..    :align: center
+..    :alt: api
 
-.. figure:: assets/arrow.png
-   :width: 100%
-   :align: center
-   :alt: api
+.. .. figure:: assets/arrow.png
+..    :width: 100%
+..    :align: center
+..    :alt: api
 
-.. figure:: assets/apiauth2.png
-    :width: 100%
-    :align: center
-    :alt: api
+.. .. figure:: assets/apiauth2.png
+..     :width: 100%
+..     :align: center
+..     :alt: api
 
-**OPTION 2:**
+.. **OPTION 2:**
 
-.. figure:: assets/apidatalake1.png
-   :width: 100%
-   :align: center
-   :alt: api
+.. .. figure:: assets/apidatalake1.png
+..    :width: 100%
+..    :align: center
+..    :alt: api
 
-.. figure:: assets/arrow.png
-   :width: 100%
-   :align: center
-   :alt: api
+.. .. figure:: assets/arrow.png
+..    :width: 100%
+..    :align: center
+..    :alt: api
 
-.. figure:: assets/apidatalake2.png
-    :width: 100%
-    :align: center
-    :alt: api
+.. .. figure:: assets/apidatalake2.png
+..     :width: 100%
+..     :align: center
+..     :alt: api
 
-**OPTION 3:**
+.. **OPTION 3:**
 
-.. figure:: assets/apigui1.png
-   :width: 100%
-   :align: center
-   :alt: api
+.. .. figure:: assets/apigui1.png
+..    :width: 100%
+..    :align: center
+..    :alt: api
 
-.. figure:: assets/arrow.png
-   :width: 100%
-   :align: center
-   :alt: api
+.. .. figure:: assets/arrow.png
+..    :width: 100%
+..    :align: center
+..    :alt: api
 
-.. figure:: assets/apigui2.png
-    :width: 100%
-    :align: center
-    :alt: api
+.. .. figure:: assets/apigui2.png
+..     :width: 100%
+..     :align: center
+..     :alt: api
 
-Download data via bucket
-------------------------
+1. Download data via bucket
+---------------------------
 
 .. note:: If you intend to frequently access data, please contact the AMRnet team at amrnet.api@gmail.com .
 
-1. Data accessing using Browser
-*******************************
+a. Data accessing using Browser
+******************************************
 
-Viewing Available Files:
-~~~~~~~~~~~~~~~~~~~~~~~~
+i. Viewing Available Files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Step 1: Open a web browser (Chrome, Firefox, Safari, etc.).
 * Step 2: Navigate to the root bucket URL by entering ``https://amrnet.s3.amazonaws.com/`` into the browser's address bar and pressing Enter.
 * Step 3: This URL leads to an XML text representation listing all the files available in the Amazon S3 bucket. The XML format will display information about each file, such as its key (name), last modified date, size, etc.
 
-Searching for a Specific Organism:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ii. Searching for a Specific Organism
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Step 1: Use the search functionality of your browser (Ctrl-F on Windows/Linux or Cmd-F on Mac).
 * Step 2: Type the name of the organism you are looking for in the search box. This will highlight all occurrences of the organism's name in the XML text, making it easier to locate the specific file associated with that organism.
 
-Downloading a File:
-~~~~~~~~~~~~~~~~~~~
+iii. Downloading a File
+~~~~~~~~~~~~~~~~~~~~~~~~
 * Step 1: Once you find the ``<Key>`` field that contains the file name you are interested in, note down the file name.
 * Step 2: Open a new tab in your browser.
 * Step 3: Copy the root bucket URL ``https://amrnet.s3.amazonaws.com`` into the new tab's address bar.
 * Step 4: Append a slash ``/`` to the end of the URL, followed by the contents of the ``<Key>`` field (file name).
 * Step 5: Press Enter, and your browser should automatically start downloading the file. This method has been tested to work in Chrome, Firefox, and Safari.
 
-2. Data accessing using Command line
-************************************
+b. Data accessing using Command line
+************************************************
 
-Getting the complete list of files
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+i. Getting the complete list of files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Step 1: Install ``xq``, a command-line tool for parsing XML from the ``yq`` toolset. The installation instructions vary depending on your operating system but typically involve using a package manager like ``brew`` on macOS or ``apt`` on Ubuntu.
 * Step 2: Use ``curl`` to fetch the XML representation of the file list from the S3 bucket and pipe it to ``xq`` to parse and extract the keys (file names). The command looks like this:
 
@@ -97,8 +97,8 @@ Getting the complete list of files
 
 * Explanation: ``curl`` retrieves the XML data from the URL. The ``|`` symbol pipes this data into ``xq``, which parses the XML and extracts the file names, displaying them in the terminal.
 
-Downloading a single file
-~~~~~~~~~~~~~~~~~~~~~~~~~
+ii. Downloading a single file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Step 1: Install ``jq``, a command-line tool for parsing JSON. Like ``xq``, installation instructions will vary based on your operating system.
 * Step 2: Use ``curl`` to download the file by constructing the URL with the file name. The command for downloading a file named ``amrnet_<ORGAMISM>.csv`` is:
@@ -118,22 +118,22 @@ For example:
 
 By following these steps, you can efficiently search for and download specific files from the S3 bucket using both a web browser and the command line.
 
-3. Data accessing using Using S3cmd tool
-****************************************
+c. Data accessing using Using S3cmd tool 
+***************************************************
 
 The `s3cmd <https://s3tools.org/s3cmd>`_ tool is a versatile and powerful command-line utility designed to interact with Amazon S3 (Simple Storage Service). It simplifies tasks such as browsing, downloading, and syncing files from S3 buckets. This tool is particularly useful for managing large datasets and automating workflows involving S3 storage.
 
-API
------
+2. Download data via API
+------------------------
 
 1. Send an email to amrnet.api@gmail.com requesting an API token. 
 Include details like:
 
 **Organism name**, 
 
-**Specific Country or All**, 
+.. **Specific Country or All**, 
 
-**Specific Date/Period (starting and Ending year) or All**
+.. **Specific Date/Period (starting and Ending year) or All**
 
 Example:
 
@@ -146,13 +146,11 @@ Example:
         I am writing to request an API token for accessing the AMRnet database. Below are the specific details for my request:
 
         Organism Name: Escherichia coli
-        Country: United Kingdom
-        Period: 2010 to 2020
 
 
 2. You will receive email from us with all the necessary detailed. like: **API_TOKEN_KEY, collection, database, dataSource**.
 3. Once you received these details use the method below to download required data.
-4. To download data with specific country and period add a **filter**.
+4. To download data with specific COUNTRY and DATE add a **filter**.
 
 Example code to download all the data for an organism:
 
@@ -169,7 +167,7 @@ Example code to download all the data for an organism:
             }'
 
 
-Example code to download the data with filters for an organism:
+Example code to download the data with filters **DATE** and **COUNTRY** for an organism:
 
 
 .. code-block:: bash
@@ -185,25 +183,12 @@ Example code to download the data with filters for an organism:
                 "filter": {"$and": [{"DATE": "2015"},{"COUNTRY": "Blantyre"}]}
             }'
 
-.. note::
+Example code to download the data with only one filter e.g. **DATE** for an organism:
 
-    To test your cURL requests, you can use the online tool `Run Curl Commands Online <https://reqbin.com/curl>`_. This tool provides a convenient way to execute and test your cURL commands directly in your web browser without needing to install any additional software.
-
-
-Command line
-************
-
-To download data using our API, please follow the given steps:
-
-1. Once you have API token, Replace ``<API_TOKEN_KEY>`` in the following command with the actual API token you received.
-2. Determine the specific database and collection you need data from. 
-3. Open your command line interface (CLI) or terminal and execute the following curl command to download data.
-
-For example:
 
 .. code-block:: bash
 
-            curl --location --request POST 'https://eu-west-2.aws.data.mongodb-api.com/app/data-vnnyv/endpoint/data/v1/action/find'\
+    curl --location --request POST 'https://eu-west-2.aws.data.mongodb-api.com/app/data-vnnyv/endpoint/data/v1/action/findOne' \
             --header 'Content-Type: application/json' \
             --header 'Access-Control-Request-Headers: *' \
             --header 'api-key: <API_TOKEN_KEY>' \
@@ -211,12 +196,26 @@ For example:
                 "collection":"<COLLECTION_NAME>",
                 "database":"<DATABASE_NAME>",
                 "dataSource":"<dataSource_NAME>"
+                "filter": {"DATE": "2015"}
             }'
 
+.. note::
+
+    To test your cURL requests, you can use the online tool `Run Curl Commands Online <https://reqbin.com/curl>`_. This tool provides a convenient way to execute and test your cURL commands directly in your web browser without needing to install any additional software.
+
+
+a. Command line
+***************
+
+To download data using our API, please follow the given steps:
+
+1. Once you have API token, Replace ``<API_TOKEN_KEY>`` in the following command with the actual API token you received.
+2. Determine the specific database and collection you need data from. 
+3. Open your command line interface (CLI) or terminal and execute the following **curl** command to download data.
 4. If you want to save the response data to a file, you can use the -o option with curl. This command will save the response data to a file named data.json in the current directory.
 
-Platform
-********
+b. Platform
+***********
 .. note::
 
     Users have the flexibility to access the API through their preferred platform. As an illustration, we provide guidance on utilizing the Postman tool to access data via the API.
@@ -245,19 +244,6 @@ Steps to Import the Example ``cURL`` Command using Postman
    :width: 100%
    :align: center
    :alt: CURL
-
-.. code-block:: bash
-
-    curl --location --request POST 'https://eu-west-2.aws.data.mongodb-api.com/app/data-vnnyv/endpoint/data/v1/action/findOne' \
-            --header 'Content-Type: application/json' \
-            --header 'Access-Control-Request-Headers: *' \
-            --header 'api-key: <AAPI_TOKEN_KEY>' \
-            --data-raw '{
-                "collection":"<COLLECTION_NAME>",
-                "database":"<DATABASE_NAME>",
-                "dataSource":"<dataSource_NAME>"
-            }'
-
     
 6. Review the imported request details and add ``<API_TOKEN_KEY>``in ``Headers`` in Postman.
 7. Replace database name and collection name based on data to download
@@ -285,5 +271,5 @@ Steps to Import the Example ``cURL`` Command using Postman
    :align: center
    :alt: save
 
-Graphical User Interface (GUI)
-******************************
+3. Graphical User Interface (GUI)
+---------------------------------


### PR DESCRIPTION
- fix typo at the top ‘Architetures’ -> ‘Architectures’
- we should remove the figures for now and work on adding some clearer illustrations later. Right now we just need to focus on providing CLEAR documentation for at least ONE option for accessing the data.
- it’s fine to have one token per user+organism, but they should then be free to choose whatever countries and time periods they need to without disruption.
- the content under https://amrnet.readthedocs.io/en/staging/api.html#command-line reproduces the content under https://amrnet.readthedocs.io/en/staging/api.html#api - please remove redundancy.
- It is not clear from what’s written on the page, but am I right in thinking that the section labelled “2. Data accessing using Command line” is describing how to download the same set of files listed on https://amrnet.s3.amazonaws.com/, but using the command line instead of pasting the URL into the browser? This is not clear. **Added more clear instructions and indentation**
