### PR TITLE
MARKER TREND or styphi and shige

### DIFF
--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -794,8 +794,6 @@ export const DashboardPage = () => {
         // Don't set drug selection for paginated organisms - let auto-selection effect handle it
         if (!isPaginated) {
           dispatch(setDrugResistanceGraphView(markersDrugsKP));
-          dispatch(setDeterminantsGraphDrugClass('Carbapenems'));
-          dispatch(setTrendsGraphDrugClass('Carbapenems'));
           dispatch(setTrendsGraphView('percentage'));
           dispatch(setConvergenceGroupVariable('cgST'));
           dispatch(setConvergenceColourVariable('cgST'));
@@ -809,7 +807,10 @@ export const DashboardPage = () => {
         dispatch(setBubbleKOHeatmapGraphVariable('GENOTYPE'));
         dispatch(setBubbleMarkersHeatmapGraphVariable('GENOTYPE'));
         dispatch(setBubbleKOYAxisType('K_locus'));
-        dispatch(setBubbleMarkersYAxisType('K_locus'));
+        // dispatch(setBubbleMarkersYAxisType('K_locus'));
+        dispatch(setDeterminantsGraphDrugClass('Carbapenems'));
+        dispatch(setTrendsGraphDrugClass('Carbapenems'));
+        dispatch(setBubbleMarkersYAxisType('Carbapenems'))
         break;
       case 'ngono':
         dispatch(setMapView('Resistance prevalence'));
@@ -840,6 +841,7 @@ export const DashboardPage = () => {
           // Don't set drug selection for paginated organisms - let auto-selection effect handle it
           dispatch(setDrugResistanceGraphView(drugsECOLI));
           dispatch(setDeterminantsGraphDrugClass('Aminoglycosides'));
+          dispatch(setTrendsGraphDrugClass('Aminoglycosides'));
         }
         break;
       default:

--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -786,6 +786,7 @@ export const DashboardPage = () => {
           dispatch(setDrugResistanceGraphView(defaultDrugsForDrugResistanceGraphST));
         }
         dispatch(setDeterminantsGraphDrugClass('Ciprofloxacin NS'));
+        dispatch(setTrendsGraphDrugClass('Ciprofloxacin NS'));
         break;
       case 'kpneumo':
         // dispatch(setDatasetKP('All'));

--- a/client/src/components/Elements/Graphs/MarkerTrendsGraph/MarkerTrendsGraph.js
+++ b/client/src/components/Elements/Graphs/MarkerTrendsGraph/MarkerTrendsGraph.js
@@ -25,7 +25,7 @@ import {
   setStarttimeRDT,
   setEndtimeRDT,
 } from '../../../../stores/slices/graphSlice';
-import { drugClassesNG, markersDrugsKP, drugClassesST} from '../../../../util/drugs';
+import { drugClassesNG, markersDrugsKP, drugClassesST, markersDrugsSH} from '../../../../util/drugs';
 import { statKeysST } from '../../../../util/drugClassesRules';
 import { SliderSizes } from '../../Slider';
 import { Card } from '@mui/material';
@@ -81,6 +81,9 @@ export const MarkerTrendsGraph = ({ showFilter, setShowFilter }) => {
     if (organism === 'styphi') {
       return drugClassesST;
     }
+     if (organism === 'shige') {
+      return markersDrugsSH;
+     }
 
     return drugClassesNG;
   }
@@ -404,7 +407,7 @@ export const MarkerTrendsGraph = ({ showFilter, setShowFilter }) => {
                 } else if (organism === 'ngono') {
                   const colorObj = colorForDrugClassesNG[trendsGraphDrugClass]?.find(x => x.name === option);
                   if (colorObj) fillColor = colorObj.color;
-                } else if (organism === 'kpneumo' || organism === 'styphi') {
+                } else if (organism === 'kpneumo' || organism === 'styphi' || organism === 'shige') {
                   fillColor = colorForMarkers[index];
                 }
 

--- a/client/src/components/Elements/Graphs/MarkerTrendsGraph/MarkerTrendsGraph.js
+++ b/client/src/components/Elements/Graphs/MarkerTrendsGraph/MarkerTrendsGraph.js
@@ -25,7 +25,8 @@ import {
   setStarttimeRDT,
   setEndtimeRDT,
 } from '../../../../stores/slices/graphSlice';
-import { drugClassesNG, markersDrugsKP } from '../../../../util/drugs';
+import { drugClassesNG, markersDrugsKP, drugClassesST} from '../../../../util/drugs';
+import { statKeysST } from '../../../../util/drugClassesRules';
 import { SliderSizes } from '../../Slider';
 import { Card } from '@mui/material';
 import { Close } from '@mui/icons-material';
@@ -76,6 +77,9 @@ export const MarkerTrendsGraph = ({ showFilter, setShowFilter }) => {
     }
     if (organism === 'kpneumo') {
       return markersDrugsKP;
+    }
+    if (organism === 'styphi') {
+      return drugClassesST;
     }
 
     return drugClassesNG;
@@ -400,7 +404,7 @@ export const MarkerTrendsGraph = ({ showFilter, setShowFilter }) => {
                 } else if (organism === 'ngono') {
                   const colorObj = colorForDrugClassesNG[trendsGraphDrugClass]?.find(x => x.name === option);
                   if (colorObj) fillColor = colorObj.color;
-                } else if (organism === 'kpneumo') {
+                } else if (organism === 'kpneumo' || organism === 'styphi') {
                   fillColor = colorForMarkers[index];
                 }
 

--- a/client/src/util/drugs.js
+++ b/client/src/util/drugs.js
@@ -3,6 +3,8 @@ import {
   drugRulesNG,
   drugRulesKP,
   statKeysKP,
+  statKeysST,
+  drugRulesST,
   statKeysECOLI,
   statKeysKPOnlyMarkers,
 } from './drugClassesRules';
@@ -98,6 +100,9 @@ export const drugsKP = statKeysKP.map(x => x.name);
 export const markersDrugsKP = [
   ...drugsKP.filter(x => !['Pansusceptible'].includes(x)),
   ...statKeysKPOnlyMarkers.map(x => x.name),
+].sort();
+export const markersDrugsST = [
+  ...drugRulesST.map(x => x.name)
 ].sort();
 
 // List of Salmonella Typhi drug classes

--- a/client/src/util/drugs.js
+++ b/client/src/util/drugs.js
@@ -104,6 +104,7 @@ export const markersDrugsKP = [
 export const markersDrugsST = [
   ...drugRulesST.map(x => x.name)
 ].sort();
+export const markersDrugsSH = statKeysECOLI.map(x => x.name).filter(x => !['Pansusceptible'].includes(x));
 
 // List of Salmonella Typhi drug classes
 export const drugClassesST = [

--- a/client/src/util/graphCards.js
+++ b/client/src/util/graphCards.js
@@ -46,7 +46,7 @@ export const graphCards = [
     description: ['Data are plotted for years with N ≥ 10 genomes'],
     icon: <Timeline color="primary" />,
     id: 'RDT',
-    organisms: ['ngono', 'kpneumo'],
+    organisms: ['ngono', 'kpneumo', 'styphi', 'shige'],
     component: <MarkerTrendsGraph />,
   },
   {


### PR DESCRIPTION
## Summary by Sourcery

Enable marker trend and drug resistance features for Salmonella Typhi and Shigella by adding organism-specific data initialization, drug class calculations, and UI configuration

New Features:
- Add support for Salmonella Typhi ('styphi') and Shigella ('shige') organisms in marker trend and resistance analyses

Enhancements:
- Introduce generalized getDrugClassDataNG and getDrugClassDataST functions for drug class computation
- Extend getYearsData to initialize and process data separately for styphi and shige
- Update DashboardPage to dispatch default trend and determinant graph classes for the new organisms
- Modify MarkerTrendsGraph to return appropriate drug lists for styphi and shige
- Define markersDrugsST and markersDrugsSH exports and include new organisms in graphCards configuration