### PR TITLE
Global Filter and Reset

### DIFF
--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -38,6 +38,7 @@ import {
   setTotalGenomes,
   setTotalGenotypes,
   setYears,
+  setYearsCompleteListToShowInGlobalFilter
 } from '../../stores/slices/dashboardSlice.ts';
 import {
   setActualGenomesDRT,
@@ -347,6 +348,7 @@ export const DashboardPage = () => {
     dispatch(setActualGenotypes(genotypes.length));
     dispatch(setGenotypesForFilter(genotypes));
     dispatch(setYears(years));
+    dispatch(setYearsCompleteListToShowInGlobalFilter(years));
     dispatch(setCountriesForFilter(countries));
     dispatch(setPMID(PMID));
     // dispatch(setNgmast(ngmast));
@@ -1100,7 +1102,7 @@ export const DashboardPage = () => {
 
     return null;
   }
-
+console.log("yearsForFilter", yearsForFilter)
   useEffect(() => {
     if (yearsForFilter.length > 0) {
       dispatch(setTimeInitial(yearsForFilter[0]));

--- a/client/src/components/Elements/Map/TopLeftControls/TopLeftControls.js
+++ b/client/src/components/Elements/Map/TopLeftControls/TopLeftControls.js
@@ -40,7 +40,7 @@ export const TopLeftControls = ({ style, closeButton = null, title = 'Filters' }
   const datasetKP = useAppSelector(state => state.map.datasetKP);
   const actualTimeInitial = useAppSelector(state => state.dashboard.actualTimeInitial);
   const actualTimeFinal = useAppSelector(state => state.dashboard.actualTimeFinal);
-  const years = useAppSelector(state => state.dashboard.years);
+  const yearsCompleteListToShowInGlobalFilter = useAppSelector(state => state.dashboard.yearsCompleteListToShowInGlobalFilter);
   const pathovar = useAppSelector(state => state.dashboard.pathovar);
   const organism = useAppSelector(state => state.dashboard.organism);
   const selectedLineages = useAppSelector(state => state.dashboard.selectedLineages);
@@ -268,7 +268,7 @@ export const TopLeftControls = ({ style, closeButton = null, title = 'Filters' }
                 fullWidth
                 disabled={organism === 'none'}
               >
-                {years
+                {yearsCompleteListToShowInGlobalFilter
                   .filter(year => year <= actualTimeFinal)
                   .map((year, index) => {
                     return (
@@ -298,7 +298,7 @@ export const TopLeftControls = ({ style, closeButton = null, title = 'Filters' }
                 fullWidth
                 disabled={organism === 'none'}
               >
-                {years
+                {yearsCompleteListToShowInGlobalFilter
                   .filter(year => year >= actualTimeInitial)
                   .map((year, index) => {
                     return (

--- a/client/src/components/Elements/ResetButton/ResetButton.js
+++ b/client/src/components/Elements/ResetButton/ResetButton.js
@@ -67,6 +67,8 @@ export const ResetButton = () => {
   const maxSliderValueRD = useAppSelector(state => state.graph.maxSliderValueRD);
   const loadingData = useAppSelector(state => state.dashboard.loadingData);
   const loadingMap = useAppSelector(state => state.map.loadingMap);
+  const yearsCompleteListToShowInGlobalFilter = useAppSelector(state => state.dashboard.yearsCompleteListToShowInGlobalFilter);
+
 
   async function handleClick() {
     dispatch(setResetBool(true));
@@ -74,8 +76,8 @@ export const ResetButton = () => {
 
     dispatch(setDataset('All'));
     dispatch(setDatasetKP('All'));
-    dispatch(setActualTimeInitial(timeInitial));
-    dispatch(setActualTimeFinal(timeFinal));
+    dispatch(setActualTimeInitial(yearsCompleteListToShowInGlobalFilter[0]));
+    dispatch(setActualTimeFinal(yearsCompleteListToShowInGlobalFilter[yearsCompleteListToShowInGlobalFilter.length-1]));
     dispatch(setPosition({ coordinates: [0, 0], zoom: 1 }));
     dispatch(setActualRegion('All'));
     dispatch(setActualCountry('All'));

--- a/client/src/stores/slices/dashboardSlice.ts
+++ b/client/src/stores/slices/dashboardSlice.ts
@@ -36,6 +36,7 @@ interface DashboardState {
   actualTimeInitial: number | string;
   actualTimeFinal: number | string;
   years: Array<number>;
+  yearsCompleteListToShowInGlobalFilter: Array<number>;
   genotypesForFilter: Array<string>;
   genotypesForFilterSelected: Array<string>;
   genotypesForFilterSelectedRD: Array<string>;
@@ -81,6 +82,7 @@ const initialState: DashboardState = {
   actualTimeInitial: '',
   actualTimeFinal: '',
   years: [],
+  yearsCompleteListToShowInGlobalFilter: [],
   genotypesForFilter: [],
   genotypesForFilterSelected: [],
   genotypesForFilterSelectedRD: [],
@@ -173,6 +175,9 @@ export const dashboardSlice = createSlice({
     setYears: (state, action: PayloadAction<Array<number>>) => {
       state.years = action.payload;
     },
+    setYearsCompleteListToShowInGlobalFilter: (state, action: PayloadAction<Array<number>>) => {
+      state.yearsCompleteListToShowInGlobalFilter = action.payload;
+    },
     setGenotypesForFilter: (state, action: PayloadAction<Array<string>>) => {
       state.genotypesForFilter = action.payload;
     },
@@ -262,6 +267,7 @@ export const {
   setActualTimeInitial,
   setActualTimeFinal,
   setYears,
+  setYearsCompleteListToShowInGlobalFilter,
   setGenotypesForFilter,
   setGenotypesForFilterSelected,
   setGenotypesForFilterSelectedRD,


### PR DESCRIPTION
Global Filter — complete Start and End year list visible for further selection, and
Fix reset for Global Filter values

## Summary by Sourcery

Show the complete year range in the global time filter and ensure the reset button restores the full range correctly.

New Features:
- Display the full list of years in the global start/end year dropdowns

Bug Fixes:
- Reset button now resets the time filter to the full year range

Enhancements:
- Add a dedicated yearsCompleteListToShowInGlobalFilter state to track the full year list