### PR TITLE
Add missing 'he' package

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "gopd": "^1.2.0",
     "has-tostringtag": "^1.0.2",
     "hasown": "^2.0.2",
+    "he": "1.2.0",
     "helmet": "^8.1.0",
     "html2pdf.js": "^0.10.3",
     "http-errors": "~2.0.0",


### PR DESCRIPTION
Added missing 'he' package to target "Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'he' imported from /app/routes/api/email.js" from heroku logs