### PR TITLE
Hide Heat-Map and Geographic Comparisons

### DIFF
--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -634,7 +634,7 @@ export const DashboardPage = () => {
     <MainLayout>
       <Note />
       <Map />
-      {['styphi', 'kpneumo'].includes(organism) && <ContinentGraphs />}
+      {/* {['styphi', 'kpneumo'].includes(organism) && <ContinentGraphs />} */}
       <SelectCountry />
       <Graphs />
       <DownloadData />

--- a/client/src/components/Elements/Map/TopRightControls/TopRightControls.js
+++ b/client/src/components/Elements/Map/TopRightControls/TopRightControls.js
@@ -151,7 +151,7 @@ export const TopRightControls = () => {
     <div className={`${classes.topRightControls} ${matches ? classes.bp700 : ''}`}>
       <Card elevation={3} className={classes.card}>
         <CardContent className={classes.cardContent}>
-          <div className={classes.mapViewWrapper}>
+          {/* <div className={classes.mapViewWrapper}>
             <Typography gutterBottom variant="caption">
               Select map view
             </Typography>
@@ -171,7 +171,7 @@ export const TopRightControls = () => {
                 Economic Region
               </ToggleButton>
             </ToggleButtonGroup>
-          </div>
+          </div> */}
           <div className={classes.label}>
             <Typography variant="caption">Colour country by</Typography>
             <Tooltip


### PR DESCRIPTION
This PR removes the Heat-Map and Geographic Comparisons sections from the dashboard as per the latest feedback for amrnet.org

- Commented out the Heat-Map section.
- Commented out the Geographic Comparisons section.
- Tested UI layout to reflect these changes.