### PR TITLE
Potential fix for code scanning alert no. 191: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
     "webpack": "^5.99.9",
     "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.2",
-    "yarn": "^1.22.22"
+    "yarn": "^1.22.22",
+    "express-rate-limit": "^8.0.1"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.18.0",

--- a/routes/api/generateDataClean.js
+++ b/routes/api/generateDataClean.js
@@ -1,9 +1,16 @@
 import express from 'express';
 import { client } from '../../config/db.js';
+import rateLimit from 'express-rate-limit';
 
 const router = express.Router();
 
-router.post('/newdoctyphi', function (req, res, next) {
+const newdoctyphiLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  message: { error: 'Too many requests, please try again later.' },
+});
+
+router.post('/newdoctyphi', newdoctyphiLimiter, function (req, res, next) {
   const organism = req.body.organism;
   let collection, collection2, localFilePath;
 


### PR DESCRIPTION
Potential fix for [https://github.com/amrnet/amrnet/security/code-scanning/191](https://github.com/amrnet/amrnet/security/code-scanning/191)

To fix the problem, we should add rate-limiting middleware to the `POST /newdoctyphi` route, just as is done for the `POST /newdockleb` route. The best way is to use the same `express-rate-limit` package and create a new limiter instance (e.g., `newdoctyphiLimiter`) with appropriate configuration (e.g., 100 requests per 15 minutes per IP). This limiter should be applied as middleware to the `/newdoctyphi` route. 

Specifically:
- Import `express-rate-limit` if not already imported.
- Define a new rate limiter instance for `/newdoctyphi` (e.g., `newdoctyphiLimiter`).
- Apply this limiter as middleware to the `/newdoctyphi` route by adding it as the second argument to `router.post('/newdoctyphi', ...)`.

All changes should be made within `routes/api/generateDataClean.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Apply express-rate-limit middleware to the POST /newdoctyphi route, enforcing 100 requests per 15-minute window and adding the express-rate-limit package to dependencies to resolve the security alert

Bug Fixes:
- Enforce rate limiting on the POST /newdoctyphi endpoint to address the missing rate limiting code-scanning alert

Enhancements:
- Import express-rate-limit and define a limiter instance with a window of 15 minutes and a max of 100 requests
- Apply the new rate limiter middleware to the /newdoctyphi route

Build:
- Add express-rate-limit as a project dependency in package.json