### PR TITLE
Set Ciprofloxacin as default drug and update AMR Marker by Genotype display

### DIFF
--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -875,7 +875,7 @@ export const DashboardPage = () => {
         }
         dispatch(setDeterminantsGraphDrugClass('Ciprofloxacin'));
         dispatch(setTrendsGraphDrugClass('Ciprofloxacin'));
-        dispatch(setBubbleMarkersYAxisType('Azithromycin'));
+        dispatch(setBubbleMarkersYAxisType('Ciprofloxacin'));
         break;
       case 'kpneumo':
         // dispatch(setDatasetKP('All'));

--- a/client/src/components/Dashboard/filters.js
+++ b/client/src/components/Dashboard/filters.js
@@ -745,10 +745,10 @@ export function getYearsData({ data, years, organism, getUniqueGenotypes = false
           });
           drugStats[rule.key] = drugData.length;
 
-          if (!amrLikeOrganisms.includes(organism) && rule.key === 'Ciprofloxacin NS') {
+          if (!amrLikeOrganisms.includes(organism) && rule.key === 'Ciprofloxacin') {
             const cipRCount = yearData.filter(x => x[rule.columnID] === 'CipR').length;
             drugStats['Ciprofloxacin R'] = cipRCount;
-            drugStats['Ciprofloxacin NS'] += cipRCount;
+            drugStats['Ciprofloxacin'] += cipRCount;
           }
         });
 
@@ -1256,9 +1256,9 @@ export function getGenotypesData({
         const drugData = genotypeData.filter(x => rule.values.map(String).includes(String(x[rule.columnID])));
         response[rule.key] = drugData.length;
 
-        if (rule.key === 'Ciprofloxacin NS') {
+        if (rule.key === 'Ciprofloxacin') {
           response['Ciprofloxacin R'] = genotypeData.filter(x => x[rule.columnID] === 'CipR').length;
-          response['Ciprofloxacin NS'] = response['Ciprofloxacin NS'] + response['Ciprofloxacin R'];
+          response['Ciprofloxacin'] = response['Ciprofloxacin'] + response['Ciprofloxacin R'];
         }
 
         // Only process drug classes if the rule key exists in drugClassesRulesST

--- a/client/src/components/Elements/Graphs/graphColorHelper.js
+++ b/client/src/components/Elements/Graphs/graphColorHelper.js
@@ -43,7 +43,7 @@ export const getColorForDrug = drug => {
 
     // case 'Fluoroquinolones (CipNS)':
     case 'Ciprofloxacin (non-susceptible)':
-    case 'Ciprofloxacin NS':
+    case 'Ciprofloxacin':
     case 'Ciprofloxacin S':
       return '#f56207ff';
 
@@ -53,7 +53,7 @@ export const getColorForDrug = drug => {
     // case 'Fluoroquinolones (CipR)':
     case 'Ciprofloxacin R':
     case 'Ciprofloxacin (resistant)':
-    case 'Ciprofloxacin':
+    // case 'Ciprofloxacin':
       return '#9e9ac8';
 
     case 'Fluoroquinolones':

--- a/client/src/components/Elements/ResetButton/ResetButton.js
+++ b/client/src/components/Elements/ResetButton/ResetButton.js
@@ -99,6 +99,7 @@ export const ResetButton = () => {
       // dispatch(setTrendsGraphDrugClass('Azithromycin'));
       dispatch(setTrendsGraphView('percentage'));
       dispatch(setConvergenceColourPallete({}));
+      dispatch(setBubbleMarkersYAxisType('Ciprofloxacin'));
       // dispatch(setNgmastDrugsData(ngmastData.ngmastDrugData));
       // dispatch(setCustomDropdownMapViewNG(ngmastData.ngmastDrugData.slice(0, 1).map(x => x.name)));
     } else {
@@ -116,6 +117,7 @@ export const ResetButton = () => {
       dispatch(setCurrentSliderValueKOT(20));
       dispatch(setCurrentSliderValueKP_GT(20));
       dispatch(setCurrentSliderValueKP_GE(20));
+      dispatch(setBubbleMarkersYAxisType(markersDrugsKP[0]));
     }
     if (['shige', 'decoli', 'sentericaints'].includes(organism)) {
       dispatch(setSelectedLineages(pathovar));
@@ -138,7 +140,7 @@ export const ResetButton = () => {
     dispatch(setBubbleKOHeatmapGraphVariable('GENOTYPE'));
     dispatch(setBubbleKOYAxisType('O_locus'));
     dispatch(setBubbleMarkersHeatmapGraphVariable('GENOTYPE'));
-    dispatch(setBubbleMarkersYAxisType(markersDrugsKP[0]));
+    
 
     if (organism === 'ngono') {
       dispatch(setCurrentSliderValueRD(maxSliderValueRD));

--- a/client/src/components/Elements/ResetButton/ResetButton.js
+++ b/client/src/components/Elements/ResetButton/ResetButton.js
@@ -90,7 +90,7 @@ export const ResetButton = () => {
 
     if (organism === 'styphi') {
       dispatch(setMapView('Resistance prevalence'));
-      dispatch(setDeterminantsGraphDrugClass('Ciprofloxacin NS'));
+      dispatch(setDeterminantsGraphDrugClass('Ciprofloxacin'));
       dispatch(setDrugResistanceGraphView(defaultDrugsForDrugResistanceGraphST));
       dispatch(setCurrentSliderValue(20)); // to reset the genotype trend slider value for styphi
       dispatch(setMapView('Resistance prevalence'));

--- a/client/src/util/drugClassesRules.js
+++ b/client/src/util/drugClassesRules.js
@@ -7,7 +7,7 @@ export const drugRulesST = [
   { key: 'Trimethoprim-sulfamethoxazole', columnID: 'co_trim', values: ['1'] },
   { key: 'Ceftriaxone', columnID: 'ESBL_category', values: ['ESBL'] },
   {
-    key: 'Ciprofloxacin NS',
+    key: 'Ciprofloxacin',
     columnID: 'cip_pred_pheno',
     values: ['CipNS'],
     legends: 'Ciprofloxacin (non-susceptible)',

--- a/client/src/util/drugs.js
+++ b/client/src/util/drugs.js
@@ -44,7 +44,7 @@ export const drugsSTLegendsOnly = [
 export const defaultDrugsForDrugResistanceGraphST = [
   'Azithromycin',
   'Ceftriaxone',
-  'Ciprofloxacin NS',
+  'Ciprofloxacin',
   'Ciprofloxacin R',
   'XDR',
   'MDR',


### PR DESCRIPTION
Summary

- Set Ciprofloxacin as the default and reset drug.
- Updated logic so "AMR Marker by Genotype" shows data when Ciprofloxacin is selected.
<img width="1306" height="697" alt="Screenshot 2025-08-28 at 10 31 21" src="https://github.com/user-attachments/assets/351a8f05-b2f2-40df-9a38-befe4e31891b" />
