### PR TITLE
docs: enable myst_parser and gate AMR drug data model to dev builds

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,16 @@ language_map = {
 
 # sphinx config
 templates_path = ["_templates"]
-exclude_patterns = ["_build", "locale"]
+exclude_patterns = [
+    "_build",
+    "locale",
+    # Internal-only .md files kept in docs/ for convenience but not part
+    # of the published site. Without this, myst_parser would pick them up
+    # and emit "document isn't included in any toctree" warnings.
+    "readthedocs-translation-guide.md",
+    "translation_status.md",
+    "tutorial-integration-guide.md",
+]
 html_static_path = ["_static"]
 
 extensions = [
@@ -35,10 +44,16 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
     "matplotlib.sphinxext.plot_directive",
+    "myst_parser",
     "nbsphinx",
     "sphinx_copybutton",
     "sphinxext.opengraph",
 ]
+# Tell Sphinx which file extensions to treat as source.
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
 
 # Pygments style configuration
 highlight_language = 'python'
@@ -62,10 +77,16 @@ _dev_build = (
 if _dev_build:
     tags.add('dev')
 else:
-    exclude_patterns.extend(['saureus.rst', 'strepneumo.rst'])
+    exclude_patterns.extend([
+        'saureus.rst',
+        'strepneumo.rst',
+        'AMR_drug_data_model.md',  # internal developer reference, dev-only
+    ])
     # toctree refs inside `.. only:: dev` are parsed even when hidden — silence
-    # the false-positive "excluded document" warnings on the prod build.
-    suppress_warnings.append('toc.excluded')
+    # the false-positive "excluded document" / "nonexisting document" warnings
+    # on the prod build. (Different warning categories are emitted for .rst vs .md
+    # excluded files, so suppress the umbrella `toc` category.)
+    suppress_warnings.extend(['toc.excluded', 'toc.not_readable', 'toc'])
 
 # autodoc config
 autodoc_member_order = "bysource"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -73,3 +73,11 @@ Disclaimer
     :hidden:
 
     Developer Guide <installation>
+
+.. only:: dev
+
+   .. toctree::
+       :caption: Internal references (dev only)
+       :hidden:
+
+       AMR drug data model <AMR_drug_data_model>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ docs = [
     "nbconvert==7.16.6",
     "sphinx-copybutton==0.5.2",
     "sphinxext-opengraph==0.10.0",
+    "myst-parser>=4.0.0",  # enables Markdown sources (e.g. AMR_drug_data_model.md)
 ]
 
 [tool.uv]


### PR DESCRIPTION
Wires `docs/AMR_drug_data_model.md` into the **development-only** Read the Docs build. After merging, the doc renders at:

- https://amrnet.readthedocs.io/en/development/AMR_drug_data_model.html — **visible**
- https://amrnet.readthedocs.io/en/latest/AMR_drug_data_model.html — **404** (intentional)

Same gating philosophy as `saureus.html` / `strepneumo.html`.

## What changed

- `pyproject.toml` — `myst-parser>=4.0.0` added to the `[dependency-groups] docs` so RTD's `uv sync --group docs` installs it.
- `docs/conf.py`:
  - `myst_parser` added to `extensions`.
  - `source_suffix` declared so Sphinx treats `.md` as Markdown.
  - `exclude_patterns` always excludes three internal-only `.md` files in `docs/` (`readthedocs-translation-guide.md`, `translation_status.md`, `tutorial-integration-guide.md`) — without this, myst would pick them up and emit "not in any toctree" warnings.
  - The existing `_dev_build` conditional now also excludes `AMR_drug_data_model.md` from the prod build.
  - `suppress_warnings` broadened to silence the umbrella `toc` category in addition to `toc.excluded`, because myst-parsed `.md` exclusions emit a "nonexisting document" warning rather than "excluded".
- `docs/index.rst` — adds a `.. only:: dev` block with a new toctree captioned "Internal references (dev only)" pointing at `AMR_drug_data_model`.

## Local verification

```
sphinx-build -b html .            _build/test_prod   # prod build
sphinx-build -b html -t dev .     _build/test_dev    # dev build
```

| File | prod build | dev build |
|---|---|---|
| `AMR_drug_data_model.html` | ❌ not generated | ✅ generated |
| `saureus.html`, `strepneumo.html` | ❌ not generated | ✅ generated |
| "Internal references" caption in `index.html` | ❌ absent | ✅ present |

The pre-existing warnings (`data.rst:113` list-table, `source.rst` duplicate target, `right.rst` orphan, etc.) are unchanged by this PR.

## Note for reviewer

This is a docs-only change — no application code, no behaviour change. After merge it'll trigger a RTD rebuild for both `latest` and `development`.