### PR TITLE
Updated readthedocs

### DIFF
--- a/docs/Org/decoli.rst
+++ b/docs/Org/decoli.rst
@@ -1,0 +1,26 @@
+*Escherichia coli* diarrheagenic
+=================================
+
+.. container:: justify-text
+
+   Enterobase classifies *E. coli* genomes to pathotypes using `this logic <https://enterobase.readthedocs.io/en/latest/pipelines/backend-pipeline-phylotypes.html?highlight=pathovar>`__. Pathotypes included in the *E. coli* (diarrheagenic) dashboard are:
+
+   - Shiga toxin-producing *E. coli* (STEC)
+   - Enterohemorrhagic *E. coli* (EHEC)
+   - Enterotoxigenic *E. coli* (ETEC)
+   - Enteropathogenic *E. coli* (EPEC)
+   - Enteroinvasive *E. coli* (EIEC)
+
+   Last update: 24 January 2024.
+
+   .. warning::
+      The *E. coli* data used in AMRnet are not yet curated for purpose-of-sampling, and therefore reflect the biases of global sequencing efforts which may be skewed towards sequencing AMR strains and/or outbreaks. Data curation efforts are ongoing however until then, please be careful when interpreting the data in the dashboard.
+
+Variable definitions
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. container:: justify-text
+
+   - **Lineages**: Lineages are labeled by the pathovar followed by the (7-locus) ST.
+
+   - **AMR determinants**: `Enterobase <https://enterobase.warwick.ac.uk/>`_ identifies AMR determinants using NCBI’s `AMRFinderPlus <https://www.ncbi.nlm.nih.gov/pathogens/antimicrobial-resistance/AMRFinder/>`_. AMRnet imports these AMR genotype calls, and assigns them to drugs/classes in the dashboard using the Subclass curated in `refgenes <https://doi.org/10.1099/mgen.0.000832>`_.

--- a/docs/Org/ecoli.rst
+++ b/docs/Org/ecoli.rst
@@ -1,0 +1,19 @@
+*Escherichia coli*
+===================
+
+.. container:: justify-text
+
+   *Escherichia coli* data in AMRnet are drawn from `Enterobase <https://enterobase.warwick.ac.uk/>`__, which calls AMR genotypes using NCBI’s `AMRFinderPlus <https://www.ncbi.nlm.nih.gov/pathogens/antimicrobial-resistance/AMRFinder/>`_ and assigns lineages using MLST, `cgMLST <https://doi.org/10.1101/gr.251678.119>`_ and `hierarchical clustering <https://doi.org/10.1093/bioinformatics/btab234>`_. Last update: 24 January 2024.
+
+   .. warning::
+      The *E. coli* data used in AMRnet are not yet curated for purpose-of-sampling, and therefore reflect the biases of global sequencing efforts which may be skewed towards sequencing AMR strains and/or outbreaks. Data curation efforts are ongoing however until then, please be careful when interpreting the data in the dashboard.
+
+Variable definitions
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. container:: justify-text
+
+   - **Lineages**: Lineages are labeled by 7-locus sequence type (ST).
+
+   - **AMR determinants**: `Enterobase <https://enterobase.warwick.ac.uk/>`_ identifies AMR determinants using NCBI’s `AMRFinderPlus <https://www.ncbi.nlm.nih.gov/pathogens/antimicrobial-resistance/AMRFinder/>`_. AMRnet imports these AMR genotype calls, and assigns them to drugs/classes in the dashboard using the Subclass curated in `refgenes <https://doi.org/10.1099/mgen.0.000832>`_.
+

--- a/docs/Org/kpneumo.rst
+++ b/docs/Org/kpneumo.rst
@@ -1,0 +1,27 @@
+
+*Klebsiella pneumoniae*
+=======================
+.. container:: justify-text
+
+    *Klebsiella pneumoniae* data are sourced from `Pathogenwatch <https://doi.org/10.1093/cid/ciab784>`__, which calls AMR (using `Kleborate <https://github.com/klebgenomics/Kleborate>`_) and genotypes (`MLST <https://doi.org/10.1128/jcm.43.8.4178-4182.2005>`__) from genomes assembled from public data. Last update: 24 May 2025.
+
+    .. warning:: The *Klebsiella pneumoniae* data used in AMRnet are not yet curated for purpose-of-sampling, and therefore reflect the biases of global sequencing efforts which have been largely directed at sequencing ESBL and carbapenemase-producing strains or hypervirulent strains. Data curation efforts are ongoing however until then, please be careful when interpreting the data in the dashboard.
+
+Variable definitions
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. container:: justify-text
+
+    - **Genotypes**: `7-locus MLST scheme <https://doi.org/10.1128/jcm.43.8.4178-4182.2005>`_ for Klebsiella pneumoniae, and sublineages (defined from core-genome MLST, as described `here <https://doi.org/10.1093/molbev/msac135>`__), maintained by `Institut Pasteur <https://bigsdb.pasteur.fr/klebsiella/>`_.
+    - **AMR determinants** are called using `Kleborate v3 <https://github.com/klebgenomics/Kleborate>`_, described `here <https://doi.org/10.1038/s41467-021-24448-3>`__. Fluoroquinolone resistance is defined as presence of an acquired qnr/qep gene OR a mutation in the quinolone-resistance determining regions of gyrA or parC.
+    - **No acquired resistance**: no resistance determinants identified besides a wildtype beta-lactamase SHV allele associated with intrinsic resistance to ampicillin (i.e. not an ESBL or inhibitor-resistant variant of SHV, see `Tsang et al 2024 <https://www.microbiologyresearch.org/content/journal/mgen/10.1099/mgen.0.001294>`_.
+
+Abbreviations
+~~~~~~~~~~~~~~
+
+.. container:: justify-text
+
+    - **ESBL**: extended-spectrum beta-lactamase
+    - **3GC**: third-generation cephalosporins
+    - **ST**: sequence type
+    - **cgST**: core-genome sequence type

--- a/docs/Org/ngono.rst
+++ b/docs/Org/ngono.rst
@@ -1,0 +1,29 @@
+*Neisseria gonorrhoeae*
+=======================
+
+.. container:: justify-text
+
+   *Neisseria gonorrhoeae* data are sourced from `Pathogenwatch <https://doi.org/10.1186/s13073-021-00858-2>`__, which calls AMR and lineage `genotypes <https://pubmlst.org/neisseria/>`_ (`MLST <https://doi.org/10.1186/1741-7007-5-35>`_, `NG-MAST <https://doi.org/10.1086/383047>`_) from genomes assembled from public data. The prevalence estimates shown are calculated using genome collections derived from non-targeted sampling frames (i.e. surveillance and burden studies, as opposed to AMR focused studies or outbreak investigations). These include EuroGASP `2013 <https://doi.org/10.1016/s1473-3099(18)30225-1>`_ & `2018 <https://doi.org/10.1016/s2666-5247(22)00044-1>`_, and several national surveillance studies. Last update: 24 January 2024.
+
+Variable definitions
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. container:: justify-text
+
+   - **Genotypes**: sequence types from the `7-locus MLST scheme <https://doi.org/10.1128/jcm.43.8.4178-4182.2005>`_ for **Neisseria**, or 2-locus **N. gonorrhoeae** multi-antigen sequence typing (`NG-MAST <https://doi.org/10.1086/383047>`_) scheme, both hosted by `PubMLST <https://pubmlst.org/neisseria/>`_.
+   - **AMR determinants** are identified by Pathogenwatch using an inhouse dictionary developed and maintained in consultation with an expert advisory group, described `here <https://doi.org/10.1186/s13073-021-00858-2>`__.
+   - **AMR determinants within genotypes** - This plot shows combinations of determinants that result in clinical resistance to Azithromycin or Ceftriaxone, as defined in Figure 3 of `Sánchez-Busó et al (2021) <https://doi.org/10.1186/s13073-021-00858-2>`_.
+   - **Susceptible to cat I/II drugs** - No determinants found for Azithromycin, Ceftriaxone, Cefixime (category I) or Benzylpenicillin, Ciprofloxacin, Spectinomycin (category II).
+
+Abbreviations
+~~~~~~~~~~~~~~
+
+.. container:: justify-text
+
+   - **MDR**: multidrug resistant (Resistant to one of Azithromycin / Ceftriaxone / Cefixime [category I representatives], plus two or more of Benzylpenicillin / Ciprofloxacin / Spectinomycin [category II representatives])
+   - **XDR**: extensively drug resistant (Resistant to two of Azithromycin / Ceftriaxone / Cefixime [category I representatives], plus three of Benzylpenicillin / Ciprofloxacin / Spectinomycin [category II representatives])
+
+   .. note::
+
+      These definitions are based on those defined in the `European CDC Response Plan <https://www.ecdc.europa.eu/sites/default/files/documents/multi-and-extensively-drug-resistant-gonorrhoea-response-plan-Europe-2019.pdf>`_, modified to use the specific representatives of category I and II antibiotic classes that are available in the dashboard.
+

--- a/docs/Org/senterica.rst
+++ b/docs/Org/senterica.rst
@@ -1,0 +1,32 @@
+Nontyphoidal *Salmonella*
+=========================
+
+
+.. container:: justify-text
+
+   Nontyphoidal *Salmonella* data in AMRnet are drawn from `Enterobase <https://enterobase.warwick.ac.uk/>`_, which calls AMR genotypes using NCBI’s `AMRFinderPlus <https://www.ncbi.nlm.nih.gov/pathogens/antimicrobial-resistance/AMRFinder/>`_, assigns lineages using 7-gene MLST. The last update was made in May 14th 2025.
+
+For information about Salmonella Typhi, please see the Typhi dashboard.
+
+.. warning::
+    The Salmonella enterica data used in AMRnet are not yet curated for purpose-of-sampling, and therefore reflect the biases of global sequencing efforts.
+
+Variable definitions
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. container:: justify-text
+
+
+    - **Genotype** - Pathogenwatch assigns sequence types (STs) using the 7-locus MLST scheme for Salmonella enterica, defined by XX.
+    - The genotypes reported here are from the X.
+    - Antimicrobial resistance determinants are described in the paper XXXX
+
+Abbreviations
+~~~~~~~~~~~~~~
+
+.. container:: justify-text
+
+    - 1. MDR, multidrug resistant (resistant to ampicillin, chloramphenicol, and trimethoprim-sulfamethoxazole)
+    - 2. XDR, extensively drug resistant (MDR plus resistant to ciprofloxacin and ceftriaxone)
+    - 3. Ciprofloxacin NS, ciprofloxacin non-susceptible (MIC >=0.06 mg/L, due to presence of one or more genes or mutations in *gyrA/parC/gyrB*)
+    - 4. Ciprofloxacin R, ciprofloxacin resistant (MIC >=0.5 mg/L, due to presence of multiple mutations and/or genes, see Carey et al, 2023 https://doi.org/10.7554/eLife.85867)

--- a/docs/Org/sentericaints.rst
+++ b/docs/Org/sentericaints.rst
@@ -1,0 +1,30 @@
+
+Invasive Nontyphoidal *Salmonella* 
+===================================
+
+.. container:: justify-text
+
+   *Salmonella* (invasive non-typhoidal) data in AMRnet are drawn from `Enterobase <https://enterobase.warwick.ac.uk/>`_, which calls AMR genotypes using NCBI’s `AMRFinderPlus <https://www.ncbi.nlm.nih.gov/pathogens/antimicrobial-resistance/AMRFinder/>`_, assigns lineages using MLST, `cgMLST <https://doi.org/10.1101/gr.251678.119>`_ and `hierarchical clustering <https://doi.org/10.1093/bioinformatics/btab234>`_, and assigns serotypes using `SISTR <https://doi.org/10.1371/journal.pone.0147101>`_. The iNTS dashboard currently includes all genomes identified as serotype Typhimurium or Enteritidis (which account for `>90% of iNTS <https://doi.org/10.1016/S1473-3099(21)00615-0>`_), and identifies lineages thereof using MLST. Last update: 24 January 2024.
+
+
+   The invasive non-typhoidal *Salmonella* (iNTS) dashboard is populated with data from specific *Salmonella enterica* lineages that are associated with invasive disease in low-income countries; namely serotype Typhimurium (ST19, ST313 and sublineages thereof as defined by `Van Puyvelde et al <https://doi.org/10.1038/s41467-023-41152-6>`_) and Enteritidis (Central/Eastern and West African clades as defined by `Fong et al <https://doi.org/10.1099/mgen.0.001017>`_). Together these account for `>90% of iNTS <https://doi.org/10.1016/S1473-3099(21)00615-0>`_. Data in AMRnet are drawn from `Enterobase <https://enterobase.warwick.ac.uk/>`_, which calls AMR genotypes using NCBI’s `AMRFinderPlus <https://www.ncbi.nlm.nih.gov/pathogens/antimicrobial-resistance/AMRFinder/>`_, assigns lineages using MLST, `cgMLST <https://doi.org/10.1101/gr.251678.119>`_ and `hierarchical clustering <https://doi.org/10.1093/bioinformatics/btab234>`_, and assigns serotypes using `SISTR <https://doi.org/10.1371/journal.pone.0147101>`_. Last update: 24 January 2024.
+
+   .. warning::
+      The iNTS data used in AMRnet are not yet curated for purpose-of-sampling, and therefore reflect the biases of global sequencing efforts which may be skewed towards sequencing AMR strains and/or outbreaks. Data curation efforts are ongoing however until then, please be careful when interpreting the data in the dashboard.
+
+Variable definitions
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. container:: justify-text
+    
+   - **Lineages**: Lineages are labeled by iTYM (invasive Typhimurium) or iENT (invasive Enteritidis) followed by the lineage name, defined from cgMLST as follows:
+
+   * iTYM ST19-L1: HC150-305
+   * iTYM ST19-L3: HC150=1547
+   * iTYM ST19-L4: HC150=48
+   * iTYM ST313-L1: HC150=9882
+   * iTYM ST313-L2: HC150=728 and HC50=728
+   * iENT CEAC: HC150=12675
+   * iENT WAC: HC150=2452
+
+   - **AMR determinants**: `Enterobase <https://enterobase.warwick.ac.uk/>`_ identifies AMR determinants using NCBI’s `AMRFinderPlus <https://www.ncbi.nlm.nih.gov/pathogens/antimicrobial-resistance/AMRFinder/>`_. AMRnet imports these AMR genotype calls, and assigns them to drugs/classes in the dashboard using the Subclass curated in `refgenes <https://doi.org/10.1099/mgen.0.000832>`_.

--- a/docs/Org/shige.rst
+++ b/docs/Org/shige.rst
@@ -1,0 +1,19 @@
+*Shigella* + EIEC
+==================
+
+.. container:: justify-text
+
+   *Shigella* and enteroinvasive *E. coli* (EIEC) data in AMRnet are drawn from `Enterobase <https://enterobase.warwick.ac.uk/>`__, which calls AMR genotypes using NCBI’s `AMRFinderPlus <https://www.ncbi.nlm.nih.gov/pathogens/antimicrobial-resistance/AMRFinder/>`_ and assigns lineages using `cgMLST <https://doi.org/10.1101/gr.251678.119>`_ and `hierarchical clustering <https://doi.org/10.1093/bioinformatics/btab234>`_. Last update: 24 January 2024.
+
+   .. warning::
+
+      The *Shigella* + EIEC data used in AMRnet are not yet curated for purpose-of-sampling, and therefore reflect the biases of global sequencing efforts which may be skewed towards sequencing AMR strains and/or outbreaks. Data curation efforts are ongoing however until then, please be careful when interpreting the data in the dashboard.
+
+Variable definitions
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. container:: justify-text
+
+   - **Lineages**: The logic used by `Enterobase <https://doi.org/10.1101/gr.251678.119>`__ to classify genomes as *Shigella* or EIEC are detailed `here <https://enterobase.readthedocs.io/en/latest/pipelines/backend-pipeline-phylotypes.html?highlight=shigella>`__. *Shigella sonnei* are monophyletic and labelled as lineage ‘S. *sonnei*’. For other *Shigella*, lineages are labeled by the species followed by the HC400 (`HierCC <https://enterobase.readthedocs.io/en/latest/features/clustering.html>`_) cluster ID (as this nomenclature has been `shown <https://doi.org/10.1038/s41467-022-28121-1>`_ to mirror the paraphyletic lineage structure of *Shigella*). EIEC lineages are labeled by ST (e.g. ‘EIEC ST99’).
+   - **AMR determinants**: `Enterobase <https://enterobase.warwick.ac.uk/>`__ identifies AMR determinants using NCBI’s `AMRFinderPlus <https://www.ncbi.nlm.nih.gov/pathogens/antimicrobial-resistance/AMRFinder/>`_. AMRnet imports these AMR genotype calls, and assigns them to drugs/classes in the dashboard using the Subclass curated in `refgenes <https://doi.org/10.1099/mgen.0.000832>`_.
+

--- a/docs/Org/styphi.rst
+++ b/docs/Org/styphi.rst
@@ -1,0 +1,18 @@
+*Salmonella* Typhi
+==================
+.. container:: justify-text
+
+   *Salmonella* Typhi data in AMRnet are drawn from `Pathogenwatch <http://Pathogen.watch>`__, which calls AMR determinants and `GenoTyphi <https://doi.org/10.1093/infdis/jiab414>`_ genotypes from genome assemblies. The *Salmonella* Typhi data in Pathogenwatch are curated by the `Global Typhoid Genomics Consortium <https://www.typhoidgenomics.org>`_, as described `here <https://doi.org/10.7554/eLife.85867>`_. The prevalence estimates shown are calculated using genome collections derived from non-targeted sampling frames (i.e. surveillance and burden studies, as opposed to AMR focused studies or outbreak investigations) with known year of isolation and country of origin. Last update: 12 November 2024.
+
+   **Variable definitions**
+
+   - **Genotypes**: GenoTyphi scheme, see `Dyson & Holt, 2021 <https://doi.org/10.1093/infdis/jiab414>`_.
+   - **AMR determinants** are described in the `Typhi Pathogenwatch paper <https://doi.org/10.1038/s41467-021-23091-2>`_.
+   - **Travel-associated cases** are attributed to the country of travel, not the country of isolation, see `Ingle et al, 2019 <https://doi.org/10.1371/journal.pntd.0007620>`_.
+
+   **Abbreviations**
+
+   - **MDR**: multidrug resistant (resistant to ampicillin, chloramphenicol, and trimethoprim-sulfamethoxazole)
+   - **XDR**: extensively drug resistant (MDR plus resistant to ciprofloxacin and ceftriaxone)
+   - **Ciprofloxacin NS**: ciprofloxacin non-susceptible (MIC >=0.06 mg/L, due to presence of one or more *qnr* genes or mutations in *gyrA/parC/gyrB*)
+   - **Ciprofloxacin R**: ciprofloxacin resistant (MIC >=0.5 mg/L, due to presence of multiple mutations and/or genes)

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -1,4 +1,4 @@
-Data Dictionary
+Data access
 ===============
 
 .. container:: justify-text

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,123 +1,81 @@
+AMRnet
+======
+
+.. container:: justify-text
+
+   The `AMRnet <https://www.amrnet.org/>`_ aims to make high-quality, robust and reliable genome-derived AMR surveillance data accessible to a wide audience. Visualizations are geared towards showing national annual AMR prevalence estimates and trends, that can be broken down and explored in terms of underlying genotypes and resistance mechanisms. We do not generate sequence data, but we hope that by making publicly deposited data more accessible and useful, we can encourage and motivate more sequencing and data sharing.
+
+   We started with Salmonella Typhi, built on our `TyphiNET <https://www.typhi.net>`_ dashboard which uses data curated by the `Global Typhoid Genomics Consortium <http://typhoidgenomics.org>`_ (to improve data quality and identify which datasets are suitable for inclusion) and analysed in `Pathogenwatch <http://pathogen.watch>`_ (to call AMR determinants and lineages from sequence data). Dashboards are now available for Klebsiella pneumoniae, Neisseria gonorrhoeae, non-typhoidal Salmonella, E. coli and Shigella using data sourced from the `Pathogenwatch <http://pathogen.watch>`_ and `Enterobase <https://enterobase.warwick.ac.uk/>`_ platforms. In the future, we hope to add additional organisms, sourced from these and other platforms.
+
+   A major barrier to using public data for surveillance is the need for careful data curation, to identify which datasets are relevant for inclusion in pooled estimates of AMR and genotype prevalence. This kind of curation can benefit a wide range of users and we plan to work with other organism communities to curate data, and to contribute to wider efforts around metadata standards. Please get in touch if you would like to work with us (`amrnetdashboard@gmail.com <amrnetdashboard@gmail.com>`_)
+
+   Find out more about the project team (based at London School of Hygiene and Tropical Medicine), and our policy advisory group, `here <https://www.lshtm.ac.uk/amrnet>`__.
+
+   The dashboard code is open access and available in `GitHub <https://github.com/amrnet/amrnet>`_. Issues and feature requests can be posted `here <https://github.com/amrnet/amrnet/issues>`__. API access is described on the :doc:`/data` page.
+
+Citation for AMRnet
+-------------------
+
+.. container:: justify-text
+
+   If you use the AMRnet website or code, please cite AMRnet (Louise Cerdeira, Vandana Sharma, Kathryn Holt), **GitHub**: https://github.com/amrnet/amrnet, **DOI**: 10.5281/zenodo.10810219
+
+
+   If you want to install the AMRnet code to develop your own dashboard instances,
+   follow the installation instructions in the :doc:`Installation Guide <installation>`.
+
+
+
+License
+-------
+.. container:: justify-text
+
+   Distributed under the terms of the :doc:`GPLv3 License <license>`.
+
+   ``AMRnet`` is free and open source software.
+
+Support
+-------
+.. container:: justify-text
+
+   Found a bug 🐛, or have a feature request ✨, raise an issue on the
+   GitHub `issue
+   tracker <https://github.com/amrnet/amrnet/issues>`_.
+   Alternatively you can get support on the
+   `discussions <https://github.com/amrnet/amrnet/discussions>`_
+   page.
+
+Disclaimer
+----------
+.. container:: justify-text
+
+   ``AMRnet`` is an open source dashboard that continues to benefit from
+   the collaboration of many contributors. Although efforts have been made to ensure the
+   that relevant web development standards are implemented, it remains the
+   user's responsibility to confirm and accept the output. Refer to the
+   :doc:`License <license>` for clarification of the conditions of use.
+   
 .. autosummary::
     :toctree: gen
     :template: custom-module-template.rst
     :recursive:
 
 .. toctree::
-    :caption: User Resources
+    :caption: Dashboard users
     :hidden:
-
-    User Tutorial <tutorial>
-    User guide <userguide>
-    Dashboard usage <usage>
-    Data rights <right>
+    
+    AMRnet <index>
+    Dashboard overview <usage>
 
 .. toctree::
-    :caption: API & Integration
+    :caption: API users
     :hidden:
 
     API Reference <api>
-    Dashboard Architecture <architecture>
-    FARM Stack GUI <gui>
-    Data Dictionary <data>
+    Data access <data>
 
 .. toctree::
-    :caption: For developers
+    :caption: Developers
     :hidden:
 
-    Installation <installation>
-    Features <feature>
-    Performance Optimization <performance>
-    Deployment Guide <deployment>
-    Security Guide <security>
-    Internationalization <internationalization>
-    Professional Translation Services <professional-translation-services>
-    Troubleshooting <troubleshooting>
-    Contributor Guide <contributing>
-    Code of Conduct <codeofconduct>
-    License <license>
-    .. Changelog <https://github.com/amrnet/amrnet/releases>
-
-
-.. .. image:: assets/amrnet-logo.png
-..     :class: only-light
-..     :width: 25%
-.. .. image:: assets/amrnet-logo.png
-..     :class: only-dark
-..     :width: 25%
-
-Overview
-========
-.. container:: justify-text
-
-    **AMRnet** aims to make high-quality, robust and reliable genome-derived
-    AMR Surveillance data accessible to a wide audience. Visualizations
-    are geared towards showing national annual AMR prevalence estimates
-    and trends, that can be broken down and explored in terms of underlying
-    genotypes and resistance mechanisms. We do not generate sequence data,
-    but we hope that by making publicly deposited data more accessible and
-    useful, we can encourage and motivate more sequencing and data sharing.
-
-    `Subscribe <https://amrnet.beehiiv.com/subscribe>`_ to the **AMRnet** mailing list!
-
-Quick start
------------
-.. container:: justify-text
-
-    **For Users:** Visit the live dashboard at `AMRnet.org <https://www.amrnet.org>`_
-
-    **For Developers:** Get started with local development:
-
-    .. code-block:: shell
-
-        git clone https://github.com/amrnet/amrnet.git
-        cd amrnet
-        npm install
-        cd client && npm install && cd ..
-        npm run start:dev
-
-    See :ref:`label-installation` for complete installation instructions.
-
-Features
---------
-.. container:: justify-text
-
-    See the complete list of ``AMRnet`` features :ref:`here<label-features>`.
-
-Contributing
-------------
-.. container:: justify-text
-
-    Contributions are very welcome. To learn more, see the :ref:`Contributor Guide<label-contributing>`.
-
-License
--------
-.. container:: justify-text
-
-    Distributed under the terms of the :doc:`GPLv3 License <license>` ``AMRnet``
-    is free and open source software.
-
-Support
--------
-.. container:: justify-text
-
-    Found a bug 🐛, or have a feature request ✨, raise an issue on the
-    GitHub `issue
-    tracker <https://github.com/amrnet/amrnet/issues>`_.
-    Alternatively you can get support on the
-    `discussions <https://github.com/amrnet/amrnet/discussions>`_
-    page.
-
-Disclaimer
-----------
-.. container:: justify-text
-
-    **AMRnet** is an open source dashboard that continues to benefit from the
-    collaboration of many contributors. Although efforts have been made
-    to ensure the that relevant web development standards are implemented,
-    it remains the user’s responsibility to confirm and accept the output.
-    Refer to the :doc:`License <license>` for clarification of the conditions
-    of use.
-
-Acknowledgements
-----------------
+    Developer Guide <installation>

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,7 +1,24 @@
 .. _label-installation:
 
-Installation
-============
+Developer Guide
+===============
+
+.. toctree::
+    :maxdepth: 2
+    :hidden:
+
+    Features <feature>
+    Performance Optimization <performance>
+    Deployment Guide <deployment>
+    Security Guide <security>
+    Internationalization <internationalization>
+    Professional Translation Services <professional-translation-services>
+    Troubleshooting <troubleshooting>
+    Contributor Guide <contributing>
+    Code of Conduct <codeofconduct>
+    License <license>
+
+
 .. container:: justify-text
 
     These instructions will get you a copy of ``AMRnet`` up and running on your

--- a/docs/right.rst
+++ b/docs/right.rst
@@ -1,16 +1,7 @@
-Data Usage
-==========
-.. container:: justify-text
 
-    AMRnet retrieves and processes publicly accessible data from `Pathogenwatch <https://pathogen.watch/>`_ and `Enterobase <https://enterobase.warwick.ac.uk/>`_. All data is public domain and there are no usage restrictions, however we ask that if you use the `dashboard <https://www.amrnet.org/>`_ or data downloads, you provide appropriate attribution to:
-
-    1. AMRnet (citation below)
-    2. The relevant data source platform (Pathogenwatch or Enterobase, depending on the pathogen)
-    3. The relevant primary data sources, if you are focusing on data from a specific country or set of studies. (Individual genome accessions, bioprojects, and pubmed identifiers for each genome can be found in the AMRnet database downloads.)
-
-Citation
---------
-.. container:: justify-text
+.. Citation
+.. --------
+.. .. container:: justify-text
    
 
-    If you use the AMRnet website or code, please cite AMRnet (Louise Cerdeira, Vandana Sharma, Mary Maranga, Megan Carey, Zoe Dyson, Kathryn Holt), **GitHub**: https://github.com/amrnet/amrnet, **DOI**: 10.5281/zenodo.10810219
+..     If you use the AMRnet website or code, please cite AMRnet (Louise Cerdeira, Vandana Sharma, Mary Maranga, Megan Carey, Zoe Dyson, Kathryn Holt), **GitHub**: https://github.com/amrnet/amrnet, **DOI**: 10.5281/zenodo.10810219

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,15 +1,33 @@
 Dashboard overview
-==================
+====================
+
+.. toctree::
+    :maxdepth: 2
+    :hidden:
+
+    Escherichia coli  <Org/ecoli>
+    Escherichia coli diarrheagenic <Org/decoli>
+    Shigella + EIEC <Org/shige>
+    Klebsiella pneumoniae <Org/kpneumo>
+    Neisseria gonorrhoeae <Org/ngono>
+    Nontyphoidal Salmonella <Org/senterica>
+    Invasive Nontyphoidal Salmonella <Org/sentericaints>
+    Salmonella Typhi <Org/styphi>
+
 .. container:: justify-text
 
-   **Header**: Use the menu to **select a species or pathogen group** to display. Each pathogen has its own dashboard configuration that is customised to show genotypes, resistances and other relevant parameters. Numbers indicate the total number of genomes and genotypes currently available in the selected dashboard.
+   **Header**
+
+   Use the menu to **select a species or pathogen group** to display. Each pathogen has its own dashboard configuration that is customised to show genotypes, resistances and other relevant parameters. Numbers indicate the total number of genomes and genotypes currently available in the selected dashboard.
 
    .. figure:: assets/header.png
       :width: 100%
       :align: center
       :alt: header
 
-   **Map**: Use the **Plotting options** panel on the right to **select a variable to display per-country summary data** on the world map. Prevalence data are pooled weighted estimates of proportion for the selected resistance or genotype. Use the **Global filters** panel on the left to recalculate summary data for a specific time period and/or subgroup/s (options available vary by pathogen). A country must have N≥20 samples (using the current filters) for summary data to be displayed otherwise, it will be coloured grey to indicate insufficient data are available.
+   **Map**
+
+   Use the **Plotting options** panel on the right to **select a variable to display per-country summary data** on the world map. Prevalence data are pooled weighted estimates of proportion for the selected resistance or genotype. Use the **Global filters** panel on the left to recalculate summary data for a specific time period and/or subgroup/s (options available vary by pathogen). A country must have N≥20 samples (using the current filters) for summary data to be displayed otherwise, it will be coloured grey to indicate insufficient data are available.
    Filters set in this panel apply not only to the map, but to all plots on the page. **Clicking on a country in the map** also functions as a filter, so that the **Summary plots** in the panels below reflect data for the selected country only. Per-country values displayed in the map can be downloaded by clicking the downward-arrow button at the top right of the panel. A static image (PNG format) of the current map view can be downloaded by clicking the camera icon.
 
    .. figure:: assets/map.png
@@ -17,14 +35,15 @@ Dashboard overview
       :align: center
       :alt: map
 
-   **Summary plots**: This panel offers a series of summary plots. The default view is "AMR trends". **Click a plot title** in the rotating selector at the top of the panel, to choose a different plot. The specific plots available vary by pathogen, as do the definitions of AMR and genotype variables (see per-organism details below). Summary plots are intended to show region- or country-level summaries, but if no country is selected they will populate with pooled estimates of proportion across all data passing the current filters.
+   **Summary plots**
+
+   This panel offers a series of summary plots. The default view is "AMR trends". **Click a plot title** in the rotating selector at the top of the panel, to choose a different plot. The specific plots available vary by pathogen, as do the definitions of AMR and genotype variables (see per-organism details below). Summary plots are intended to show region- or country-level summaries, but if no country is selected they will populate with pooled estimates of proportion across all data passing the current filters.
 
    All plots are interactive. Use the **Plotting options** panel on the right to modify the region/country to display, or to select other options available for the current plot such as which variables to display, and whether to show **counts or percentages**.
 
    Each plot has a dynamic legend to the right; click on an x-axis value to display counts and percentages of secondary variables calculated amongst genomes matching that x-axis value. For example, most pathogens will have a ‘AMR by genotype’ plot; click a genotype to display counts and percentages of resistance estimated for each drug or class.
 
    Summarised values displayed in the current plot can be downloaded by clicking the downward-arrow button at the top of the Summary plots panel. A static image (PNG format) of the current plotting view can be downloaded by clicking the camera icon.
-
 
 
    .. added summary plots figure
@@ -34,164 +53,14 @@ Dashboard overview
       :align: center
       :alt: summary
 
-   **Downloads**: At the bottom are buttons to download (1) the individual genome-level information that is used to populate the dashboard (‘Download database (CSV format)’); and (2) a static report of the currently displayed plots, together with a basic description of the data sources and variable definitions (‘Download PDF’). Please note PDF reports are not yet available for all organisms, they will be added in future updates.
+   **Downloads**
+
+   At the bottom are buttons to download (1) the individual genome-level information that is used to populate the dashboard (‘Download database (CSV format)’); and (2) a static report of the currently displayed plots, together with a basic description of the data sources and variable definitions (‘Download PDF’). Please note PDF reports are not yet available for all organisms, they will be added in future updates.
 
    .. figure::  assets/downloads.png
       :width: 100%
       :align: center
       :alt: downloads
 
-   .. note::
-      Please note PDF reports are not yet available for all organisms, they will be added in future updates.
-
-Individual pathogen details
----------------------------
-
-*Salmonella* Typhi
-~~~~~~~~~~~~~~~~~~
-.. container:: justify-text
-
-   *Salmonella* Typhi data in AMRnet are drawn from `Pathogenwatch <http://Pathogen.watch>`__, which calls AMR determinants and `GenoTyphi <https://doi.org/10.1093/infdis/jiab414>`_ genotypes from genome assemblies. The *Salmonella* Typhi data in Pathogenwatch are curated by the `Global Typhoid Genomics Consortium <https://www.typhoidgenomics.org>`_, as described `here <https://doi.org/10.7554/eLife.85867>`_. The prevalence estimates shown are calculated using genome collections derived from non-targeted sampling frames (i.e. surveillance and burden studies, as opposed to AMR focused studies or outbreak investigations) with known year of isolation and country of origin. Last update: 12 November 2024.
-
-   **Variable definitions**
-
-   - **Genotypes**: GenoTyphi scheme, see `Dyson & Holt, 2021 <https://doi.org/10.1093/infdis/jiab414>`_.
-   - **AMR determinants** are described in the `Typhi Pathogenwatch paper <https://doi.org/10.1038/s41467-021-23091-2>`_.
-   - **Travel-associated cases** are attributed to the country of travel, not the country of isolation, see `Ingle et al, 2019 <https://doi.org/10.1371/journal.pntd.0007620>`_.
-
-   **Abbreviations**
-
-   - **MDR**: multidrug resistant (resistant to ampicillin, chloramphenicol, and trimethoprim-sulfamethoxazole)
-   - **XDR**: extensively drug resistant (MDR plus resistant to ciprofloxacin and ceftriaxone)
-   - **Ciprofloxacin NS**: ciprofloxacin non-susceptible (MIC >=0.06 mg/L, due to presence of one or more *qnr* genes or mutations in *gyrA/parC/gyrB*)
-   - **Ciprofloxacin R**: ciprofloxacin resistant (MIC >=0.5 mg/L, due to presence of multiple mutations and/or genes)
-
-*Klebsiella pneumoniae*
-~~~~~~~~~~~~~~~~~~~~~~~
-*Klebsiella pneumoniae* data are sourced from `Pathogenwatch <https://doi.org/10.1093/cid/ciab784>`__, which calls AMR (using `Kleborate <https://github.com/klebgenomics/Kleborate>`_) and genotypes (`MLST <https://doi.org/10.1128/jcm.43.8.4178-4182.2005>`__) from genomes assembled from public data. Last update: 24 May 2025.
-
-.. warning:: The *Klebsiella pneumoniae* data used in AMRnet are not yet curated for purpose-of-sampling, and therefore reflect the biases of global sequencing efforts which have been largely directed at sequencing ESBL and carbapenemase-producing strains or hypervirulent strains. Data curation efforts are ongoing however until then, please be careful when interpreting the data in the dashboard.
-
-**Variable definitions**
-
-- **Genotypes**: `7-locus MLST scheme <https://doi.org/10.1128/jcm.43.8.4178-4182.2005>`_ for Klebsiella pneumoniae, and sublineages (defined from core-genome MLST, as described `here <https://doi.org/10.1093/molbev/msac135>`__), maintained by `Institut Pasteur <https://bigsdb.pasteur.fr/klebsiella/>`_.
-- **AMR determinants** are called using `Kleborate v3 <https://github.com/klebgenomics/Kleborate>`_, described `here <https://doi.org/10.1038/s41467-021-24448-3>`__. Fluoroquinolone resistance is defined as presence of an acquired qnr/qep gene OR a mutation in the quinolone-resistance determining regions of gyrA or parC.
-- **No acquired resistance**: no resistance determinants identified besides a wildtype beta-lactamase SHV allele associated with intrinsic resistance to ampicillin (i.e. not an ESBL or inhibitor-resistant variant of SHV, see `Tsang et al 2024 <https://www.microbiologyresearch.org/content/journal/mgen/10.1099/mgen.0.001294>`_.
-
-**Abbreviations**
-
-- **ESBL**: extended-spectrum beta-lactamase
-- **3GC**: third-generation cephalosporins
-- **ST**: sequence type
-- **cgST**: core-genome sequence type
-
-*Neisseria gonorrhoeae*
-~~~~~~~~~~~~~~~~~~~~~~~
-
-.. container:: justify-text
-
-   *Neisseria gonorrhoeae* data are sourced from `Pathogenwatch <https://doi.org/10.1186/s13073-021-00858-2>`__, which calls AMR and lineage `genotypes <https://pubmlst.org/neisseria/>`_ (`MLST <https://doi.org/10.1186/1741-7007-5-35>`_, `NG-MAST <https://doi.org/10.1086/383047>`_) from genomes assembled from public data. The prevalence estimates shown are calculated using genome collections derived from non-targeted sampling frames (i.e. surveillance and burden studies, as opposed to AMR focused studies or outbreak investigations). These include EuroGASP `2013 <https://doi.org/10.1016/s1473-3099(18)30225-1>`_ & `2018 <https://doi.org/10.1016/s2666-5247(22)00044-1>`_, and several national surveillance studies. Last update: 24 January 2024.
-
-   **Variable definitions**
-
-   - **Genotypes**: sequence types from the `7-locus MLST scheme <https://doi.org/10.1128/jcm.43.8.4178-4182.2005>`_ for **Neisseria**, or 2-locus **N. gonorrhoeae** multi-antigen sequence typing (`NG-MAST <https://doi.org/10.1086/383047>`_) scheme, both hosted by `PubMLST <https://pubmlst.org/neisseria/>`_.
-   - **AMR determinants** are identified by Pathogenwatch using an inhouse dictionary developed and maintained in consultation with an expert advisory group, described `here <https://doi.org/10.1186/s13073-021-00858-2>`__.
-   - **AMR determinants within genotypes** - This plot shows combinations of determinants that result in clinical resistance to Azithromycin or Ceftriaxone, as defined in Figure 3 of `Sánchez-Busó et al (2021) <https://doi.org/10.1186/s13073-021-00858-2>`_.
-   - **Susceptible to cat I/II drugs** - No determinants found for Azithromycin, Ceftriaxone, Cefixime (category I) or Benzylpenicillin, Ciprofloxacin, Spectinomycin (category II).
-
-   **Abbreviations**
-
-   - **MDR**: multidrug resistant (Resistant to one of Azithromycin / Ceftriaxone / Cefixime [category I representatives], plus two or more of Benzylpenicillin / Ciprofloxacin / Spectinomycin [category II representatives])
-   - **XDR**: extensively drug resistant (Resistant to two of Azithromycin / Ceftriaxone / Cefixime [category I representatives], plus three of Benzylpenicillin / Ciprofloxacin / Spectinomycin [category II representatives])
-
-   .. note::
-
-      These definitions are based on those defined in the `European CDC Response Plan <https://www.ecdc.europa.eu/sites/default/files/documents/multi-and-extensively-drug-resistant-gonorrhoea-response-plan-Europe-2019.pdf>`_, modified to use the specific representatives of category I and II antibiotic classes that are available in the dashboard.
-
-
-*Escherichia coli*
-~~~~~~~~~~~~~~~~~~
-
-.. container:: justify-text
-
-   *Escherichia coli* data in AMRnet are drawn from `Enterobase <https://enterobase.warwick.ac.uk/>`__, which calls AMR genotypes using NCBI’s `AMRFinderPlus <https://www.ncbi.nlm.nih.gov/pathogens/antimicrobial-resistance/AMRFinder/>`_ and assigns lineages using MLST, `cgMLST <https://doi.org/10.1101/gr.251678.119>`_ and `hierarchical clustering <https://doi.org/10.1093/bioinformatics/btab234>`_. Last update: 24 January 2024.
-
-   .. warning::
-      The *E. coli* data used in AMRnet are not yet curated for purpose-of-sampling, and therefore reflect the biases of global sequencing efforts which may be skewed towards sequencing AMR strains and/or outbreaks. Data curation efforts are ongoing however until then, please be careful when interpreting the data in the dashboard.
-
-   **Variable definitions**
-
-   - **Lineages**: Lineages are labeled by 7-locus sequence type (ST).
-
-   - **AMR determinants**: `Enterobase <https://enterobase.warwick.ac.uk/>`_ identifies AMR determinants using NCBI’s `AMRFinderPlus <https://www.ncbi.nlm.nih.gov/pathogens/antimicrobial-resistance/AMRFinder/>`_. AMRnet imports these AMR genotype calls, and assigns them to drugs/classes in the dashboard using the Subclass curated in `refgenes <https://doi.org/10.1099/mgen.0.000832>`_.
-
-
-*Escherichia coli* (diarrheagenic)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. container:: justify-text
-
-   Enterobase classifies *E. coli* genomes to pathotypes using `this logic <https://enterobase.readthedocs.io/en/latest/pipelines/backend-pipeline-phylotypes.html?highlight=pathovar>`__. Pathotypes included in the *E. coli* (diarrheagenic) dashboard are:
-
-   - Shiga toxin-producing *E. coli* (STEC)
-   - Enterohemorrhagic *E. coli* (EHEC)
-   - Enterotoxigenic *E. coli* (ETEC)
-   - Enteropathogenic *E. coli* (EPEC)
-   - Enteroinvasive *E. coli* (EIEC)
-
-   Last update: 24 January 2024.
-
-   .. warning::
-      The *E. coli* data used in AMRnet are not yet curated for purpose-of-sampling, and therefore reflect the biases of global sequencing efforts which may be skewed towards sequencing AMR strains and/or outbreaks. Data curation efforts are ongoing however until then, please be careful when interpreting the data in the dashboard.
-
-   **Variable definitions**
-
-   - **Lineages**: Lineages are labeled by the pathovar followed by the (7-locus) ST.
-
-   - **AMR determinants**: `Enterobase <https://enterobase.warwick.ac.uk/>`_ identifies AMR determinants using NCBI’s `AMRFinderPlus <https://www.ncbi.nlm.nih.gov/pathogens/antimicrobial-resistance/AMRFinder/>`_. AMRnet imports these AMR genotype calls, and assigns them to drugs/classes in the dashboard using the Subclass curated in `refgenes <https://doi.org/10.1099/mgen.0.000832>`_.
-
-
-*Shigella* + EIEC
-~~~~~~~~~~~~~~~~~
-
-.. container:: justify-text
-
-   *Shigella* and enteroinvasive *E. coli* (EIEC) data in AMRnet are drawn from `Enterobase <https://enterobase.warwick.ac.uk/>`__, which calls AMR genotypes using NCBI’s `AMRFinderPlus <https://www.ncbi.nlm.nih.gov/pathogens/antimicrobial-resistance/AMRFinder/>`_ and assigns lineages using `cgMLST <https://doi.org/10.1101/gr.251678.119>`_ and `hierarchical clustering <https://doi.org/10.1093/bioinformatics/btab234>`_. Last update: 24 January 2024.
-
-   .. warning::
-
-      The *Shigella* + EIEC data used in AMRnet are not yet curated for purpose-of-sampling, and therefore reflect the biases of global sequencing efforts which may be skewed towards sequencing AMR strains and/or outbreaks. Data curation efforts are ongoing however until then, please be careful when interpreting the data in the dashboard.
-
-   **Variable definitions**
-
-   - **Lineages**: The logic used by `Enterobase <https://doi.org/10.1101/gr.251678.119>`__ to classify genomes as *Shigella* or EIEC are detailed `here <https://enterobase.readthedocs.io/en/latest/pipelines/backend-pipeline-phylotypes.html?highlight=shigella>`__. *Shigella sonnei* are monophyletic and labelled as lineage ‘S. *sonnei*’. For other *Shigella*, lineages are labeled by the species followed by the HC400 (`HierCC <https://enterobase.readthedocs.io/en/latest/features/clustering.html>`_) cluster ID (as this nomenclature has been `shown <https://doi.org/10.1038/s41467-022-28121-1>`_ to mirror the paraphyletic lineage structure of *Shigella*). EIEC lineages are labeled by ST (e.g. ‘EIEC ST99’).
-   - **AMR determinants**: `Enterobase <https://enterobase.warwick.ac.uk/>`__ identifies AMR determinants using NCBI’s `AMRFinderPlus <https://www.ncbi.nlm.nih.gov/pathogens/antimicrobial-resistance/AMRFinder/>`_. AMRnet imports these AMR genotype calls, and assigns them to drugs/classes in the dashboard using the Subclass curated in `refgenes <https://doi.org/10.1099/mgen.0.000832>`_.
-
-
-
-*Salmonella* (invasive non-typhoidal)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. container:: justify-text
-
-   *Salmonella* (invasive non-typhoidal) data in AMRnet are drawn from `Enterobase <https://enterobase.warwick.ac.uk/>`_, which calls AMR genotypes using NCBI’s `AMRFinderPlus <https://www.ncbi.nlm.nih.gov/pathogens/antimicrobial-resistance/AMRFinder/>`_, assigns lineages using MLST, `cgMLST <https://doi.org/10.1101/gr.251678.119>`_ and `hierarchical clustering <https://doi.org/10.1093/bioinformatics/btab234>`_, and assigns serotypes using `SISTR <https://doi.org/10.1371/journal.pone.0147101>`_. The iNTS dashboard currently includes all genomes identified as serotype Typhimurium or Enteritidis (which account for `>90% of iNTS <https://doi.org/10.1016/S1473-3099(21)00615-0>`_), and identifies lineages thereof using MLST. Last update: 24 January 2024.
-
-
-   The invasive non-typhoidal *Salmonella* (iNTS) dashboard is populated with data from specific *Salmonella enterica* lineages that are associated with invasive disease in low-income countries; namely serotype Typhimurium (ST19, ST313 and sublineages thereof as defined by `Van Puyvelde et al <https://doi.org/10.1038/s41467-023-41152-6>`_) and Enteritidis (Central/Eastern and West African clades as defined by `Fong et al <https://doi.org/10.1099/mgen.0.001017>`_). Together these account for `>90% of iNTS <https://doi.org/10.1016/S1473-3099(21)00615-0>`_. Data in AMRnet are drawn from `Enterobase <https://enterobase.warwick.ac.uk/>`_, which calls AMR genotypes using NCBI’s `AMRFinderPlus <https://www.ncbi.nlm.nih.gov/pathogens/antimicrobial-resistance/AMRFinder/>`_, assigns lineages using MLST, `cgMLST <https://doi.org/10.1101/gr.251678.119>`_ and `hierarchical clustering <https://doi.org/10.1093/bioinformatics/btab234>`_, and assigns serotypes using `SISTR <https://doi.org/10.1371/journal.pone.0147101>`_. Last update: 24 January 2024.
-
-   .. warning::
-      The iNTS data used in AMRnet are not yet curated for purpose-of-sampling, and therefore reflect the biases of global sequencing efforts which may be skewed towards sequencing AMR strains and/or outbreaks. Data curation efforts are ongoing however until then, please be careful when interpreting the data in the dashboard.
-
-   **Variable definitions**
-
-   - **Lineages**: Lineages are labeled by iTYM (invasive Typhimurium) or iENT (invasive Enteritidis) followed by the lineage name, defined from cgMLST as follows:
-
-   * iTYM ST19-L1: HC150-305
-   * iTYM ST19-L3: HC150=1547
-   * iTYM ST19-L4: HC150=48
-   * iTYM ST313-L1: HC150=9882
-   * iTYM ST313-L2: HC150=728 and HC50=728
-   * iENT CEAC: HC150=12675
-   * iENT WAC: HC150=2452
-
-   - **AMR determinants**: `Enterobase <https://enterobase.warwick.ac.uk/>`_ identifies AMR determinants using NCBI’s `AMRFinderPlus <https://www.ncbi.nlm.nih.gov/pathogens/antimicrobial-resistance/AMRFinder/>`_. AMRnet imports these AMR genotype calls, and assigns them to drugs/classes in the dashboard using the Subclass curated in `refgenes <https://doi.org/10.1099/mgen.0.000832>`_.
+   .. .. note::
+   ..    Please note PDF reports are not yet available for all organisms, they will be added in future updates.

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -1,80 +1,80 @@
-AMRnet
-======
+.. AMRnet
+.. ======
 
-.. container:: justify-text
+.. .. container:: justify-text
 
-   The `AMRnet <https://www.amrnet.org/>`_ aims to make high-quality, robust and reliable genome-derived AMR surveillance data accessible to a wide audience. Visualizations are geared towards showing national annual AMR prevalence estimates and trends, that can be broken down and explored in terms of underlying genotypes and resistance mechanisms. We do not generate sequence data, but we hope that by making publicly deposited data more accessible and useful, we can encourage and motivate more sequencing and data sharing.
+..    The `AMRnet <https://www.amrnet.org/>`_ aims to make high-quality, robust and reliable genome-derived AMR surveillance data accessible to a wide audience. Visualizations are geared towards showing national annual AMR prevalence estimates and trends, that can be broken down and explored in terms of underlying genotypes and resistance mechanisms. We do not generate sequence data, but we hope that by making publicly deposited data more accessible and useful, we can encourage and motivate more sequencing and data sharing.
 
-   We started with Salmonella Typhi, built on our `TyphiNET <https://www.typhi.net>`_ dashboard which uses data curated by the `Global Typhoid Genomics Consortium <http://typhoidgenomics.org>`_ (to improve data quality and identify which datasets are suitable for inclusion) and analysed in `Pathogenwatch <http://pathogen.watch>`_ (to call AMR determinants and lineages from sequence data). Dashboards are now available for Klebsiella pneumoniae, Neisseria gonorrhoeae, non-typhoidal Salmonella, E. coli and Shigella using data sourced from the `Pathogenwatch <http://pathogen.watch>`_ and `Enterobase <https://enterobase.warwick.ac.uk/>`_ platforms. In the future, we hope to add additional organisms, sourced from these and other platforms.
+..    We started with Salmonella Typhi, built on our `TyphiNET <https://www.typhi.net>`_ dashboard which uses data curated by the `Global Typhoid Genomics Consortium <http://typhoidgenomics.org>`_ (to improve data quality and identify which datasets are suitable for inclusion) and analysed in `Pathogenwatch <http://pathogen.watch>`_ (to call AMR determinants and lineages from sequence data). Dashboards are now available for Klebsiella pneumoniae, Neisseria gonorrhoeae, non-typhoidal Salmonella, E. coli and Shigella using data sourced from the `Pathogenwatch <http://pathogen.watch>`_ and `Enterobase <https://enterobase.warwick.ac.uk/>`_ platforms. In the future, we hope to add additional organisms, sourced from these and other platforms.
 
-   A major barrier to using public data for surveillance is the need for careful data curation, to identify which datasets are relevant for inclusion in pooled estimates of AMR and genotype prevalence. This kind of curation can benefit a wide range of users and we plan to work with other organism communities to curate data, and to contribute to wider efforts around metadata standards. Please get in touch if you would like to work with us (`amrnetdashboard@gmail.com <amrnetdashboard@gmail.com>`_)
+..    A major barrier to using public data for surveillance is the need for careful data curation, to identify which datasets are relevant for inclusion in pooled estimates of AMR and genotype prevalence. This kind of curation can benefit a wide range of users and we plan to work with other organism communities to curate data, and to contribute to wider efforts around metadata standards. Please get in touch if you would like to work with us (`amrnetdashboard@gmail.com <amrnetdashboard@gmail.com>`_)
 
-   Find out more about the project team (based at London School of Hygiene and Tropical Medicine), and our policy advisory group, `here <https://www.lshtm.ac.uk/amrnet>`__.
+..    Find out more about the project team (based at London School of Hygiene and Tropical Medicine), and our policy advisory group, `here <https://www.lshtm.ac.uk/amrnet>`__.
 
-   The dashboard code is open access and available in `GitHub <https://github.com/amrnet/amrnet>`_. Issues and feature requests can be posted `here <https://github.com/amrnet/amrnet/issues>`__. API access is described on the :doc:`/data` page.
+..    The dashboard code is open access and available in `GitHub <https://github.com/amrnet/amrnet>`_. Issues and feature requests can be posted `here <https://github.com/amrnet/amrnet/issues>`__. API access is described on the :doc:`/data` page.
 
-Citation for AMRnet
--------------------
+.. Citation for AMRnet
+.. -------------------
 
-.. container:: justify-text
+.. .. container:: justify-text
 
-   If you use the AMRnet website or code, please cite AMRnet (Louise Cerdeira, Vandana Sharma, Kathryn Holt), **GitHub**: https://github.com/amrnet/amrnet, **DOI**: 10.5281/zenodo.10810219
-
-
-
-Dashboard Development
-=====================
-.. container:: justify-text
-
-   If you want to install the AMRnet code to develop your own dashboard instances,
-   follow the installation instructions in the :doc:`Installation Guide <installation>`.
-
-   **Quick Start:**
-
-   .. code-block:: shell
-
-      # Clone the repository
-      git clone https://github.com/amrnet/amrnet.git
-      cd amrnet
-
-      # Install dependencies
-      npm install
-      cd client && npm install && cd ..
-
-      # Set up environment
-      cp .env.example .env
-
-      # Start development servers
-      npm run start:dev
-
-   The application will be available at ``http://localhost:3000`` for development.
+..    If you use the AMRnet website or code, please cite AMRnet (Louise Cerdeira, Vandana Sharma, Kathryn Holt), **GitHub**: https://github.com/amrnet/amrnet, **DOI**: 10.5281/zenodo.10810219
 
 
-License
--------
-.. container:: justify-text
 
-   Distributed under the terms of the :doc:`GPLv3 License <license>`.
+.. Dashboard Development
+.. =====================
+.. .. container:: justify-text
 
-   ``AMRnet`` is free and open source software.
+..    If you want to install the AMRnet code to develop your own dashboard instances,
+..    follow the installation instructions in the :doc:`Installation Guide <installation>`.
 
-Support
--------
-.. container:: justify-text
+..    **Quick Start:**
 
-   Found a bug 🐛, or have a feature request ✨, raise an issue on the
-   GitHub `issue
-   tracker <https://github.com/amrnet/amrnet/issues>`_.
-   Alternatively you can get support on the
-   `discussions <https://github.com/amrnet/amrnet/discussions>`_
-   page.
+..    .. code-block:: shell
 
-Disclaimer
-----------
-.. container:: justify-text
+..       # Clone the repository
+..       git clone https://github.com/amrnet/amrnet.git
+..       cd amrnet
 
-   ``AMRnet`` is an open source dashboard that continues to benefit from
-   the collaboration of many contributors. Although efforts have been made to ensure the
-   that relevant web development standards are implemented, it remains the
-   user's responsibility to confirm and accept the output. Refer to the
-   :doc:`License <license>` for clarification of the conditions of use.
+..       # Install dependencies
+..       npm install
+..       cd client && npm install && cd ..
+
+..       # Set up environment
+..       cp .env.example .env
+
+..       # Start development servers
+..       npm run start:dev
+
+..    The application will be available at ``http://localhost:3000`` for development.
+
+
+.. License
+.. -------
+.. .. container:: justify-text
+
+..    Distributed under the terms of the :doc:`GPLv3 License <license>`.
+
+..    ``AMRnet`` is free and open source software.
+
+.. Support
+.. -------
+.. .. container:: justify-text
+
+..    Found a bug 🐛, or have a feature request ✨, raise an issue on the
+..    GitHub `issue
+..    tracker <https://github.com/amrnet/amrnet/issues>`_.
+..    Alternatively you can get support on the
+..    `discussions <https://github.com/amrnet/amrnet/discussions>`_
+..    page.
+
+.. Disclaimer
+.. ----------
+.. .. container:: justify-text
+
+..    ``AMRnet`` is an open source dashboard that continues to benefit from
+..    the collaboration of many contributors. Although efforts have been made to ensure the
+..    that relevant web development standards are implemented, it remains the
+..    user's responsibility to confirm and accept the output. Refer to the
+..    :doc:`License <license>` for clarification of the conditions of use.


### PR DESCRIPTION
- Updated 3 top-level sections based on feedback
- Split organisms to make separate content levels
- Restructure contents
- Rename and rearrange organisms
- Hide "Data usage" and " User Tutorial"

## Summary by Sourcery

Restructure ReadTheDocs documentation: update top-level sections, reorganize content hierarchy, split organism details into separate pages, rename and rearrange organism files, and hide Data Usage and User Tutorial sections

Documentation:
- Update index, data, installation, usage, rights, and userguide sections based on feedback
- Split organism content into individual rst pages under docs/Org
- Rename and rearrange organism documentation files for clarity
- Hide Data Usage and User Tutorial sections from the documentation