### PR TITLE
feat(amrInsights): rename ATB → AM and remove PMEN Clones tab (Phase 1 of dashboard reorg)

### DIFF
--- a/client/src/components/Elements/AMRInsights/AMRInsights.js
+++ b/client/src/components/Elements/AMRInsights/AMRInsights.js
@@ -23,7 +23,6 @@ import { GeneMapGraph } from '../Graphs/GeneMapGraph';
 import { GenomicVsPhenotypicGraph } from '../Graphs/GenomicVsPhenotypicGraph';
 import { QRDRPathwayGraph } from '../Graphs/QRDRPathwayGraph';
 import { SerotypeResistanceGraph } from '../Graphs/SerotypeResistanceGraph';
-import { PMENCloneGraph } from '../Graphs/PMENCloneGraph/PMENCloneGraph';
 import { StratifiedResistanceGraph } from '../Graphs/StratifiedResistanceGraph';
 import { LINcodeGenotypeGraph } from '../Graphs/LINcodeGenotypeGraph/LINcodeGenotypeGraph';
 import { useStyles } from './AMRInsightsMUI';
@@ -57,12 +56,6 @@ const TABS = [
     labelKey: 'amrInsights.tabs.serotypeResistance',
     value: 'SRT',
     component: <SerotypeResistanceGraph />,
-    onlyFor: ['strepneumo'],
-  },
-  {
-    labelKey: 'amrInsights.tabs.pmenClones',
-    value: 'PMEN',
-    component: <PMENCloneGraph />,
     onlyFor: ['strepneumo'],
   },
   {

--- a/client/src/components/Elements/Graphs/ATBCorrelationGraph/ATBCorrelationGraph.js
+++ b/client/src/components/Elements/Graphs/ATBCorrelationGraph/ATBCorrelationGraph.js
@@ -71,7 +71,7 @@ const CustomTooltip = ({ active, payload }) => {
   return (
     <Box sx={{ backgroundColor: '#fff', padding: '8px 12px', border: '1px solid rgba(0,0,0,0.2)', borderRadius: '4px' }}>
       <Typography variant="body2" fontWeight={600}>{data.country}</Typography>
-      <Typography variant="caption" display="block">ATB consumption: {data.x?.toFixed(2)} DDD/1000/day ({data.consumptionYear})</Typography>
+      <Typography variant="caption" display="block">AM consumption: {data.x?.toFixed(2)} DDD/1000/day ({data.consumptionYear})</Typography>
       <Typography variant="caption" display="block">Resistance: {data.y?.toFixed(1)}% ({data.resistanceYear || ''})</Typography>
       {data.genomes > 0 && <Typography variant="caption" display="block">Samples tested: {data.genomes}</Typography>}
       <Typography variant="caption" display="block" color="textSecondary">Region: {data.region}</Typography>
@@ -311,7 +311,7 @@ export const ATBCorrelationGraph = ({ showFilter, setShowFilter }) => {
               <ScatterChart margin={{ top: 20, right: 20, bottom: 40, left: 20 }}>
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis type="number" dataKey="x" domain={['auto', 'auto']}>
-                  <Label value="ATB Consumption (DDD/1000 inhabitants/day)" position="bottom" offset={20} style={{ fontSize: 12 }} />
+                  <Label value="AM Consumption (DDD/1000 inhabitants/day)" position="bottom" offset={20} style={{ fontSize: 12 }} />
                 </XAxis>
                 <YAxis type="number" dataKey="y" domain={[0, 100]}>
                   <Label value="Genomic Resistance — WHO GLASS (%)" angle={-90} position="insideLeft" offset={10} style={{ fontSize: 11, textAnchor: 'middle' }} />
@@ -366,7 +366,7 @@ export const ATBCorrelationGraph = ({ showFilter, setShowFilter }) => {
           <Typography variant="body2" fontWeight={600} sx={{ marginTop: '8px' }}>Data Sources</Typography>
           <Box className={classes.tooltipWrapper}>
             <Typography variant="caption" sx={{ lineHeight: 1.5 }}>
-              <strong>ATB Consumption:</strong> {dataSource === 'glass'
+              <strong>AM Consumption:</strong> {dataSource === 'glass'
                 ? `WHO GLASS-AMC via GHO OData API (${glassData?.consumption?.length || 0} country-year records, 2016-2023). Total antibiotic consumption as DDD/1000/day.`
                 : 'Static dataset adapted from WHO GLASS AMC/AMU report and ECDC ESAC-Net (16 countries, 2020).'}
               <br /><br />

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -268,7 +268,7 @@
       "serotypeResistance": "Vaccine Coverage",
       "pmenClones": "PMEN Clones",
       "cooccurrence": "AMR Co-occurrence",
-      "atbCorrelation": "ATB Usage vs Resistance",
+      "atbCorrelation": "AM Usage vs Resistance",
       "oneHealthSource": "One Health source",
       "linCode": "LIN code lineages",
       "linGenotype": "LINcode × Genotype"

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -245,7 +245,7 @@
       "serotypeResistance": "Cobertura Vacunal",
       "pmenClones": "Clones PMEN",
       "cooccurrence": "Co-ocurrencia de RAM",
-      "atbCorrelation": "Uso de ATB vs Resistencia"
+      "atbCorrelation": "Uso de AM vs Resistencia"
     },
     "gvp": {
       "compareTooltip": "Compara las predicciones de resistencia derivadas del genoma de AMRnet con los datos de vigilancia fenotípica. Cada punto = un país. Puntos en la diagonal = concordancia perfecta. Barras de error = IC Wilson 95% sobre la estimación genómica.",

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -245,7 +245,7 @@
       "serotypeResistance": "Couverture Vaccinale",
       "pmenClones": "Clones PMEN",
       "cooccurrence": "Co-occurrence RAM",
-      "atbCorrelation": "Usage ATB vs Résistance"
+      "atbCorrelation": "Usage AM vs Résistance"
     },
     "gvp": {
       "compareTooltip": "Compare les prédictions de résistance dérivées du génome par AMRnet avec les données de surveillance phénotypique. Chaque point = un pays. Points sur la diagonale = concordance parfaite. Barres d’erreur = IC Wilson 95 % sur l’estimation génomique.",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -245,7 +245,7 @@
       "serotypeResistance": "Cobertura Vacinal",
       "pmenClones": "Clones PMEN",
       "cooccurrence": "Co-ocorrência de RAM",
-      "atbCorrelation": "Uso de ATB vs Resistência",
+      "atbCorrelation": "Uso de AM vs Resistência",
       "oneHealthSource": "Fontes One Health",
       "linCode": "Linhagens LIN code"
     },


### PR DESCRIPTION
First of three planned PRs for the dashboard reorganization. This is the small, low-risk one — pure rename + tab removal, no layout changes.

## Changes

**Rename "ATB" → "AM" in user-facing strings (4 locale files + 3 hardcoded in `ATBCorrelationGraph.js`)**
- Tab title: `ATB Usage vs Resistance` → `AM Usage vs Resistance` (en/es/fr/pt — value only, the i18n key `amrInsights.tabs.atbCorrelation` is preserved for backward compatibility)
- Chart x-axis label: `ATB Consumption (DDD/1000…)` → `AM Consumption (…)`
- Tooltip: `ATB consumption: …` → `AM consumption: …`
- Data Sources panel header: `ATB Consumption:` → `AM Consumption:`

**Remove "PMEN Clones" tab from AMR Insights**
- Tab entry (`value: 'PMEN'`) and the `PMENCloneGraph` import are removed from `AMRInsights.js`.
- The `PMENCloneGraph.js` component file is **kept on disk** for possible future reactivation; only the UI entry point is removed.

## What's NOT in this PR (coming in Phases 2 and 3)

- **Phase 2** (next): Wrap Global Overview in tabs (Map / Bar plot), with the Bar plot tab hosting `<StratifiedResistanceGraph mode="source" />`. "One Health Source" will be removed from AMR Insights as part of that PR (bundled to avoid a gap in dev-only access).
- **Phase 3** (later, larger): Move QRDR Mutations and Vaccine Coverage into Summary plots with country/region plotting options on the right-hand floating panel.

## Verification suggested before merge

- [ ] AMR Insights → confirm there's no "PMEN Clones" tab any more (organism: strepneumo)
- [ ] AMR Insights → confirm the last tab is now labelled "AM Usage vs Resistance" instead of "ATB Usage vs Resistance"
- [ ] Open the AM Usage vs Resistance tab → axis label, tooltips, and data-source panel say "AM" not "ATB"