### PR TITLE
feat(dashboard): Global Overview tabs (dev-only) + remove One Health Source from AMR Insights

### DIFF
--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useAppDispatch, useAppSelector } from '../../stores/hooks';
 import { loadOrganismQuickly } from '../../utils/quickPaginationFix';
 import { DownloadData } from '../Elements/DownloadData';
-import { Map } from '../Elements/Map';
+import { GlobalOverviewTabs } from '../Elements/GlobalOverviewTabs';
 import { Note } from '../Elements/Note';
 import { MainLayout } from '../Layout';
 // import optimizedDataService from '../../services/optimizedDataService'; // Unused import
@@ -1953,7 +1953,7 @@ export const DashboardPage = () => {
     <>
       <MainLayout>
         <Note />
-        <Map />
+        <GlobalOverviewTabs />
         {/* <SelectCountry /> */}
         <Graphs />
         <ContinentGraphs />

--- a/client/src/components/Elements/AMRInsights/AMRInsights.js
+++ b/client/src/components/Elements/AMRInsights/AMRInsights.js
@@ -59,12 +59,6 @@ const TABS = [
     onlyFor: ['strepneumo'],
   },
   {
-    labelKey: 'amrInsights.tabs.oneHealthSource',
-    value: 'OHS',
-    component: <StratifiedResistanceGraph mode="source" />,
-    onlyFor: ['senterica', 'sentericaints', 'ecoli', 'decoli', 'shige'],
-  },
-  {
     labelKey: 'amrInsights.tabs.linCode',
     value: 'LIN',
     component: <StratifiedResistanceGraph mode="lin" />,

--- a/client/src/components/Elements/GlobalOverviewTabs/GlobalOverviewTabs.js
+++ b/client/src/components/Elements/GlobalOverviewTabs/GlobalOverviewTabs.js
@@ -1,0 +1,78 @@
+// Global Overview top-of-dashboard panel.
+//
+// Production: renders the existing <Map /> directly — no behavioural change.
+// Development: renders a two-tab interface
+//     Tab 1 "Map"      → existing <Map /> (default)
+//     Tab 2 "Bar plot" → <StratifiedResistanceGraph mode="source" />
+//                        for organisms with One Health source data, or
+//                        a "no data" notice for the rest.
+//
+// The dev-only gate uses isProduction() so the prod build is unchanged.
+
+import { Box, Card, CardContent, Tab, Tabs, Typography } from '@mui/material';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAppSelector } from '../../../stores/hooks';
+import { isProduction } from '../../../util/env';
+import { Map } from '../Map';
+import { StratifiedResistanceGraph } from '../Graphs/StratifiedResistanceGraph';
+import { useStyles } from './GlobalOverviewTabsMUI';
+
+// Organisms that have source_niche / source_type populated in MongoDB.
+// Mirrors the AMR Insights One Health Source tab's onlyFor list.
+const ORGANISMS_WITH_SOURCE_DATA = ['senterica', 'sentericaints', 'ecoli', 'decoli', 'shige'];
+
+export const GlobalOverviewTabs = () => {
+  const classes = useStyles();
+  const { t } = useTranslation();
+
+  // Production keeps the current single-Map layout untouched.
+  if (isProduction()) {
+    return <Map />;
+  }
+
+  return <DevOverviewTabs classes={classes} t={t} />;
+};
+
+// Extracted so React hooks aren't called conditionally above.
+const DevOverviewTabs = ({ classes, t }) => {
+  const [tab, setTab] = useState('map');
+  const organism = useAppSelector(state => state.dashboard.organism);
+  const hasSourceData = ORGANISMS_WITH_SOURCE_DATA.includes(organism);
+
+  const handleChangeTab = (_event, newValue) => setTab(newValue);
+
+  return (
+    <Box className={classes.wrapper}>
+      <Tabs
+        value={tab}
+        onChange={handleChangeTab}
+        className={classes.tabsBar}
+        textColor="primary"
+        indicatorColor="primary"
+      >
+        <Tab value="map" label={t('globalOverview.tabs.map')} className={classes.tab} />
+        <Tab value="barplot" label={t('globalOverview.tabs.barplot')} className={classes.tab} />
+      </Tabs>
+
+      {/* Both panels stay mounted with display toggling so internal state
+          (e.g., map zoom, collapse) survives tab switches. */}
+      <Box sx={{ display: tab === 'map' ? 'block' : 'none' }}>
+        <Map />
+      </Box>
+      <Box sx={{ display: tab === 'barplot' ? 'block' : 'none' }}>
+        <Card className={classes.card}>
+          {hasSourceData ? (
+            <StratifiedResistanceGraph mode="source" />
+          ) : (
+            <CardContent className={classes.emptyState}>
+              <Typography color="text.secondary" align="center">
+                {t('globalOverview.tabs.barplotNoData')}
+              </Typography>
+            </CardContent>
+          )}
+        </Card>
+      </Box>
+    </Box>
+  );
+};

--- a/client/src/components/Elements/GlobalOverviewTabs/GlobalOverviewTabsMUI.js
+++ b/client/src/components/Elements/GlobalOverviewTabs/GlobalOverviewTabsMUI.js
@@ -1,0 +1,32 @@
+import { makeStyles } from '@mui/styles';
+
+export const useStyles = makeStyles(_theme => ({
+  wrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    rowGap: '8px',
+  },
+  tabsBar: {
+    minHeight: '36px',
+    '& .MuiTab-root': {
+      minHeight: '36px',
+      textTransform: 'none',
+      fontSize: '14px',
+      fontWeight: 500,
+    },
+  },
+  tab: {},
+  card: {
+    '&.MuiCard-root': {
+      borderRadius: '16px',
+      overflow: 'visible',
+    },
+  },
+  emptyState: {
+    padding: '48px 24px',
+    minHeight: '160px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+}));

--- a/client/src/components/Elements/GlobalOverviewTabs/index.js
+++ b/client/src/components/Elements/GlobalOverviewTabs/index.js
@@ -1,0 +1,1 @@
+export * from './GlobalOverviewTabs';

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -879,5 +879,12 @@
       ")",
       "4. Ciprofloxacin R, ciprofloxacin resistant (MIC >=0.5 mg/L, due to presence of multiple mutations and/or genes, see Carey et al, 2023 https://doi.org/10.7554/eLife.85867)"
     ]
+  },
+  "globalOverview": {
+    "tabs": {
+      "map": "Map",
+      "barplot": "Bar plot",
+      "barplotNoData": "No One Health source data available for this organism."
+    }
   }
 }

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -506,5 +506,12 @@
     "Ciprofloxacin": "Ciprofloxacino",
     "Susceptible": "Susceptible a medicamentos cat I/II",
     "Susceptible to cat I/II drugs": "Susceptible a medicamentos cat I/II"
+  },
+  "globalOverview": {
+    "tabs": {
+      "map": "Mapa",
+      "barplot": "Gráfico de barras",
+      "barplotNoData": "No hay datos de fuentes One Health disponibles para este organismo."
+    }
   }
 }

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -506,5 +506,12 @@
     "Ciprofloxacin": "Ciprofloxacine",
     "Susceptible": "Sensible aux antibiotiques cat I/II",
     "Susceptible to cat I/II drugs": "Sensible aux antibiotiques cat I/II"
+  },
+  "globalOverview": {
+    "tabs": {
+      "map": "Carte",
+      "barplot": "Graphique à barres",
+      "barplotNoData": "Aucune donnée de source One Health disponible pour cet organisme."
+    }
   }
 }

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -590,5 +590,12 @@
     "Beta-lactam": "Beta-lactâmico",
     "Phenicol": "Fenicol",
     "Carbapenem": "Carbapenem"
+  },
+  "globalOverview": {
+    "tabs": {
+      "map": "Mapa",
+      "barplot": "Gráfico de barras",
+      "barplotNoData": "Não há dados de fontes One Health disponíveis para este organismo."
+    }
   }
 }


### PR DESCRIPTION
Phase 2 of the dashboard reorganization (Phase 1 was #383).

## What this PR does

Wraps the Global Overview area in a tabbed interface — but **only for the development build**. Production keeps the existing single-Map layout untouched.

### New component: `GlobalOverviewTabs`

Located at `client/src/components/Elements/GlobalOverviewTabs/`. Exposes a single export, which:
- Returns `<Map />` directly when `isProduction()` is true (prod layout unchanged)
- Otherwise renders two tabs:
  - **Tab 1 "Map"** → existing `<Map />` (default)
  - **Tab 2 "Bar plot"** → `<StratifiedResistanceGraph mode="source" />` for organisms with One Health source data, else a "no data for this organism" notice

The `senterica`, `sentericaints`, `ecoli`, `decoli`, `shige` organism list is the same one used by the (now-removed) AMR Insights One Health Source tab.

### Other changes

- `Dashboard.js` imports and renders `<GlobalOverviewTabs />` in place of the previous direct `<Map />`. The dev-only gate is fully encapsulated inside the new component; the Dashboard layout is identical in both builds.
- `AMRInsights.js`: the "One Health Source" tab (value `OHS`) is removed. The same view is now reachable on the dev-only Global Overview "Bar plot" tab. The `StratifiedResistanceGraph` import stays because the LIN tab still uses it.
- New i18n keys added to all four locales:
  ```
  globalOverview.tabs.map
  globalOverview.tabs.barplot
  globalOverview.tabs.barplotNoData
  ```

## Production impact: zero

`isProduction()` (already used to gate AMR Insights and the Radar tab) returns true on `www.amrnet.org`. The new component short-circuits to `<Map />` exactly as before. The new tab strip is never rendered, the `OHS` tab being absent from AMR Insights is invisible to prod users (AMR Insights itself is dev-only).

The bundle hash *will* change because the new module is included, but the runtime behaviour on prod is unchanged.

## State preservation

Both Map and Bar plot panels stay mounted with `display: none` toggling, so internal state (map zoom, collapse, current filters) survives tab switches.

## Verification suggested before merge

On `dev.amrnet.org` (after deploy):

- [ ] **styphi / kpneumo / ngono / saureus / strepneumo**: Bar plot tab is reachable and shows the "no data for this organism" notice
- [ ] **senterica / sentericaints / ecoli / decoli / shige**: Bar plot tab renders the One Health Source bar chart
- [ ] **Map tab**: behaves exactly as before (zoom, filter, mapView dropdown, Share button, etc.)
- [ ] **AMR Insights**: the "One Health Source" tab is gone; "LIN code" / "Stratified Resistance" / etc. still work
- [ ] **Map zoom + tab switch**: zoom in, switch to Bar plot, switch back — zoom level preserved
- [ ] **Tab persistence across organism change**: pick organism A on Map tab → switch to Bar plot → pick organism B. The Bar plot stays selected.

On a local production build (`REACT_APP_ENVIRONMENT=production npm run build`):

- [ ] No "Map" / "Bar plot" tab strip appears — single `<Map />` layout, identical to current production.

## What's next

Phase 3 (separate, larger PR) — move QRDR Mutations and Vaccine Coverage into Summary Plots with country/region plotting options on the right-hand floating panel. Will need answers to the four design questions you already provided; I'll start scoping after this lands.