### PR TITLE
Potential fix for code scanning alert no. 187: Database query built from user-controlled sources

### DIFF
--- a/routes/api/optimized.js
+++ b/routes/api/optimized.js
@@ -701,7 +701,17 @@ router.get('/paginated/:organism', async (req, res) => {
     // Apply filters if provided
     if (filters) {
       const parsedFilters = JSON.parse(filters);
-      Object.assign(query, parsedFilters);
+      // Validate that all filter values are primitives (string, number, boolean, or null)
+      for (const [key, value] of Object.entries(parsedFilters)) {
+        if (
+          typeof value === 'object' && value !== null ||
+          typeof value === 'function' ||
+          Array.isArray(value)
+        ) {
+          return res.status(400).json({ error: 'Invalid filter value: must be a primitive.' });
+        }
+        query[key] = value;
+      }
     }
 
     // Get appropriate projection based on data type


### PR DESCRIPTION
Potential fix for [https://github.com/amrnet/amrnet/security/code-scanning/187](https://github.com/amrnet/amrnet/security/code-scanning/187)

To fix this problem, we need to ensure that user-provided `filters` are interpreted as literal values and cannot inject MongoDB query operators (such as `$ne`, `$gt`, etc.). The best way to do this is to validate that each value in the parsed `filters` object is a primitive (string, number, boolean, or null), and not an object or array. If a value is an object or array, we should reject the request or ignore that filter. This can be done by iterating over the keys of `parsedFilters` and checking the type of each value before merging it into the `query` object.

**What to change:**  
- In the `/paginated/:organism` route handler, after parsing `filters`, validate that each value is a primitive before merging into `query`.
- If any value is not a primitive, return a 400 error.
- No new imports are needed; use `typeof` and `Array.isArray` for validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Implement validation for user-supplied filters in the `/paginated/:organism` route to only accept primitive values and return a 400 error on invalid types, mitigating MongoDB operator injection

Bug Fixes:
- Reject non-primitive filter values (objects, arrays, functions) with a 400 error to prevent query operator injection

Enhancements:
- Iterate through parsed filters and merge only primitive values into the database query