### PR TITLE
Potential fix for code scanning alert no. 40: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "web-vitals": "^2.1.0",
     "webpack": "^4.44.2",
     "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^3.11.1"
+    "webpack-dev-server": "^3.11.1",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.19",

--- a/routes/api/generateDataClean.js
+++ b/routes/api/generateDataClean.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import { client } from '../../config/db2.js';
+import rateLimit from 'express-rate-limit';
 
 const router = express.Router();
 
@@ -556,7 +557,13 @@ router.post('/newdoctyphi', function (req, res, next) {
   res.status(200).json({ message: 'Typhi Collection update initiated successfully' });
 });
 
-router.post('/newdockleb', function (req, res, next) {
+const newdocklebLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  message: { error: 'Too many requests, please try again later.' },
+});
+
+router.post('/newdockleb', newdocklebLimiter, function (req, res, next) {
   const organism = req.body.organism;
   let collection, collection2, localFilePath;
 


### PR DESCRIPTION
Potential fix for [https://github.com/amrnet/amrnet/security/code-scanning/40](https://github.com/amrnet/amrnet/security/code-scanning/40)

To address the issue, we will introduce rate limiting to the route handler using the `express-rate-limit` middleware. This middleware will limit the number of requests a client can make to the `/newdockleb` endpoint within a specified time window. Specifically:

1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `express-rate-limit` package in the file.
3. Define a rate limiter with appropriate settings (e.g., a maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to the `/newdockleb` route.

This fix ensures that the route is protected against excessive requests, mitigating the risk of DoS attacks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
