### PR TITLE
Potential fix for code scanning alert no. 108: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "web-vitals": "^2.1.0",
     "webpack": "^4.44.2",
     "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^3.11.1"
+    "webpack-dev-server": "^3.11.1",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.19",

--- a/routes/api/api.js
+++ b/routes/api/api.js
@@ -4,6 +4,7 @@ import csv from 'csv-parser';
 import fs from 'fs';
 import * as Tools from '../../services/services.js';
 import { client } from '../../config/db2.js';
+import rateLimit from 'express-rate-limit';
 
 const dbAndCollectionNames = {
   styphi: { dbName: 'styphi', collectionName: 'merge_rawdata_st' },
@@ -328,7 +329,13 @@ router.get('/getDataForSenterica', async function (req, res, next) {
   }
 });
 
-router.get('/getDataForSentericaints', async function (req, res, next) {
+const sentericaintsLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+  message: { error: 'Too many requests, please try again later.' },
+});
+
+router.get('/getDataForSentericaints', sentericaintsLimiter, async function (req, res, next) {
   const dbAndCollection = dbAndCollectionNames['sentericaints'];
   try {
     const result = await client


### PR DESCRIPTION
Potential fix for [https://github.com/amrnet/amrnet/security/code-scanning/108](https://github.com/amrnet/amrnet/security/code-scanning/108)

To address the issue, we will use the `express-rate-limit` package to enforce rate-limiting on the affected route handler (`/getDataForSentericaints`). This package allows us to define a maximum number of requests per time window, ensuring that the database is not overwhelmed by excessive traffic.

Steps to fix:
1. Install the `express-rate-limit` package if not already installed.
2. Import the package in `routes/api/api.js`.
3. Define a rate-limiting middleware with appropriate configuration (e.g., 100 requests per 15 minutes).
4. Apply the rate-limiting middleware to the `/getDataForSentericaints` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
