### PR TITLE
Fix code scanning alert no. 36: Missing rate limiting

### DIFF
--- a/routes/api/generateDataClean.js
+++ b/routes/api/generateDataClean.js
@@ -1,9 +1,15 @@
 import express from 'express';
 import { client } from '../../config/db2.js';
-
+import RateLimit from 'express-rate-limit';
 const router = express.Router();
 
-router.post('/newdoctyphi', function (req, res, next) {
+// set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
+router.post('/newdoctyphi', limiter, function (req, res, next) {
   const organism = req.body.organism;
   let collection, collection2, localFilePath;
 
@@ -556,7 +562,7 @@ router.post('/newdoctyphi', function (req, res, next) {
   res.status(200).json({ message: 'Typhi Collection update initiated successfully' });
 });
 
-router.post('/newdockleb', function (req, res, next) {
+router.post('/newdockleb', limiter, function (req, res, next) {
   const organism = req.body.organism;
   let collection, collection2, localFilePath;
 


### PR DESCRIPTION
Fixes [https://github.com/amrnet/amrnet/security/code-scanning/36](https://github.com/amrnet/amrnet/security/code-scanning/36)

To fix the problem, we will introduce rate limiting to the Express application using the `express-rate-limit` package. This will limit the number of requests that can be made to the `/newdoctyphi` and `/newdockleb` endpoints within a specified time window.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `routes/api/generateDataClean.js` file.
3. Set up a rate limiter with a reasonable limit (e.g., 100 requests per 15 minutes).
4. Apply the rate limiter to the specific routes that perform database access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
