### PR TITLE
PDF improvement

### DIFF
--- a/client/src/components/Elements/ContinentGraphs/BubbleGeographicGraph/BubbleGeographicGraph.js
+++ b/client/src/components/Elements/ContinentGraphs/BubbleGeographicGraph/BubbleGeographicGraph.js
@@ -43,12 +43,12 @@ import { organismsCards, organismsWithLotsGenotypes } from '../../../../util/org
 
 const kpTrendOptions = Object.keys(drugClassesRulesKP)
   .map((drug) => {
-    const label = drug === 'ESBL' ? 'ESBLs' : drug;
+    const label = drug === 'ESBL' ? 'ESBLs' : 'Carbapenemase'; // Added 'Carbapenemase' for KP trends in geo comp graphs
     return {
       organism: 'kpneumo',
       key: drug,
       value: `kp-trends-${drug.toLowerCase()}`,
-      label: label,
+      label: `${label} genes`, // Added 'genes' for KP trends in geo comp graphs
     };
   })
   .sort((a, b) => a.key.localeCompare(b.key));
@@ -120,6 +120,8 @@ export const BubbleGeographicGraph = ({ showFilter, setShowFilter }) => {
   const drugsCountriesData = useAppSelector((state) => state.graph.drugsCountriesData);
   const yAxisType = useAppSelector((state) => state.map.yAxisType);
   const yAxisTypeTrend = useAppSelector((state) => state.map.yAxisTypeTrend);
+  const loadingPDF = useAppSelector((state) => state.dashboard.loadingPDF);
+  
 
   useEffect(() => {
     setXAxisType('country');
@@ -730,7 +732,8 @@ export const BubbleGeographicGraph = ({ showFilter, setShowFilter }) => {
   return (
     <CardContent className={classes.bubbleGeographicGraph}>
       <div className={classes.graphWrapper}>
-        <div className={classes.graph} id="CVM">
+      {/* // BG is replaced from CVM for BubbleGeographicGraph and overflow visible for Download PDF */}
+        <div className={classes.graph} style={loadingPDF ? { overflow: 'visible' } : undefined} id="BG"> 
           {plotChart}
         </div>
       </div>

--- a/client/src/components/Elements/ContinentGraphs/ContinentGraphs.js
+++ b/client/src/components/Elements/ContinentGraphs/ContinentGraphs.js
@@ -60,6 +60,7 @@ export const ContinentGraphs = () => {
   const [currentTab, setCurrentTab] = useState(TABS[0].value);
   const [showFilter, setShowFilter] = useState(!matches500);
   const [loading, setLoading] = useState(false);
+  const matches1000 = useMediaQuery('(max-width:1000px)');
 
   const dispatch = useAppDispatch();
   const collapses = useAppSelector((state) => state.graph.collapses);
@@ -72,7 +73,8 @@ export const ContinentGraphs = () => {
   const globalOverviewLabel = useAppSelector((state) => state.dashboard.globalOverviewLabel);
   const actualGenomes = useAppSelector((state) => state.dashboard.actualGenomes);
   const selectedLineages = useAppSelector((state) => state.dashboard.selectedLineages);
-
+  // coloredOptions is used to draw the legend in the Trend Line graph
+  const coloredOptions = useAppSelector((state) => state.graph.coloredOptions); 
   useEffect(() => {
     setShowFilter(!matches500);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -107,6 +109,29 @@ export const ContinentGraphs = () => {
   if (!continentGraphCard.organisms.includes(organism)) {
     return null;
   }
+// This is a component that renders the continent graphs legends based on the selected organism
+function drawLegend({
+    legendData,
+    context,
+    factor,
+    mobileFactor,
+    yPosition,
+    xSpace,
+  }) {
+    legendData.forEach((legend, i) => {
+      const yFactor = (i % factor) * 24;
+      const xFactor = Math.floor(i / factor) * xSpace;
+      context.textAlign = 'left';
+      context.fillStyle =legend.color;
+      context.beginPath();
+      context.arc(52 + xFactor, yPosition - mobileFactor + yFactor, 5, 0, 2 * Math.PI);
+      context.fill();
+      context.closePath();
+      context.fillStyle = 'black';
+      context.fillText(legend.name,52 + xFactor + 12,yPosition + 4 - mobileFactor + yFactor,);
+    });
+  }
+
 
   async function handleClick(event) {
     event.stopPropagation();
@@ -115,7 +140,6 @@ export const ContinentGraphs = () => {
       const canvas = document.createElement('canvas');
       const ctx = canvas.getContext('2d');
 
-      // const graph = document.getElementById('CVM');
       const graph = document.getElementById(currentTab);
       // Store original styles
       const originalOverflow = graph.style.overflow;
@@ -144,8 +168,7 @@ export const ContinentGraphs = () => {
 
       canvas.width = graphImg.width < 670 ? 922 : graphImg.width + 100;
       console.log('canvas.width', canvas.width, graphImg.width);
-      // canvas.height = graphImg.height + 220 + ('CVM' ? 250 : heightFactor);
-      canvas.height = graphImg.height + 220 + ('BG' ? 250 : heightFactor);
+      canvas.height = graphImg.height + 220 + ('BG' ? 250 : heightFactor); // BG is replaced from CVM for BubbleGeographicGraph
       ctx.fillStyle = 'white';
       ctx.fillRect(0, 0, canvas.width, canvas.height);
 
@@ -175,7 +198,27 @@ export const ContinentGraphs = () => {
         154,
       );
       ctx.fillText(`Total: ${actualGenomes} genomes`, canvas.width / 2, 174);
+      
+      // This is a component that renders the continent graphs legends based on the selected organism
 
+      if (currentTab === 'TL') {
+        ctx.fillStyle = 'white';
+        const whiteBoxY =  graphImg.height*0.73+220
+        ctx.fillRect(0, whiteBoxY, canvas.width, canvas.height);
+        const variablesFactor = Math.ceil(coloredOptions.length / 3);;
+        let heightFactor = 0;
+        heightFactor += variablesFactor * 22;
+
+        const mobileFactor = matches1000 ? 100 : 0;
+        drawLegend({
+          legendData: coloredOptions,
+          context: ctx,
+          factor: variablesFactor,
+          mobileFactor,
+          yPosition: 670,
+          xSpace: 270,
+        });
+      }
       const getAxisLabel = () => {
         switch (organism) {
           case 'decoli':

--- a/client/src/components/Elements/ContinentGraphs/ContinentGraphs.js
+++ b/client/src/components/Elements/ContinentGraphs/ContinentGraphs.js
@@ -73,6 +73,8 @@ export const ContinentGraphs = () => {
   const globalOverviewLabel = useAppSelector((state) => state.dashboard.globalOverviewLabel);
   const actualGenomes = useAppSelector((state) => state.dashboard.actualGenomes);
   const selectedLineages = useAppSelector((state) => state.dashboard.selectedLineages);
+  const drugClass = useAppSelector((state) => state.graph.drugClass); // Drug class selected in the graph for SS
+  const drugGene = useAppSelector((state) => state.graph.drugGene);// Drug gene selected in the graph for SS
   // coloredOptions is used to draw the legend in the Trend Line graph
   const coloredOptions = useAppSelector((state) => state.graph.coloredOptions); 
   useEffect(() => {
@@ -168,7 +170,7 @@ function drawLegend({
 
       canvas.width = graphImg.width < 670 ? 922 : graphImg.width + 100;
       console.log('canvas.width', canvas.width, graphImg.width);
-      canvas.height = graphImg.height + 220 + ('BG' ? 250 : heightFactor); // BG is replaced from CVM for BubbleGeographicGraph
+      canvas.height = graphImg.height + 520  +('BG' ? 250 : heightFactor); // BG is replaced from CVM for BubbleGeographicGraph
       ctx.fillStyle = 'white';
       ctx.fillRect(0, 0, canvas.width, canvas.height);
 
@@ -198,6 +200,7 @@ function drawLegend({
         154,
       );
       ctx.fillText(`Total: ${actualGenomes} genomes`, canvas.width / 2, 174);
+      ctx.fillText(`${drugClass} : ${drugGene} Gene`, canvas.width / 2, 194); // Add drug class and gene to the title to PDF
       
       // This is a component that renders the continent graphs legends based on the selected organism
 

--- a/client/src/components/Elements/DownloadData/DownloadData.js
+++ b/client/src/components/Elements/DownloadData/DownloadData.js
@@ -1328,32 +1328,33 @@ export const DownloadData = () => {
     });
     await addImageToPDF({ doc, elementId: 'BG', pageWidth }); // BG is replaced from CVM for BubbleGeographicGraph
 
-    // TL Map Page
-    addStandardPage({
-      doc,
-      title: 'Geographic Comparisons (Trend Line)',
-      subtitle1: commonSubtitle1,
-      subtitle2: commonSubtitle2,
-      date,
-      pageWidth,
-      pageHeight,
-    });
-    doc.text(`${drugClass} : ${drugGene} Gene`, 16, 66); // Add drug class and gene to the title
-    await addImageToPDF({ doc, elementId: 'TL', pageWidth });
+    // TL Map Page 
+    // Hidden for now from PDF, as we dont have a trend line map on the dashboard
+    // addStandardPage({
+    //   doc,
+    //   title: 'Geographic Comparisons (Trend Line)',
+    //   subtitle1: commonSubtitle1,
+    //   subtitle2: commonSubtitle2,
+    //   date,
+    //   pageWidth,
+    //   pageHeight,
+    // });
+    // doc.text(`${drugClass} : ${drugGene} Gene`, 16, 66); // Add drug class and gene to the title
+    // await addImageToPDF({ doc, elementId: 'TL', pageWidth });
 
-    // Trend Line Page Add a Legends
-    const whiteBoxY = 100 + ((displayHeight-20) * 0.73);
-    doc.setFillColor(255, 255, 255); // White color
-    doc.rect(10, whiteBoxY, pageWidth - 20, 140, 'F'); // Draw a filled rectangle as background
+    // // Trend Line Page Add a Legends
+    // const whiteBoxY = 100 + ((displayHeight-20) * 0.73);
+    // doc.setFillColor(255, 255, 255); // White color
+    // doc.rect(10, whiteBoxY, pageWidth - 20, 140, 'F'); // Draw a filled rectangle as background
     
-    drawLegend({
-      document: doc,
-      legendData: coloredOptions,
-      factor: 17, // Adjust factor based on the number of legend items
-      rectY:whiteBoxY,
-      xSpace: 80, // Space between legend items
-      isDrug: false,
-    });
+    // drawLegend({
+    //   document: doc,
+    //   legendData: coloredOptions,
+    //   factor: 17, // Adjust factor based on the number of legend items
+    //   rectY:whiteBoxY,
+    //   xSpace: 80, // Space between legend items
+    //   isDrug: false,
+    // });
 
     // Pathotype or Serotype Page 
     if (['sentericaints', 'decoli', 'shige'].includes(organism)) {

--- a/client/src/components/Elements/DownloadData/DownloadData.js
+++ b/client/src/components/Elements/DownloadData/DownloadData.js
@@ -18,6 +18,7 @@ import { imgOnLoadPromise } from '../../../util/imgOnLoadPromise';
 import { graphCards } from '../../../util/graphCards';
 import domtoimage from 'dom-to-image';
 import { setCollapses, setDownload } from '../../../stores/slices/graphSlice';
+import { setLoadingPDF } from '../../../stores/slices/dashboardSlice';
 import { drugAcronymsOpposite, ngonoSusceptibleRule } from '../../../util/drugs';
 // import { drugsKP, drugsST, drugsNG } from '../../../util/drugs';
 import { colorsForKODiversityGraph, getColorForDrug } from '../Graphs/graphColorHelper';
@@ -196,7 +197,7 @@ export const DownloadData = () => {
   const classes = useStyles();
   const matches1000 = useMediaQuery('(max-width:1000px)');
   const [loadingCSV, setLoadingCSV] = useState(false);
-  const [loadingPDF, setLoadingPDF] = useState(false);
+  // const [loadingPDF, setLoadingPDF] = useState(false);
   const [showAlert, setShowAlert] = useState(false);
 
   const dispatch = useAppDispatch();
@@ -248,6 +249,11 @@ export const DownloadData = () => {
   const endtimeRDT = useAppSelector((state) => state.graph.endtimeRDT);
   const actualGenomesRDT = useAppSelector((state) => state.graph.actualGenomesRDT);
   const selectedLineages = useAppSelector((state) => state.dashboard.selectedLineages);
+  const coloredOptions = useAppSelector((state) => state.graph.coloredOptions);
+  //loadingPDF:  Loading state for PDF generation and temp change the visibility of the Geo Comp HEat map 
+  // to show all the selected values to take a correct screenshot
+  const loadingPDF = useAppSelector((state) => state.dashboard.loadingPDF); 
+
 
   async function handleClickDownloadDatabase() {
     let firstName, secondName;
@@ -335,6 +341,7 @@ export const DownloadData = () => {
       .catch((error) => {console.error('Error downloading database:', error)})
       .finally(() => {
         setLoadingCSV(false);
+        dispatch(setLoadingPDF(false));
       });
   }
 
@@ -493,7 +500,7 @@ export const DownloadData = () => {
   };
 
   async function handleClickDownloadPDF() {
-    setLoadingPDF(true);
+    dispatch(setLoadingPDF(true));
     dispatch(
       setCollapses({
         continent: true,
@@ -554,8 +561,8 @@ export const DownloadData = () => {
         texts = getSentericaintsTexts();
         firstName = 'Salmonella enterica';
         secondName = '(non-typhoidal)';
-        secondword = 340;
-        firstWord = 250;
+        secondword = 360;
+        firstWord = 260;
         amrnetHeading = 147;
       } else if (organism === 'ecoli') {
         texts = getEcoliTexts();
@@ -1099,28 +1106,26 @@ export const DownloadData = () => {
       drawFooter({ document: doc, pageHeight, pageWidth, date });
 
       // Map
+      // Add 'Global Overview of {mapView}' title
+      const actualMapView = mapLegends.find((x) => x.value === mapView).label;
       doc.addPage();
       drawHeader({ document: doc, pageWidth });
       drawFooter({ document: doc, pageHeight, pageWidth, date });
 
       doc.setFontSize(fontSize).setFont(undefined, 'bold');
-      // doc.text('Global Overview of', amrnetHeading, 44, { align: 'center' });
-      // doc.setFont(undefined, 'bolditalic');
-      // doc.text(firstName, firstWord, 44, { align: 'center' });
-      // doc.setFont(undefined, 'bold');
-      // doc.text(secondName, secondword, 44, { align: 'center' });
-      // doc.setFontSize(12).setFont(undefined, 'normal');
-      // doc.text(`Total: ${actualGenomes} genomes`, pageWidth / 2, 60, { align: 'center' });
-      // doc.text(`Country: ${actualCountry}`, pageWidth / 2, 72, { align: 'center' });
-      // doc.text(`Time Period: ${actualTimeInitial} to ${actualTimeFinal}`, pageWidth / 2, 84, {
-      //   align: 'center',
-      // });
+      doc.text(`Global Overview of ${actualMapView} `, pageWidth/2, 44, { align: 'center' });
+      //Rename Report heading based on new Org name
+      doc.setFontSize(12).setFont(undefined, 'normal');
+      doc.text(`Total: ${actualGenomes} genomes`, pageWidth / 2, 60, { align: 'center' });
+      doc.text(`Country: ${actualCountry}`, pageWidth / 2, 72, { align: 'center' });
+      doc.text(`Time Period: ${actualTimeInitial} to ${actualTimeFinal}`, pageWidth / 2, 84, {
+        align: 'center',
+      });
       doc.line(16, 96, pageWidth - 16, 96);
 
       doc.setFont(undefined, 'bold');
       doc.text('Map', 16, 116);
       doc.setFont(undefined, 'normal');
-      const actualMapView = mapLegends.find((x) => x.value === mapView).label;
       // doc.text(`Map View: ${actualMapView}`, 16, 128);
       // doc.text(`Dataset: ${dataset}${dataset === 'All' && organism === 'styphi' ? ' (local + travel)' : ''}`, 16, 140);
       doc.text(
@@ -1221,6 +1226,7 @@ export const DownloadData = () => {
 
       //Heatmap
       // Helper to add page with header/footer and optional title/metadata
+      let displayHeight
       function addStandardPage({ doc, title, subtitle1, subtitle2, date, pageWidth, pageHeight }) {
       doc.addPage();
       drawHeader({ document: doc, pageWidth });
@@ -1248,22 +1254,19 @@ export const DownloadData = () => {
       // );
       // const graphImgHeat = document.createElement('img');
       // const graphImgPromiseHeat = imgOnLoadPromise(graphImgHeat);
-      // graphImgHeat.src = await domtoimage.toPng(document.getElementById('CVM'), {
+      // graphImgHeat.src = await domtoimage.toPng(document.getElementById('BG'), {
         bgcolor: 'white',
       });
-      // console.log('graphImgHeat', graphImgHeat.width);
+      
       await imgLoad;
-        if (img.width > 3000) {
-        doc.addImage(img, 'PNG', x, y, undefined, undefined, undefined, 'FAST');
-         } else {
-      // Estimate height for smaller images
+      
+        // Estimate height for all images
         const aspectRatio = img.width / img.height;
         const displayWidth = pageWidth - 80;
-        const displayHeight = displayWidth / aspectRatio;
-        doc.addImage(img, 'PNG', x, y, displayWidth, displayHeight, undefined, 'FAST');
-        }
+        displayHeight = displayWidth / aspectRatio;
+        doc.addImage(img, 'PNG', x, y, displayWidth-20, displayHeight-20, undefined, 'FAST');
       //
-       }
+    }
     // Main PDF logic
     const commonSubtitle1 = `Selected View: ${actualMapView}`;
     const commonSubtitle2 = `Dataset: ${dataset}${
@@ -1273,19 +1276,19 @@ export const DownloadData = () => {
     // Heatmap Page
     addStandardPage({
       doc,
-      title: 'Geographic Comparisons',
+      title: 'Geographic Comparisons (Heat Map)' ,
       subtitle1: commonSubtitle1,
       subtitle2: commonSubtitle2,
       date,
       pageWidth,
       pageHeight,
     });
-    await addImageToPDF({ doc, elementId: 'BG', pageWidth });
+    await addImageToPDF({ doc, elementId: 'BG', pageWidth }); // BG is replaced from CVM for BubbleGeographicGraph
 
     // TL Map Page
     addStandardPage({
       doc,
-      title: 'Geographic Comparisons (TL)',
+      title: 'Geographic Comparisons (Trend Line)',
       subtitle1: commonSubtitle1,
       subtitle2: commonSubtitle2,
       date,
@@ -1294,11 +1297,25 @@ export const DownloadData = () => {
     });
     await addImageToPDF({ doc, elementId: 'TL', pageWidth });
 
-    // Pathotype or Serotype Page
-    if (['ints', 'decoli', 'shige'].includes(organism)) {
+    // Trend Line Page Add a Legends
+    const whiteBoxY = 100 + ((displayHeight-20) * 0.73);
+    doc.setFillColor(255, 255, 255); // White color
+    doc.rect(10, whiteBoxY, pageWidth - 20, 140, 'F'); // Draw a filled rectangle as background
+    
+    drawLegend({
+      document: doc,
+      legendData: coloredOptions,
+      factor: 8,
+      rectY:whiteBoxY,
+      xSpace: 200,
+      isDrug: false,
+    });
+
+    // Pathotype or Serotype Page 
+    if (['sentericaints', 'decoli', 'shige'].includes(organism)) {
       addStandardPage({
         doc,
-        title: organism === 'ints' ? 'Serotype Comparisons' : 'Pathotype Comparisons',
+        title: organism === 'sentericaints' ? 'Serotype Comparisons' : 'Pathotype Comparisons',
         subtitle1: commonSubtitle1,
         subtitle2: commonSubtitle2,
         date,
@@ -1350,7 +1367,7 @@ export const DownloadData = () => {
           case 'KO':
             title += `: ${KODiversityGraphView}`;
             break;
-          case 'BG':
+          case 'BG': // BG is replaced from CVM for BubbleGeographicGraph
             const group = variablesOptions.find(
               (option) => option.value === convergenceGroupVariable,
             ).label;
@@ -1369,11 +1386,12 @@ export const DownloadData = () => {
         doc.setFontSize(10);
         doc.text(cards[index].description.join(' / ').replaceAll('≥', '>='), 16, 56);
         doc.setFontSize(12);
-        // doc.text(`Total: ${actualGenomes} genomes`, 16, 74);
-        if (cards[index].id === 'GD') doc.text(`Total: ${actualGenomesGD} genomes`, 16, 74);
-        else if (cards[index].id === 'DRT') doc.text(`Total: ${actualGenomesDRT} genomes`, 16, 74);
-        else if (cards[index].id === 'RDT') doc.text(`Total: ${actualGenomesRDT} genomes`, 16, 74);
-        else doc.text(`Total: ${actualGenomes} genomes`, 16, 74);
+        doc.text(`Total: ${actualGenomes} genomes`, 16, 74);
+        //  Refrence Dashboard comment line 773 : unable to use actualGenomesGD, actualGenomesDRT, actualGenomesRD
+        // if (cards[index].id === 'GD') doc.text(`Total: ${actualGenomesGD} genomes`, 16, 74);
+        // else if (cards[index].id === 'DRT') doc.text(`Total: ${actualGenomesDRT} genomes`, 16, 74);
+        // else if (cards[index].id === 'RDT') doc.text(`Total: ${actualGenomesRDT} genomes`, 16, 74);
+        // else doc.text(`Total: ${actualGenomes} genomes`, 16, 74);
         doc.text(`Country: ${actualCountry}`, 16, 86);
         // doc.text(`Time Period: ${actualTimeInitial} to ${actualTimeFinal}`, 16, 98);
         if (cards[index].id === 'GD')
@@ -1403,10 +1421,10 @@ export const DownloadData = () => {
           doc.addImage(graphImg, 'PNG', 16, 130, pageWidth - 80, 271, undefined, 'FAST');
         }
         const rectY = matches1000 ? 320 : 340;
-        if (cards[index].id === 'BG') {
+        if (cards[index].id === 'BG') { // BG is replaced from CVM for BubbleGeographicGraph
           doc.setFillColor(255, 255, 255); // white
           doc.rect(0, rectY + 60, pageWidth, 200, 'F'); // fill with white
-        } else if (cards[index].id !== 'HSG2' && cards[index].id !== 'BG') {
+        } else if (cards[index].id !== 'HSG2' && cards[index].id !== 'BG') { // BG is replaced from CVM for BubbleGeographicGraph
           doc.setFillColor(255, 255, 255); // white
           doc.rect(0, rectY, pageWidth, 200, 'F'); // fill with white
         }
@@ -1546,7 +1564,7 @@ export const DownloadData = () => {
       console.error('ERROR', error.message);
       setShowAlert(true);
     } finally {
-      setLoadingPDF(false);
+      dispatch(setLoadingPDF(false));
     }
   }
 

--- a/client/src/components/Elements/DownloadData/DownloadData.js
+++ b/client/src/components/Elements/DownloadData/DownloadData.js
@@ -250,6 +250,8 @@ export const DownloadData = () => {
   const actualGenomesRDT = useAppSelector((state) => state.graph.actualGenomesRDT);
   const selectedLineages = useAppSelector((state) => state.dashboard.selectedLineages);
   const coloredOptions = useAppSelector((state) => state.graph.coloredOptions);
+  const drugClass = useAppSelector((state) => state.graph.drugClass); // Drug class selected in the graph for PDF
+  const drugGene = useAppSelector((state) => state.graph.drugGene); // Drug gene selected in the graph for PDF
   //loadingPDF:  Loading state for PDF generation and temp change the visibility of the Geo Comp HEat map 
   // to show all the selected values to take a correct screenshot
   const loadingPDF = useAppSelector((state) => state.dashboard.loadingPDF); 
@@ -568,6 +570,8 @@ export const DownloadData = () => {
         texts = getEcoliTexts();
         firstName = 'Escherichia';
         secondName = 'coli';
+        firstWord = 269; // Adjusted for E. coli
+        secondword = 315;
       } else if (organism === 'decoli') {
         texts = getDEcoliTexts();
         firstName = 'Escherichia coli';
@@ -1099,6 +1103,45 @@ export const DownloadData = () => {
         // doc.setFont(undefined, 'normal');
         doc.text(texts[18], 16, 385, { align: 'left', maxWidth: pageWidth - 36 });
         // doc.text(texts[19], 16, 415, { align: 'left', maxWidth: pageWidth - 36 });
+      } else if (organism === 'ecoli') {
+        //TODO: Add the texts for E. coli
+        // Info
+        doc.setFont(undefined, 'normal');
+        doc.text(texts[0], 16, 105, { align: 'justify', maxWidth: pageWidth - 36 });
+        doc.setFont(undefined, 'italic');
+        doc.text(texts[1], 80, 105, { align: 'justify', maxWidth: pageWidth - 36 });
+        doc.text(texts[2], 145, 105, { align: 'justify', maxWidth: pageWidth - 36 });
+        doc.setFont(undefined, 'normal');
+        doc.text(texts[3], 16, 115, { align: 'justify', maxWidth: pageWidth - 36 });
+        doc.text(texts[4], 16, 165, { align: 'justify', maxWidth: pageWidth - 36 });
+        doc.text(texts[5], 16, 175, { align: 'justify', maxWidth: pageWidth - 36 });
+        doc.text(texts[6], 16, 185, { align: 'justify', maxWidth: pageWidth - 36 });
+        doc.text(texts[7], 16, 195, { align: 'justify', maxWidth: pageWidth - 36 });
+        doc.text(texts[8], 16, 205, { align: 'justify', maxWidth: pageWidth - 36 });
+        doc.text(texts[9], 16, 225, { align: 'justify', maxWidth: pageWidth - 36 });
+
+        doc.setFillColor(255, 253, 175); // Yellow color
+        doc.rect(10, 245, pageWidth - 20, 65, 'F'); // Draw a filled rectangle as background
+        doc.setFont(undefined, 'bold');
+        doc.text(texts[10], 16, 265, { align: 'justify', maxWidth: pageWidth - 36 });
+        doc.setFont(undefined, 'normal');
+        doc.text(texts[11], 65, 265, { align: 'left', maxWidth: pageWidth - 36 });
+        doc.text(texts[12], 16, 275, { align: 'left', maxWidth: pageWidth - 36 });
+        // Abbreviations
+        doc.setFont(undefined, 'bold');
+        doc.text(texts[13], 16, 335, { align: 'left', maxWidth: pageWidth - 36 });
+        doc.text(texts[14], 16, 355, { align: 'left', maxWidth: pageWidth - 36 });
+        doc.setFont(undefined, 'normal');
+        doc.text(texts[15], 60, 355, { align: 'left', maxWidth: pageWidth - 36 });
+        doc.setFont(undefined, 'bold');
+        doc.text(texts[16], 16, 375, { align: 'left', maxWidth: pageWidth - 36 });
+        doc.setFont(undefined, 'normal');
+        doc.text(texts[17], 102, 375, { align: 'left', maxWidth: pageWidth - 36 });
+        // doc.setFont(undefined, 'italic');
+        // doc.text('gyrA/parC/gyrB', 120, 395, { align: 'left', maxWidth: pageWidth - 36 });
+        // doc.setFont(undefined, 'normal');
+        doc.text(texts[18], 16, 385, { align: 'left', maxWidth: pageWidth - 36 });
+        // doc.text(texts[19], 16, 415, { align: 'left', maxWidth: pageWidth - 36 });
       } else {
         console.log('No Report available for this organism');
       }
@@ -1295,6 +1338,7 @@ export const DownloadData = () => {
       pageWidth,
       pageHeight,
     });
+    doc.text(`${drugClass} : ${drugGene} Gene`, 16, 66); // Add drug class and gene to the title
     await addImageToPDF({ doc, elementId: 'TL', pageWidth });
 
     // Trend Line Page Add a Legends
@@ -1305,9 +1349,9 @@ export const DownloadData = () => {
     drawLegend({
       document: doc,
       legendData: coloredOptions,
-      factor: 8,
+      factor: 17, // Adjust factor based on the number of legend items
       rectY:whiteBoxY,
-      xSpace: 200,
+      xSpace: 80, // Space between legend items
       isDrug: false,
     });
 
@@ -1613,7 +1657,7 @@ export const DownloadData = () => {
         loading={loadingPDF}
         startIcon={<PictureAsPdf />}
         loadingPosition="start"
-        disabled={['ecoli'].includes(organism)} //'styphi', 'kpneumo', 'ngono', 'sentericaints', 'senterica'
+        // disabled={['ecoli'].includes(organism)} //'styphi', 'kpneumo', 'ngono', 'sentericaints', 'senterica'
       >
         Download PDF
       </LoadingButton>

--- a/client/src/components/Elements/Graphs/Graphs.js
+++ b/client/src/components/Elements/Graphs/Graphs.js
@@ -293,7 +293,7 @@ export const Graphs = () => {
       } else if (currentCard.id === 'RDT') {
         genotypesFactor = Math.ceil(genotypesForFilter.length / 9);
         heightFactor += genotypesFactor * 22 + 50;
-      } else if (currentCard.id === 'BG') {
+      } else if (currentCard.id === 'BG') { // BG is replaced from CVM for BubbleGeographicGraph
         variablesFactor = Math.ceil(Object.keys(convergenceColourPallete).length / 3);
         heightFactor += variablesFactor * 22;
       }
@@ -328,23 +328,26 @@ export const Graphs = () => {
       ctx.fillText(`Organism: ${globalOverviewLabel.stringLabel}`, canvas.width / 2, 95);
       ctx.fillText(`Dataset: ${dataset}`, canvas.width / 2, 115);
       ctx.fillText(`${getAxisLabel()} ` + selectedLineages.join(', '), canvas.width / 2, 135);
-      if (currentCard.id === 'GD') {
-        ctx.fillText(`Time period: ${starttimeGD} to ${endtimeGD}`, canvas.width / 2, 154);
-        ctx.fillText(`Total ${actualGenomesGD} genomes`, canvas.width / 2, 172);
-      } else if (currentCard.id === 'DRT') {
-        ctx.fillText(`Time period: ${starttimeDRT} to ${endtimeDRT}`, canvas.width / 2, 154);
-        ctx.fillText(`Total ${actualGenomesDRT} genomes`, canvas.width / 2, 172);
-      } else if (currentCard.id === 'RDT') {
-        ctx.fillText(`Time period: ${starttimeRDT} to ${endtimeRDT}`, canvas.width / 2, 154);
-        ctx.fillText(`Total ${actualGenomesRDT} genomes`, canvas.width / 2, 172);
-      } else {
-        ctx.fillText(
-          `Time period: ${actualTimeInitial} to ${actualTimeFinal}`,
-          canvas.width / 2,
-          154,
-        );
-        ctx.fillText(`Total ${actualGenomes} genomes`, canvas.width / 2, 172);
-      }
+      
+      //  Refrence Dashboard comment line 773 : unable to use actualGenomesGD, actualGenomesDRT, actualGenomesRD
+      
+      // if (currentCard.id === 'GD') {
+      //   ctx.fillText(`Time period: ${starttimeGD} to ${endtimeGD}`, canvas.width / 2, 154);
+      //   ctx.fillText(`Total ${actualGenomesGD} genomes`, canvas.width / 2, 172);
+      // } else if (currentCard.id === 'DRT') {
+      //   ctx.fillText(`Time period: ${starttimeDRT} to ${endtimeDRT}`, canvas.width / 2, 154);
+      //   ctx.fillText(`Total ${actualGenomesDRT} genomes`, canvas.width / 2, 172);
+      // } else if (currentCard.id === 'RDT') {
+      //   ctx.fillText(`Time period: ${starttimeRDT} to ${endtimeRDT}`, canvas.width / 2, 154);
+      //   ctx.fillText(`Total ${actualGenomesRDT} genomes`, canvas.width / 2, 172);
+      // } else {
+        // ctx.fillText(
+        //   `Time period: ${actualTimeInitial} to ${actualTimeFinal}`,
+        //   canvas.width / 2,
+        //   154,
+        // );
+        // ctx.fillText(`Total ${actualGenomes} genomes`, canvas.width / 2, 172);
+      // }
       // ctx.fillText(`Time period: ${actualTimeInitial} to ${actualTimeFinal}`, canvas.width / 2, 154);
       ctx.fillText(`Country: ${actualCountry}`, canvas.width / 2, 186);
       if (currentCard.id === 'RDWG')
@@ -353,7 +356,7 @@ export const Graphs = () => {
         ctx.fillText(`Drug Class: ${trendsGraphDrugClass}`, canvas.width / 2, 198);
       if (currentCard.id === 'KO')
         ctx.fillText(`Data view: ${KODiversityGraphView}`, canvas.width / 2, 198);
-      if (currentCard.id === 'CVM') {
+      if (currentCard.id === 'BG') { // BG is replaced from CVM for BubbleGeographicGraph
         const group = variablesOptions.find(
           (option) => option.value === convergenceGroupVariable,
         ).label;
@@ -481,7 +484,7 @@ export const Graphs = () => {
           yPosition: 670,
           xSpace: 330,
         });
-      } else if (currentCard.id === 'BG') {
+      } else if (currentCard.id === 'BG') { // BG is replaced from CVM for BubbleGeographicGraph
         ctx.fillRect(0, 660 - mobileFactor, canvas.width, canvas.height);
 
         drawLegend({

--- a/client/src/components/Elements/Graphs/GraphsOLD.js
+++ b/client/src/components/Elements/Graphs/GraphsOLD.js
@@ -192,7 +192,7 @@ export const Graphs = () => {
       } else if (card.id === 'RDT') {
         genotypesFactor = Math.ceil(genotypesForFilter.length / 9);
         heightFactor += genotypesFactor * 22 + 50;
-      } else if (card.id === 'CVM') {
+      } else if (card.id === 'BG') { // BG is replaced from CVM for BubbleGeographicGraph
         variablesFactor = Math.ceil(Object.keys(convergenceColourPallete).length / 3);
         heightFactor += variablesFactor * 22;
       }
@@ -227,7 +227,7 @@ export const Graphs = () => {
       if (card.id === 'RDWG') ctx.fillText(`Drug Class: ${determinantsGraphDrugClass}`, canvas.width / 2, 198);
       if (card.id === 'RDT') ctx.fillText(`Drug Class: ${trendsGraphDrugClass}`, canvas.width / 2, 198);
       if (card.id === 'KO') ctx.fillText(`Data view: ${KODiversityGraphView}`, canvas.width / 2, 198);
-      if (card.id === 'CVM') {
+      if (card.id === 'BG') { // BG is replaced from CVM for BubbleGeographicGraph
         const group = variablesOptions.find((option) => option.value === convergenceGroupVariable).label;
         const colour = variablesOptions.find((option) => option.value === convergenceColourVariable).label;
         ctx.fillText(`Group variable: ${group} / Colour variable: ${colour}`, canvas.width / 2, 198);
@@ -328,7 +328,7 @@ export const Graphs = () => {
           yPosition: 670,
           xSpace: 330,
         });
-      } else if (card.id === 'CVM') {
+      } else if (card.id === 'BG') { // BG is replaced from CVM for BubbleGeographicGraph
         ctx.fillRect(0, 660 - mobileFactor, canvas.width, canvas.height);
 
         drawLegend({

--- a/client/src/components/Elements/Map/MapActions/MapActions.js
+++ b/client/src/components/Elements/Map/MapActions/MapActions.js
@@ -132,21 +132,18 @@ export const MapActions = () => {
         ctx.fillText(`Total: ${actualGenomes} genomes`, canvas.width / 2, 190);
         ctx.fillText('Dataset: ' + dataset, canvas.width / 2, 240);
         ctx.fillText(`Country: ${actualCountry}`, canvas.width / 2, 290);
-        ctx.fillText(`Organism: ${globalOverviewLabel.stringLabel}`, canvas.width / 2, 337);
         const getAxisLabel = () => {
           switch (organism) {
             case 'decoli':
             case 'shige':
-              return 'Selected Pathotypes :';
+              return `Selected Pathotypes (Organism: ${globalOverviewLabel.stringLabel}) :`; //improve heading with Selected Pathotypes and Organism for Screenshots
             case 'sentericaints':
-              return 'Selected Serotypes :';
+              return `Selected Serotypes (Organism: ${globalOverviewLabel.stringLabel}):`;
             default:
-              return '';
+              return `Organism: ${globalOverviewLabel.stringLabel}`;
           }
         };
-        if (['sentericaints', 'decoli', 'shige'].includes(organism)) {
           ctx.fillText(`${getAxisLabel()} ` + selectedLineages.join(', '), canvas.width / 2, 340);
-        }
 
         const prevalenceMapViews = [
           'Genotype prevalence',

--- a/client/src/stores/slices/dashboardSlice.ts
+++ b/client/src/stores/slices/dashboardSlice.ts
@@ -38,6 +38,7 @@ interface DashboardState {
   pathovar: Array<string>;
   serotype: Array<string>;
   economicRegions: Object;
+  loadingPDF: boolean;
 }
 
 const initialState: DashboardState = {
@@ -74,6 +75,7 @@ const initialState: DashboardState = {
   pathovar: [],
   economicRegions: {},
   serotype: [],
+  loadingPDF:false
 };
 
 export const dashboardSlice = createSlice({
@@ -185,6 +187,9 @@ export const dashboardSlice = createSlice({
     setEconomicRegions: (state, action: PayloadAction<Object>) => {
       state.economicRegions = action.payload;
     },
+    setLoadingPDF: (state, action: PayloadAction<boolean>) => {
+      state.loadingPDF = action.payload;
+    },
   },
 });
 
@@ -220,6 +225,7 @@ export const {
   setPathovar,
   setEconomicRegions,
   setSerotype,
+  setLoadingPDF
 } = dashboardSlice.actions;
 
 export default dashboardSlice.reducer;

--- a/client/src/stores/slices/graphSlice.ts
+++ b/client/src/stores/slices/graphSlice.ts
@@ -65,6 +65,9 @@ interface GraphState {
   topXGenotype: Array<any>;
   topXGenotypeRDWG: Array<any>;
   download: boolean;
+  drugClass: Array<any>;
+  drugGene: string;
+  coloredOptions: Array<any>;
 }
 
 const initialState: GraphState = {
@@ -131,6 +134,9 @@ const initialState: GraphState = {
   topXGenotype: [],
   topXGenotypeRDWG: [],
   download: false,
+  drugClass: [],
+  drugGene: '',
+  coloredOptions: [],
 };
 
 export const graphSlice = createSlice({
@@ -314,6 +320,15 @@ export const graphSlice = createSlice({
     setDownload: (state, action: PayloadAction<boolean>) => {
       state.download = action.payload;
     },
+    setDrugClass: (state, action: PayloadAction<Array<any>>) => {
+      state.drugClass = action.payload;
+    },
+    setDrugGene: (state, action: PayloadAction<string>) => {
+      state.drugGene = action.payload;
+    },
+    setColoredOptions: (state, action: PayloadAction<Array<any>>) => {
+      state.coloredOptions = action.payload;
+    },
   },
 });
 
@@ -377,6 +392,10 @@ export const {
   setTopXGenotype,
   setTopXGenotypeRDWG,
   setDownload,
+  setDrugClass,
+  setDrugGene,
+  setColoredOptions
+
 } = graphSlice.actions;
 
 export default graphSlice.reducer;

--- a/client/src/util/graphCards.js
+++ b/client/src/util/graphCards.js
@@ -109,14 +109,16 @@ export const graphCards = [
     organisms: ['ngono'],
     component: <TrendsGraph />,
   },
-  {
-    title: 'K/O Trends',
-    description: ['Top K/O (up to 10)'],
-    icon: <StackedBarChart color="primary" />,
-    id: 'KO',
-    organisms: ['kpneumo'],
-    component: <TrendsGraph />,
-  },
+  //SHOWING WRONG DATA FOR BLA PLOT
+  // ERROR IN PDF GENERATION
+  // {
+  //   title: 'K/O Trends',
+  //   description: ['Top K/O (up to 10)'],
+  //   icon: <StackedBarChart color="primary" />,
+  //   id: 'KO',
+  //   organisms: ['kpneumo'],
+  //   component: <TrendsGraph />,
+  // },
   {
     title: 'AMR/virulence',
     description: ['Top Genotypes (up to 30)'],


### PR DESCRIPTION
Improve PDF with:

- Hide KO from Dashboard and PDF (representing wrong data)
- Hide TL from PDF as not available in latest devrev 
- BubbleGeographicGraph 'id' CVM is replaced by BG to match TAB id
- Added 'Carbapenemase' for KP trends in geo comp graphs
- BubbleGeographicGraph overflow visible ONLY for Download PDF
- coloredOptions is used to draw the legend in the Trend Line graph (not is use and not showing error but useful when we add TL)
- Add drug class and gene to the title to PDF
- Add 'Global Overview of {mapView}' title
- improve Ogr name and Pathotype in SS
- Added TL download button (not is use , but useful when we add TL)
- Temp. ecoli contents (adding ecoli content in next PR)