### PR TITLE
fix more Heroku build errors

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "proxy": "http://localhost:8080",
   "dependencies": {
+    "@craco/craco": "^7.1.0",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.15.11",
@@ -11,11 +12,12 @@
     "@mui/material": "^5.15.11",
     "@mui/styles": "^5.15.11",
     "@reduxjs/toolkit": "^1.9.3",
+    "ajv": "^8",
+    "ajv-keywords": "5.1.0",
     "axios": "^1.6.2",
     "framer-motion": "^11.0.8",
     "html2canvas": "1.4.1",
     "i18next": "^25.3.2",
-    "@craco/craco": "^7.1.0",
     "i18next-browser-languagedetector": "^8.2.0",
     "i18next-http-backend": "^3.0.2",
     "idb": "^8.0.0",
@@ -139,14 +141,14 @@
     "@types/react": "^18.2.64",
     "@types/react-dom": "^18.2.21",
     "@types/react-simple-maps": "^3.0.0",
-    "typescript": "^5.4.5",
-    "prettier": "^3.2.5",
+    "cross-env": "^7.0.3",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "husky": "^8.0.3",
     "lint-staged": "^15.2.2",
-    "cross-env": "^7.0.3"
+    "prettier": "^3.2.5",
+    "typescript": "^5.4.5"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "express-async-handler": "^1.2.0",
     "express-fileupload": "^1.5.1",
     "express-openid-connect": "^2.18.1",
+    "express-rate-limit": "8.0.1",
     "express-validator": "^7.2.1",
     "fast-csv": "^5.0.2",
     "gopd": "^1.2.0",

--- a/routes/api/api.js
+++ b/routes/api/api.js
@@ -3,6 +3,8 @@ import express from 'express';
 import fs from 'fs';
 import { MongoClient } from 'mongodb';
 import { getMongoConfig } from '../../config/db.js';
+import rateLimit from 'express-rate-limit';
+
 
 const router = express.Router();
 

--- a/routes/api/generateDataClean.js
+++ b/routes/api/generateDataClean.js
@@ -1,5 +1,7 @@
 import express from 'express';
 import { client } from '../../config/db.js';
+import rateLimit from 'express-rate-limit';
+
 
 const router = express.Router();
 


### PR DESCRIPTION
- added 'express-rate-limit' and added for heroku build error  "ReferenceError: rateLimit is not defined"
- added 'ajv' and 'ajv-keywords' for build error 'Cannot find module 'ajv/dist/compile/codegen"

## Summary by Sourcery

Add missing dependencies and imports to resolve Heroku build errors

Bug Fixes:
- Add express-rate-limit dependency and import rateLimit in API routes
- Add ajv and ajv-keywords dependencies in client package.json
- Include @craco/craco and reorder client dev dependencies to satisfy build requirements