### PR TITLE
Markers and minor updates from feedback

### DIFF
--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -264,7 +264,7 @@ export const DashboardPage = () => {
 
     // Get mapped values
     const genotypesSet = new Set();
-    // const ngmastSet = new Set();
+    const ngmastSet = new Set();
     const yearsSet = new Set();
     const countriesSet = new Set();
     const PMIDSet = new Set();
@@ -290,7 +290,7 @@ export const DashboardPage = () => {
       }
 
       // others
-      // if ('NG-MAST TYPE' in x) ngmastSet.add(x['NG-MAST TYPE']);
+      if ('NG-MAST TYPE' in x) ngmastSet.add(x['NG-MAST TYPE']);
       if ('PMID' in x && x['PMID'] && x['PMID'] !== '') {
         PMIDSet.add(x['PMID']);
       }
@@ -320,7 +320,7 @@ export const DashboardPage = () => {
     });
 
     const genotypes = Array.from(genotypesSet).filter(Boolean);
-    // const ngmast = Array.from(ngmastSet);
+    const ngmast = Array.from(ngmastSet);
     const years = Array.from(yearsSet).filter(Boolean);
     const countries = Array.from(countriesSet).filter(Boolean);
     const PMID = Array.from(PMIDSet).filter(Boolean);
@@ -329,6 +329,7 @@ export const DashboardPage = () => {
 
     // Sort values
     genotypes.sort((a, b) => a.localeCompare(b));
+    ngmast.sort((a, b) => a.localeCompare(b));
     years.sort();
     countries.sort();
     pathovar.sort();
@@ -424,7 +425,7 @@ export const DashboardPage = () => {
       // Get ngmast data
       // organism === 'ngono'
       //   ? getStoreOrGenerateData(`${organism}_ngmast`, () => {
-      //       const dt = getNgmastData({ data: responseData, ngmast, organism });
+            // const dt = getNgmastData({ data: responseData, ngmast, organism });
       //       return [dt.ngmastDrugData, dt.ngmastDrugClassesData];
       //     }).then(([ngmastDrugData, ngmastDrugClassesData]) => {
       //       dispatch(setNgmastDrugsData(ngmastDrugData));
@@ -449,6 +450,7 @@ export const DashboardPage = () => {
           dt.sublineageData,
           dt.uniqueCgST,
           dt.uniqueSublineages,
+          dt.NGMASTData,
         ];
       }).then(
         ([
@@ -460,6 +462,7 @@ export const DashboardPage = () => {
           sublineageData,
           uniqueCgST,
           uniqueSublineages,
+          NGMASTData
         ]) => {
           dispatch(setGenotypesYearData(genotypesData));
           dispatch(setDrugsYearData(drugsData));
@@ -483,6 +486,9 @@ export const DashboardPage = () => {
             dispatch(setColorPalleteCgST(generatePalleteForGenotypes(uniqueCgST)));
             dispatch(setColorPalleteSublineages(generatePalleteForGenotypes(uniqueSublineages)));
             dispatch(setColorPallete(generatePalleteForGenotypes(uniqueGenotypes.slice(0, 200))));
+          }else if (organism === 'ngono'){
+            dispatch(setCgSTYearData(NGMASTData));
+            dispatch(setColorPalleteCgST(generatePalleteForGenotypes(ngmast)));
           }
         },
       ),
@@ -822,8 +828,8 @@ export const DashboardPage = () => {
           dispatch(setBubbleMarkersYAxisType(markersDrugsKP[0]));
         }
         dispatch(setTrendsGraphDrugClass('ESBL'));
-        dispatch(setDistributionGraphView('genotype'));
-        dispatch(setDistributionGraphVariable('genotype'));
+        dispatch(setDistributionGraphView('percentage'));
+        dispatch(setDistributionGraphVariable('GENOTYPE'));
         dispatch(setKOTrendsGraphView('K_locus'));
         dispatch(setKOTrendsGraphPlotOption('K_locus'));
         dispatch(setBubbleHeatmapGraphVariable('GENOTYPE'));
@@ -844,6 +850,7 @@ export const DashboardPage = () => {
         dispatch(setTrendsGraphDrugClass('Azithromycin'));
         dispatch(setTrendsGraphView('percentage'));
         dispatch(setBubbleMarkersYAxisType(drugClassesNG[0]));
+        dispatch(setDistributionGraphVariable('GENOTYPE'));
         break;
       case 'sentericaints':
       case 'senterica':
@@ -1282,6 +1289,8 @@ export const DashboardPage = () => {
         );
         dispatch(setMaxSliderValueCM(convergenceData.colourVariables.length));
         dispatch(setConvergenceData(convergenceData.data));
+      }else if (organism === 'ngono'){
+        dispatch(setCgSTYearData(yearsData.NGMASTData));
       }
 
       // Dispatch drug countries resistance data

--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -468,12 +468,14 @@ export const DashboardPage = () => {
           // Only set color palette for non-paginated organisms
           // Paginated organisms (kpneumo, decoli, ecoli) will have their color palette
           // set by the progressiveGenotypeLoader after all data is processed
-          if (organism !== 'styphi' && organism !== 'senterica' && !['kpneumo', 'decoli', 'ecoli'].includes(organism)) {
-            dispatch(setColorPallete(generatePalleteForGenotypes(genotypes)));
-          }
+          let paletteSource = genotypes;
+
           if (organism === 'senterica') {
-            dispatch(setColorPallete(generatePalleteForGenotypes(uniqueGenotypes)));
+            paletteSource = uniqueGenotypes;
           }
+
+          dispatch(setColorPallete(generatePalleteForGenotypes(paletteSource)));
+
 
           if (organism === 'kpneumo') {
             dispatch(setCgSTYearData(cgSTData));

--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -105,6 +105,9 @@ import {
   drugsINTS,
   drugsKP,
   markersDrugsKP,
+  markersDrugsSH,
+  getDrugClasses,
+  drugClassesNG
 } from '../../util/drugs';
 import { continentPGraphCard } from '../../util/graphCards';
 import { ContinentGraphs } from '../Elements/ContinentGraphs';
@@ -801,6 +804,8 @@ export const DashboardPage = () => {
           dispatch(setDrugResistanceGraphView(defaultDrugsForDrugResistanceGraphST));
         }
         dispatch(setDeterminantsGraphDrugClass('Ciprofloxacin NS'));
+        dispatch(setTrendsGraphDrugClass('Ciprofloxacin NS'));
+        dispatch(setBubbleMarkersYAxisType('Ciprofloxacin NS'));
         break;
       case 'kpneumo':
         // dispatch(setDatasetKP('All'));
@@ -808,11 +813,11 @@ export const DashboardPage = () => {
         // Don't set drug selection for paginated organisms - let auto-selection effect handle it
         if (!isPaginated) {
           dispatch(setDrugResistanceGraphView(markersDrugsKP));
-          dispatch(setDeterminantsGraphDrugClass('Carbapenems'));
           dispatch(setTrendsGraphView('percentage'));
           dispatch(setConvergenceGroupVariable('cgST'));
           dispatch(setConvergenceColourVariable('cgST'));
           dispatch(setCurrentConvergenceGroupVariable('cgST'));
+          dispatch(setBubbleMarkersYAxisType(markersDrugsKP[0]));
         }
         dispatch(setTrendsGraphDrugClass('ESBL'));
         dispatch(setDistributionGraphView('genotype'));
@@ -823,7 +828,10 @@ export const DashboardPage = () => {
         dispatch(setBubbleKOHeatmapGraphVariable('GENOTYPE'));
         dispatch(setBubbleMarkersHeatmapGraphVariable('GENOTYPE'));
         dispatch(setBubbleKOYAxisType('K_locus'));
-        dispatch(setBubbleMarkersYAxisType('K_locus'));
+        // dispatch(setBubbleMarkersYAxisType('K_locus'));
+        dispatch(setDeterminantsGraphDrugClass('Carbapenems'));
+        dispatch(setTrendsGraphDrugClass('Carbapenems'));
+        dispatch(setBubbleMarkersYAxisType('Carbapenems'))
         break;
       case 'ngono':
         dispatch(setMapView('Resistance prevalence'));
@@ -833,6 +841,7 @@ export const DashboardPage = () => {
         dispatch(setDeterminantsGraphDrugClass('Azithromycin'));
         dispatch(setTrendsGraphDrugClass('Azithromycin'));
         dispatch(setTrendsGraphView('percentage'));
+        dispatch(setBubbleMarkersYAxisType(drugClassesNG[0]));
         break;
       case 'sentericaints':
       case 'senterica':
@@ -840,15 +849,21 @@ export const DashboardPage = () => {
         if (!isPaginated) {
           dispatch(setDrugResistanceGraphView(drugsINTS));
         }
-        dispatch(setDeterminantsGraphDrugClass('Aminoglycosides'));
+        dispatch(setDeterminantsGraphDrugClass(getDrugClasses(organism)[0]));
+        dispatch(setTrendsGraphDrugClass(getDrugClasses(organism)[0]));
+        dispatch(setBubbleMarkersYAxisType(getDrugClasses(organism)[0]));
         break;
       case 'ecoli':
         dispatch(setMapView(isPaginated ? 'No. Samples' : 'Resistance prevalence'));
+        dispatch(setTrendsGraphDrugClass('Aminoglycosides'));
+        dispatch(setBubbleMarkersYAxisType(markersDrugsSH[0]));
         dispatch(setDeterminantsGraphDrugClass('Aminoglycosides'));
         break;
       case 'decoli':
         dispatch(setMapView(isPaginated ? 'No. Samples' : 'Resistance prevalence'));
         dispatch(setDeterminantsGraphDrugClass('Aminoglycosides'));
+        dispatch(setTrendsGraphDrugClass('Aminoglycosides'));
+        dispatch(setBubbleMarkersYAxisType(markersDrugsSH[0]));
         break;
       case 'shige':
         if (!isPaginated) {
@@ -856,6 +871,8 @@ export const DashboardPage = () => {
           // Don't set drug selection for paginated organisms - let auto-selection effect handle it
           dispatch(setDrugResistanceGraphView(drugsECOLI));
           dispatch(setDeterminantsGraphDrugClass('Aminoglycosides'));
+          dispatch(setTrendsGraphDrugClass('Aminoglycosides'));
+          dispatch(setBubbleMarkersYAxisType(markersDrugsSH[0]));
         }
         break;
       default:
@@ -995,7 +1012,7 @@ export const DashboardPage = () => {
       dispatch(setBubbleHeatmapGraphVariable('GENOTYPE'));
       dispatch(setBubbleKOHeatmapGraphVariable('GENOTYPE'));
       dispatch(setBubbleKOYAxisType('O_locus'));
-      dispatch(setBubbleMarkersYAxisType(markersDrugsKP[0]));
+
       dispatch(setBubbleMarkersHeatmapGraphVariable('GENOTYPE'));
       dispatch(setConvergenceColourPallete({}));
       // dispatch(setNgmast([]));

--- a/client/src/components/Dashboard/filters.js
+++ b/client/src/components/Dashboard/filters.js
@@ -593,9 +593,11 @@ export function getYearsData({ data, years, organism, getUniqueGenotypes = false
   const drugsData = [];
   const genotypesAndDrugsData = {};
   let uniqueGenotypes = [];
+  let uniqueNGMAST = [];
   let uniqueCgST = [];
   let uniqueSublineages = [];
   const genotypesAndDrugsDataUniqueGenotypes = {};
+  const NGMASTData = [];
   const cgSTData = [];
   const sublineageData = [];
 
@@ -631,10 +633,11 @@ export function getYearsData({ data, years, organism, getUniqueGenotypes = false
       acc[genotype] = (acc[genotype] || 0) + 1;
       return acc;
     }, {});
-
+    console.log("yearData", yearData)
     // Calculate other genotype stats for Klebsiella
     let cgSTStats = {};
     let sublineageStats = {};
+    let NGMASTStats ={};
     if (organism === 'kpneumo') {
       cgSTStats = yearData.reduce((acc, x) => {
         const cgST = x.cgST;
@@ -655,6 +658,16 @@ export function getYearsData({ data, years, organism, getUniqueGenotypes = false
         return acc;
       }, {});
       sublineageData.push({ ...response, ...sublineageStats });
+    } else if (organism === 'ngono'){
+      NGMASTStats = yearData.reduce((acc, x) => {
+        const NGMAST = x['NG-MAST TYPE'];
+        // if (cgST && cgST !== '-' && cgST !== null && cgST !== undefined && cgST !== '' && cgST.toString().trim() !== '') {
+        //   acc[cgST] = (acc[cgST] || 0) + 1;
+        // }
+        acc[NGMAST] = (acc[NGMAST] || 0) + 1;
+        return acc;
+      }, {});
+      NGMASTData.push({ ...response, ...NGMASTStats });
     }
 
     // Initialize drugStats
@@ -729,15 +742,15 @@ export function getYearsData({ data, years, organism, getUniqueGenotypes = false
             return acc;
           }, {});
 
-  genotypesAndDrugsDataUniqueGenotypes[key].push(...Object.keys(filteredGenotypes));
+          genotypesAndDrugsDataUniqueGenotypes[key].push(...Object.keys(filteredGenotypes));
 
-  const drugClass = getDrugClassDataINTS({ drugKey: key, dataToFilter: yearData });
+          const drugClass = getDrugClassDataINTS({ drugKey: key, dataToFilter: yearData });
 
-  const item = { ...response, ...filteredGenotypes, ...drugClass, totalCount: count };
-  delete item.count;
+          const item = { ...response, ...filteredGenotypes, ...drugClass, totalCount: count };
+          delete item.count;
 
-  genotypesAndDrugsData[key].push(item);
-});
+          genotypesAndDrugsData[key].push(item);
+        });
       } else if (organism === 'kpneumo') {
         drugRulesKP.forEach(rule => {
           const drugData = yearData.filter(x => {
@@ -855,6 +868,17 @@ export function getYearsData({ data, years, organism, getUniqueGenotypes = false
           }, {});
 
         uniqueSublineages = uniqueSublineages.concat(Object.keys(sortedStatsSublineages));
+        
+      } else if (organism === 'ngono'){
+          const sortedStatsNGMAST = Object.entries(NGMASTStats)
+            .sort(([, a], [, b]) => b - a)
+            .slice(0, 20)
+            .reduce((acc, [NGMAST]) => {
+              acc[NGMAST] = NGMASTStats[NGMAST];
+              return acc;
+            }, {});
+
+          uniqueNGMAST = uniqueNGMAST.concat(Object.keys(sortedStatsNGMAST));
       }
     }
 
@@ -888,6 +912,7 @@ export function getYearsData({ data, years, organism, getUniqueGenotypes = false
     sublineageData,
     uniqueCgST,
     uniqueSublineages,
+    NGMASTData: NGMASTData.filter(x => x.count > 0)
   };
 }
 

--- a/client/src/components/Dashboard/filters.js
+++ b/client/src/components/Dashboard/filters.js
@@ -1629,7 +1629,7 @@ export function getConvergenceData({ data, groupVariable, colourVariable }) {
 
     acc[combination] = data.filter(x =>
       groupVariable === colourVariable
-        ? getVariableValue(x, groupVariable).toString() === combination.toString()
+        ? getVariableValue(x, groupVariable)?.toString() === combination?.toString()
         : getVariableValue(x, groupVariable).toString() === groupVal.toString() &&
           getVariableValue(x, colourVariable).toString() === colourVal.toString(),
     );

--- a/client/src/components/Elements/ContinentGraphs/BubbleGeographicGraph/BubbleGeographicGraph.js
+++ b/client/src/components/Elements/ContinentGraphs/BubbleGeographicGraph/BubbleGeographicGraph.js
@@ -30,7 +30,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { darkGrey, hoverColor } from '../../../../util/colorHelper';
 import { isTouchDevice } from '../../../../util/isTouchDevice';
 import { drugClassesRulesSTHeatMap, statKeys } from '../../../../util/drugClassesRules';
-import { drugAcronyms, drugAcronymsOpposite, markersDrugsKP } from '../../../../util/drugs';
+import { drugAcronyms, drugAcronymsOpposite, markersDrugsKP, markersDrugsSH, drugClassesNG, markersDrugsINTS} from '../../../../util/drugs';
 import { mixColorScale } from '../../Map/mapColorHelper';
 import { longestVisualWidth, truncateWord } from '../../../../util/helpers';
 import { Clear, Close, InfoOutlined } from '@mui/icons-material';
@@ -38,32 +38,70 @@ import { setYAxisType, setYAxisTypeTrend } from '../../../../stores/slices/mapSl
 import { organismsCards, organismsWithLotsGenotypes } from '../../../../util/organismsCards';
 import { setResetBool } from '../../../../stores/slices/graphSlice';
 
-const kpTrendOptions = markersDrugsKP
-  .map(drug => {
-    const label = drug === 'ESBL' ? 'ESBLs' : drug;
-    return {
-      organism: 'kpneumo',
-      key: drug,
-      value: `kp-trends-${drug.toLowerCase()}`,
-      label: label,
-    };
-  })
-  .sort((a, b) => a.key.localeCompare(b.key));
+// Dynamic trend options generator
+const createTrendOptions = (organism, drugs, labelMap = {}) => {
+  return drugs
+    .map(drug => {
+      const label = labelMap[drug] || drug;
+      return {
+        organism,
+        key: drug,
+        value: `${organism}-trends-${drug.toLowerCase()}`,
+        label: label,
+      };
+    })
+    .sort((a, b) => a.key.localeCompare(b.key));
+};
 
-const stTrendOptions = Object.keys(drugClassesRulesSTHeatMap)
-  .map(drug => {
-    const label = drug === 'Ciprofloxacin NS' ? 'Ciprofloxacin' : drug;
+const organismConfig = {
+  kpneumo: {
+    drugs: markersDrugsKP,
+    labelMap: { 'ESBL': 'ESBLs' }
+  },
+  styphi: {
+    drugs: Object.keys(drugClassesRulesSTHeatMap),
+    labelMap: { 'Ciprofloxacin NS': 'Ciprofloxacin' }
+  },
+  ngono: {
+    drugs: drugClassesNG,
+    labelMap: {}
+  },
+  shige: {
+    drugs: markersDrugsSH,
+    labelMap: {}
+  },
+  ecoli: {
+    drugs: markersDrugsSH,
+    labelMap: {}
+  },
+  decoli: {
+    drugs: markersDrugsSH,
+    labelMap: {}
+  },
+  senterica: {
+    drugs: markersDrugsINTS,
+    labelMap: {}
+  }
+};
 
-    return {
-      organism: 'styphi',
-      key: drug,
-      value: `st-trends-${drug.toLowerCase()}`,
-      label: label,
-    };
-  })
-  .sort((a, b) => a.key.localeCompare(b.key));
+// function to get trend options for any organism
+const getAllTrendOptionsForOrganism = (organism) => {
+  const config = organismConfig[organism];
+  
+  if (!config) {
+    console.warn(`No trend options configuration found for organism: ${organism}`);
+    return [];
+  }
+  
+  return createTrendOptions(organism, config.drugs, config.labelMap);
+};
 
-const allTrendOptions = kpTrendOptions.concat(stTrendOptions);
+// Generate all trend options 
+const kpTrendOptions = getAllTrendOptionsForOrganism('kpneumo');
+const stTrendOptions = getAllTrendOptionsForOrganism('styphi');
+const ngonoTrendOptions = getAllTrendOptionsForOrganism('ngono');
+const shigeTrendOptions = getAllTrendOptionsForOrganism('shige');
+const getOtherOrganismTrendOptions = getAllTrendOptionsForOrganism('senterica');
 
 const yOptions = [
   {
@@ -83,7 +121,8 @@ const yOptions = [
   {
     value: 'determinant',
     label: 'Resistance marker',
-    organisms: ['styphi', 'kpneumo'],
+    // Adding market for all organisms
+    organisms: ['styphi', 'kpneumo', 'ngono', 'shige', 'ecoli', 'decoli', 'senterica', 'sentericaints'],
   },
   {
     value: 'pathotype',
@@ -113,6 +152,7 @@ export const BubbleGeographicGraph = ({ showFilter, setShowFilter }) => {
   const economicRegions = useAppSelector(state => state.dashboard.economicRegions);
   const drugsRegionsData = useAppSelector(state => state.graph.drugsRegionsData);
   const drugsCountriesData = useAppSelector(state => state.graph.drugsCountriesData);
+  const genotypesDrugClassesData = useAppSelector(state => state.graph.genotypesDrugClassesData);
   const yAxisType = useAppSelector(state => state.map.yAxisType);
   const yAxisTypeTrend = useAppSelector(state => state.map.yAxisTypeTrend);
   const loadingPDF = useAppSelector(state => state.dashboard.loadingPDF);
@@ -159,35 +199,47 @@ export const BubbleGeographicGraph = ({ showFilter, setShowFilter }) => {
     );
   }, [mapData, mapRegionData, organism, xAxisSelected, xAxisType]);
 
-  const markersOptions = useMemo(() => {
-    const drugKey = allTrendOptions?.find(x => x.value === yAxisTypeTrend)?.key;
+const markersOptions = useMemo(() => {
+  const organismTrendOptions = getAllTrendOptionsForOrganism(organism);
+  const drugKey = organismTrendOptions?.find(x => x.value === yAxisTypeTrend)?.key;
 
-    const data = drugsData?.[drugKey];
-    const filteredData = data?.filter(x => xAxisSelected.includes(x.name)) ?? [];
+  if (!drugKey) return [];
+
+  // Common exclusions for all organisms
+  const EXCLUSIONS = new Set(['None', 'name', 'resistantCount', 'totalCount']);
+
+  // Helper function to aggregate drug data
+  const aggregateDrugs = (dataArray, filterFn = () => true) => {
     const drugs = {};
 
-    filteredData.forEach(obj => {
-      Object.keys(obj).forEach(key => {
-        if (['None', 'name', 'resistantCount', 'totalCount'].includes(key)) {
-          return;
-        }
-
-        if (!(key in drugs)) {
-          drugs[key] = obj[key];
-          return;
-        }
-
-        drugs[key] += obj[key];
+    dataArray.filter(filterFn).forEach(item => {
+      Object.entries(item).forEach(([key, value]) => {
+        if (EXCLUSIONS.has(key)) return;
+        drugs[key] = (drugs[key] || 0) + (value || 0);
       });
     });
 
-    return (
-      Object.entries(drugs)
-        .filter(x => x[1] > 0)
-        .sort((a, b) => b[1] - a[1])
-        .map(x => x[0]) ?? []
-    );
-  }, [drugsData, xAxisSelected, yAxisTypeTrend]);
+    return Object.entries(drugs)
+      .filter(([, count]) => count > 0)
+      .sort((a, b) => b[1] - a[1])
+      .map(([name]) => name);
+  };
+
+  // Get data source based on organism type
+  const isLegacyStructure = ['kpneumo', 'styphi'].includes(organism);
+  const dataSource = isLegacyStructure 
+    ? drugsData?.[drugKey] 
+    : genotypesDrugClassesData[drugKey];
+
+  if (!dataSource) return [];
+
+  // Apply filtering only for legacy structure
+  const filterFn = isLegacyStructure 
+    ? item => xAxisSelected.includes(item.name)
+    : () => true;
+
+  return aggregateDrugs(dataSource, filterFn);
+}, [drugsData, genotypesDrugClassesData, xAxisSelected, yAxisTypeTrend, organism]);
 
   const GLPSColumn = useMemo(
     () => (['serotype', 'pathotype'].includes(yAxisType) ? 'PATHOTYPE' : 'GENOTYPE'),
@@ -308,7 +360,10 @@ export const BubbleGeographicGraph = ({ showFilter, setShowFilter }) => {
     dispatch(setYAxisType(value));
 
     if (value === 'determinant') {
-      dispatch(setYAxisTypeTrend(allTrendOptions.filter(x => x.organism === organism)[0].value));
+      const organismTrendOptions = getAllTrendOptionsForOrganism(organism);
+      if (organismTrendOptions.length > 0) {
+        dispatch(setYAxisTypeTrend(organismTrendOptions[0].value));
+      }
     }
   }
 
@@ -349,11 +404,6 @@ export const BubbleGeographicGraph = ({ showFilter, setShowFilter }) => {
       return;
     }
 
-    // if (!showSelectAll) {
-    //   setYAxisSelected([]);
-    //   return;
-    // }
-
     if (
       yAxisSelected.length === filteredYAxisOptions.length ||
       yAxisSelected.some(x => !yAxisOptions.slice(0, 20).includes(x))
@@ -383,6 +433,7 @@ export const BubbleGeographicGraph = ({ showFilter, setShowFilter }) => {
       case 'ecoli':
       case 'kpneumo':
       case 'styphi':
+      case 'ngono':
         return 70;
       default:
         return 50;
@@ -440,7 +491,16 @@ export const BubbleGeographicGraph = ({ showFilter, setShowFilter }) => {
         }
 
         if (yAxisType === 'determinant') {
-          const count = drugsCountriesData?.[parent]?.find(g => g.name === x.name)?.[item] || 0;
+          // Enhanced to support all organisms
+          let count = 0;
+          if (['kpneumo', 'styphi'].includes(organism)) {
+            count = drugsCountriesData?.[parent]?.find(g => g.name === x.name)?.[item] || 0;
+          } else {
+            const relevantData = genotypesDrugClassesData[parent];
+            if (relevantData) {
+              count = relevantData.reduce((sum, dataItem) => sum + (dataItem[item] || 0), 0);
+            }
+          }
 
           if (count > 0) {
             info['itemCount'] = count;
@@ -468,7 +528,7 @@ export const BubbleGeographicGraph = ({ showFilter, setShowFilter }) => {
         </div>
       );
     },
-    [GLPSColumn, drugsCountriesData, economicRegions, mapData, organism, xAxisType, yAxisType],
+    [GLPSColumn, drugsCountriesData, genotypesDrugClassesData, economicRegions, mapData, organism, xAxisType, yAxisType],
   );
 
   const configuredMapData = useMemo(() => {
@@ -533,21 +593,54 @@ export const BubbleGeographicGraph = ({ showFilter, setShowFilter }) => {
         }
 
         if (yAxisType === 'determinant') {
-          const drugKey = allTrendOptions?.find(x => x.value === yAxisTypeTrend)?.key;
-          const locationDrugData = drugsData?.[drugKey];
-          const locationData = locationDrugData?.find(x => x.name === item.name);
-
+          const organismTrendOptions = getAllTrendOptionsForOrganism(organism);
+          const drugKey = organismTrendOptions?.find(x => x.value === yAxisTypeTrend)?.key;
+          
+          if (!drugKey) return; // Early exit if no drugKey found
+          
+          // Helper function to calculate percentage
+          const calculatePercentage = (count, total) => 
+            count && total ? Number(((count / total) * 100).toFixed(2)) : 0;
+          
+          // Helper function to create item object
+          const createItem = (drug, count, total, typeName) => ({
+            itemName: drug.replaceAll(' + ', '/'),
+            percentage: calculatePercentage(count, total),
+            index: 1,
+            typeName,
+            count: count || 0,
+            total: total || 0,
+            parent: drugKey,
+          });
+          
+          // Data extraction strategies
+          const getDataForOrganism = {
+            legacy: () => {
+              const locationData = drugsData?.[drugKey]?.find(x => x.name === item.name);
+              return {
+                getData: (drug) => locationData?.[drug] || 0,
+                getTotal: () => locationData?.totalCount || 0
+              };
+            },
+            modern: () => {
+              const drugClassData = genotypesDrugClassesData[drugKey];
+              return {
+                getData: (drug) => drugClassData?.reduce((sum, dataItem) => 
+                  sum + (dataItem[drug] || 0), 0) || 0,
+                getTotal: () => item.count
+              };
+            }
+          };
+          
+          // Select appropriate strategy
+          const isLegacy = ['kpneumo', 'styphi'].includes(organism);
+          const { getData, getTotal } = getDataForOrganism[isLegacy ? 'legacy' : 'modern']();
+          const totalCount = getTotal();
+          
+          // Process all drugs with single loop
           yAxisSelected.forEach(drug => {
-            const drugCount = locationData ? locationData[drug] : 0;
-            data.items.push({
-              itemName: drug.replaceAll(' + ', '/'),
-              percentage: drugCount ? Number(((drugCount / locationData.totalCount) * 100).toFixed(2)) : 0,
-              index: 1,
-              typeName: item.name,
-              count: drugCount || 0,
-              total: locationData?.totalCount || 0,
-              parent: drugKey,
-            });
+            const drugCount = getData(drug);
+            data.items.push(createItem(drug, drugCount, totalCount, item.name));
           });
         }
 
@@ -556,6 +649,7 @@ export const BubbleGeographicGraph = ({ showFilter, setShowFilter }) => {
   }, [
     GLPSColumn,
     drugsData,
+    genotypesDrugClassesData,
     mapData,
     mapRegionData,
     organism,
@@ -566,7 +660,6 @@ export const BubbleGeographicGraph = ({ showFilter, setShowFilter }) => {
     yAxisType,
     yAxisTypeTrend,
   ]);
-
   useEffect(() => {
     if (canGetData) {
       setPlotChart(() => {
@@ -853,6 +946,24 @@ export const BubbleGeographicGraph = ({ showFilter, setShowFilter }) => {
                         {organism === 'styphi' &&
                           stTrendOptions.map((option, index) => (
                             <MenuItem key={`y-st-option-${index}`} value={option.value}>
+                              {option.label}
+                            </MenuItem>
+                          ))}
+                        {organism === 'ngono' &&
+                          ngonoTrendOptions.map((option, index) => (
+                            <MenuItem key={`y-ngono-option-${index}`} value={option.value}>
+                              {option.label}
+                            </MenuItem>
+                          ))}
+                        {['ecoli', 'decoli', 'shige'].includes(organism) &&
+                          shigeTrendOptions.map((option, index) => (
+                            <MenuItem key={`y-shige-option-${index}`} value={option.value}>
+                              {option.label}
+                            </MenuItem>
+                          ))}
+                        {['senterica', 'sentericaints'].includes(organism) &&
+                          getOtherOrganismTrendOptions.map((option, index) => (
+                            <MenuItem key={`y-${organism}-option-${index}`} value={option.value}>
                               {option.label}
                             </MenuItem>
                           ))}

--- a/client/src/components/Elements/Graphs/MarkerTrendsGraph/MarkerTrendsGraph.js
+++ b/client/src/components/Elements/Graphs/MarkerTrendsGraph/MarkerTrendsGraph.js
@@ -24,7 +24,8 @@ import {
   setTrendsGraphView,
 } from '../../../../stores/slices/graphSlice';
 import { colorForDrugClassesNG, colorForMarkers, hoverColor } from '../../../../util/colorHelper';
-import { drugClassesNG, markersDrugsKP } from '../../../../util/drugs';
+import { drugClassesNG, markersDrugsKP, drugClassesST, markersDrugsSH, drugsINTS} from '../../../../util/drugs';
+import { statKeysST } from '../../../../util/drugClassesRules';
 import { getRange } from '../../../../util/helpers';
 import { isTouchDevice } from '../../../../util/isTouchDevice';
 import { SelectCountry } from '../../SelectCountry';
@@ -70,15 +71,25 @@ export const MarkerTrendsGraph = ({ showFilter, setShowFilter }) => {
   ];
 
   function getDrugClasses() {
-    if (organism === 'none') {
-      return [];
-    }
-    if (organism === 'kpneumo') {
-      return markersDrugsKP;
-    }
-
-    return drugClassesNG;
+  if (organism === 'none') {
+    return [];
   }
+  if (organism === 'kpneumo') {
+    return markersDrugsKP;
+  }
+  if (organism === 'styphi') {
+    return drugClassesST;
+  }
+  if (organism === 'shige' || organism === 'decoli' || organism === 'ecoli') {
+    return markersDrugsSH;
+  }
+  if (organism === 'ngono') {
+    return drugClassesNG;  // This should return the correct drug classes for ngono
+  }
+
+  return drugsINTS.filter(item => item !== 'Pansusceptible'); // Default fallback
+}
+
 
   function getDomain(max = null) {
     return trendsGraphView === 'number' ? ['dataMin', max ?? 'dataMax'] : [0, 100];
@@ -128,7 +139,6 @@ export const MarkerTrendsGraph = ({ showFilter, setShowFilter }) => {
     if (!processedData) return;
 
     const { genes, sortedGeneKeys } = processedData;
-
     // This is a side effect and belongs in useEffect
     dispatch(setMaxSliderValueKP_GE(Object.keys(genes).length));
 
@@ -399,7 +409,7 @@ export const MarkerTrendsGraph = ({ showFilter, setShowFilter }) => {
                 } else if (organism === 'ngono') {
                   const colorObj = colorForDrugClassesNG[trendsGraphDrugClass]?.find(x => x.name === option);
                   if (colorObj) fillColor = colorObj.color;
-                } else if (organism === 'kpneumo') {
+                } else {
                   fillColor = colorForMarkers[index];
                 }
 

--- a/client/src/components/Elements/Map/Map.js
+++ b/client/src/components/Elements/Map/Map.js
@@ -147,7 +147,7 @@ export const Map = () => {
                           Samples: countryData.count,
                           Genotypes: countryStats.GENOTYPE.count,
                           'O prevalence': countryStats.O_PREV.count,
-                          'OH prevalence': countryStats.OH_PREV.count,
+                          'H prevalence': countryStats.OH_PREV.count,
                         }
                       : {
                           Samples: countryData.count,

--- a/client/src/util/convergenceVariablesOptions.js
+++ b/client/src/util/convergenceVariablesOptions.js
@@ -8,5 +8,10 @@ export const variablesOptions = [
   // { label: 'Bla_Carb_acquired', value: 'Bla_Carb_acquired' },
   // { label: 'Bla_ESBL_acquired', value: 'Bla_ESBL_acquired' }
 ];
-
 export const variableGraphOptions = variablesOptions.filter(x => x.graph);
+
+export const variablesOptionsNG = [
+  { label: 'NGMST', value: 'NG-MAST TYPE', graph: true, mapValue: 'NGMST' },
+  { label: 'GENOTYPE', value: 'GENOTYPE' , graph: true, mapValue: 'GENOTYPE'},
+];
+export const variableGraphOptionsNG = variablesOptionsNG.filter(x => x.graph);

--- a/client/src/util/drugClassesRules.js
+++ b/client/src/util/drugClassesRules.js
@@ -1175,13 +1175,13 @@ export const drugRulesINTS = [
   { key: 'Tetracycline', columnID: 'TETRACYCLINE', values: ['TETRACYCLINE'] },
   { key: 'Tigecycline', columnID: 'TETRACYCLINE', values: ['TIGECYCLINE'] },
   { key: 'Trimethoprim', columnID: 'TRIMETHOPRIM', values: ['TRIMETHOPRIM'] },
-  {
-    key: 'Trimethoprim-sulfamethoxazole',
-    requirements: [
-      { columnID: 'SULFONAMIDE', values: ['SULFONAMIDE'] },
-      { columnID: 'TRIMETHOPRIM', values: ['TRIMETHOPRIM,dfrA'] },
-    ],
-  },
+  // {
+  //   key: 'Trimethoprim-sulfamethoxazole',
+  //   requirements: [
+  //     { columnID: 'SULFONAMIDE', values: ['SULFONAMIDE'] },
+  //     { columnID: 'TRIMETHOPRIM', values: ['TRIMETHOPRIM,dfrA'] },
+  //   ],
+  // },
   {
     key: 'Pansusceptible',
     requirements: [
@@ -1204,7 +1204,7 @@ export const statKeysINTS = [
   { name: 'Azithromycin', column: 'MACROLIDE', key: 'AZITHROMYCIN', resistanceView: true },
   { name: 'Ceftriaxone', column: 'BETA-LACTAM', key: 'CEPHALOSPORIN', resistanceView: true },
   { name: 'Chloramphenicol', column: 'PHENICOL', key: 'CHLORAMPHENICOL', resistanceView: true },
-  { name: 'CipNS', column: 'QUINOLONE', key: 'QUINOLONE', resistanceView: true },
+  { name: 'Ciprofloxacin NS', column: 'QUINOLONE', key: 'QUINOLONE', resistanceView: true },
   { name: 'Colistin', column: 'COLISTIN', key: 'COLISTIN', resistanceView: true },
   {
     name: 'Gentamicin',

--- a/client/src/util/drugs.js
+++ b/client/src/util/drugs.js
@@ -3,7 +3,10 @@ import {
   drugRulesNG,
   drugRulesKP,
   statKeysKP,
+  statKeysST,
+  drugRulesST,
   statKeysECOLI,
+  statKeysINTS,
   statKeysKPOnlyMarkers,
 } from './drugClassesRules';
 
@@ -99,6 +102,9 @@ export const markersDrugsKP = [
   ...drugsKP.filter(x => !['Pansusceptible'].includes(x)),
   ...statKeysKPOnlyMarkers.map(x => x.name),
 ].sort();
+export const markersDrugsST = [...drugRulesST.map(x => x.name)].sort();
+export const markersDrugsSH = statKeysECOLI.map(x => x.name).filter(x => !['Pansusceptible'].includes(x));
+export const markersDrugsINTS = statKeysINTS.map(x => x.name).filter(x => !['Pansusceptible'].includes(x));
 
 // List of Salmonella Typhi drug classes
 export const drugClassesST = [

--- a/client/src/util/graphCards.js
+++ b/client/src/util/graphCards.js
@@ -46,7 +46,7 @@ export const graphCards = [
     description: ['Data are plotted for years with N ≥ 10 genomes'],
     icon: <Timeline color="primary" />,
     id: 'RDT',
-    organisms: ['ngono', 'kpneumo'],
+    organisms: ['ngono', 'kpneumo', 'styphi', 'shige', 'senterica', 'decoli', 'ecoli', 'sentericaints'],
     component: <MarkerTrendsGraph />,
   },
   {
@@ -54,7 +54,7 @@ export const graphCards = [
     description: ['Top Genotypes (up to 10)'],
     icon: <StackedBarChart color="primary" />,
     id: 'RDWG',
-    organisms: ['styphi', 'ngono', 'shige', 'ecoli', 'decoli'],
+    organisms: [],
     component: <DeterminantsGraph />,
   },
   {
@@ -62,7 +62,7 @@ export const graphCards = [
     description: [''],
     icon: <ViewModule color="primary" />,
     id: 'BAMRH',
-    organisms: ['kpneumo'],
+    organisms: ['ngono', 'kpneumo', 'styphi', 'shige', 'senterica', 'decoli', 'ecoli', 'sentericaints'],
     component: <BubbleMarkersHeatmapGraph />,
   },
   {


### PR DESCRIPTION
## Summary by Sourcery

Expand support for additional organisms, introduce generic trend options generator, and refactor graph and filter logic to streamline per-organism data handling

New Features:
- Add support for new organisms (ngono, shige, ecoli, decoli, senterica, sentericaints) across graphs and filters
- Introduce a generic createTrendOptions/organismConfig pattern to dynamically generate trend options
- Extend getYearsData to compute NG-MAST statistics for ngono and integrate drug class data for all organisms
- Enable NG-MAST TYPE as a distribution variable in DistributionGraph for ngono
- Add variableGraphOptionsNG and getDrugClasses util to support ngono-specific convergence and marker trends

Bug Fixes:
- Fix Map component label from "OH prevalence" to "H prevalence"
- Rename "CipNS" to "Ciprofloxacin NS" in statKeysINTS

Enhancements:
- Refactor BubbleGeographicGraph to centralize trend option creation and aggregate drug data for legacy versus modern structures
- Unify BubbleMarkersHeatmapGraph y-axis option extraction and map data configuration using genotype-based data
- Simplify ConvergenceGraph legend rendering by removing gradient legend in favor of a consistent color legend
- Refactor getDrugClassData functions in util/drugClassesRules for clearer and more extensible logic