### PR TITLE
AMR marker by Genotype insufficent data

### DIFF
--- a/client/src/components/Elements/Graphs/DeterminantsGraph/DeterminantsGraph.js
+++ b/client/src/components/Elements/Graphs/DeterminantsGraph/DeterminantsGraph.js
@@ -356,7 +356,7 @@ export const DeterminantsGraph = ({ showFilter, setShowFilter }) => {
         <div className={classes.rightSide}>
           <SliderSizes style={{ width: '100%' }} />
           <div className={classes.tooltipWrapper}>
-            {currentTooltip ? (
+            {currentTooltip?.count > 0 ? (
               <div className={classes.tooltip}>
                 <div className={classes.tooltipTitle}>
                   <Typography variant="h5" fontWeight="600">
@@ -386,9 +386,11 @@ export const DeterminantsGraph = ({ showFilter, setShowFilter }) => {
                   })}
                 </div>
               </div>
+            ) : currentTooltip?.count === 0 ? (
+              <div className={classes.insufficientData}>Insufficient data</div>
             ) : (
               <div className={classes.noGenotypeSelected}>No genotype selected</div>
-            )}
+          )}
           </div>
         </div>
       </div>

--- a/client/src/components/Elements/Graphs/DeterminantsGraph/DeterminantsGraphMUI.js
+++ b/client/src/components/Elements/Graphs/DeterminantsGraph/DeterminantsGraphMUI.js
@@ -185,6 +185,14 @@ const useStyles = makeStyles((theme) => ({
     columnGap: '8px',
     paddingBottom: '4px',
   },
+  insufficientData: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    height: '100%',
+    color: 'red',
+    fontWeight: '600',
+  },
 }));
 
 export { useStyles };


### PR DESCRIPTION
## Summary by Sourcery

Introduce an “Insufficient data” state in the determinants graph for selected genotypes with zero counts, displaying a styled message in place of the tooltip.

Enhancements:
- Add conditional rendering to show “Insufficient data” when the tooltip count is zero
- Define new insufficientData style for centering and coloring the warning message