### PR TITLE
Promote development → main: Phase 1 + Phase 2 dashboard reorg

### DIFF
--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useAppDispatch, useAppSelector } from '../../stores/hooks';
 import { loadOrganismQuickly } from '../../utils/quickPaginationFix';
 import { DownloadData } from '../Elements/DownloadData';
-import { Map } from '../Elements/Map';
+import { GlobalOverviewTabs } from '../Elements/GlobalOverviewTabs';
 import { Note } from '../Elements/Note';
 import { MainLayout } from '../Layout';
 // import optimizedDataService from '../../services/optimizedDataService'; // Unused import
@@ -1953,7 +1953,7 @@ export const DashboardPage = () => {
     <>
       <MainLayout>
         <Note />
-        <Map />
+        <GlobalOverviewTabs />
         {/* <SelectCountry /> */}
         <Graphs />
         <ContinentGraphs />

--- a/client/src/components/Elements/AMRInsights/AMRInsights.js
+++ b/client/src/components/Elements/AMRInsights/AMRInsights.js
@@ -59,12 +59,6 @@ const TABS = [
     onlyFor: ['strepneumo'],
   },
   {
-    labelKey: 'amrInsights.tabs.oneHealthSource',
-    value: 'OHS',
-    component: <StratifiedResistanceGraph mode="source" />,
-    onlyFor: ['senterica', 'sentericaints', 'ecoli', 'decoli', 'shige'],
-  },
-  {
     labelKey: 'amrInsights.tabs.linCode',
     value: 'LIN',
     component: <StratifiedResistanceGraph mode="lin" />,

--- a/client/src/components/Elements/AMRInsights/AMRInsights.js
+++ b/client/src/components/Elements/AMRInsights/AMRInsights.js
@@ -23,7 +23,6 @@ import { GeneMapGraph } from '../Graphs/GeneMapGraph';
 import { GenomicVsPhenotypicGraph } from '../Graphs/GenomicVsPhenotypicGraph';
 import { QRDRPathwayGraph } from '../Graphs/QRDRPathwayGraph';
 import { SerotypeResistanceGraph } from '../Graphs/SerotypeResistanceGraph';
-import { PMENCloneGraph } from '../Graphs/PMENCloneGraph/PMENCloneGraph';
 import { StratifiedResistanceGraph } from '../Graphs/StratifiedResistanceGraph';
 import { LINcodeGenotypeGraph } from '../Graphs/LINcodeGenotypeGraph/LINcodeGenotypeGraph';
 import { useStyles } from './AMRInsightsMUI';
@@ -57,12 +56,6 @@ const TABS = [
     labelKey: 'amrInsights.tabs.serotypeResistance',
     value: 'SRT',
     component: <SerotypeResistanceGraph />,
-    onlyFor: ['strepneumo'],
-  },
-  {
-    labelKey: 'amrInsights.tabs.pmenClones',
-    value: 'PMEN',
-    component: <PMENCloneGraph />,
     onlyFor: ['strepneumo'],
   },
   {

--- a/client/src/components/Elements/GlobalOverviewTabs/GlobalOverviewTabs.js
+++ b/client/src/components/Elements/GlobalOverviewTabs/GlobalOverviewTabs.js
@@ -1,0 +1,78 @@
+// Global Overview top-of-dashboard panel.
+//
+// Production: renders the existing <Map /> directly — no behavioural change.
+// Development: renders a two-tab interface
+//     Tab 1 "Map"      → existing <Map /> (default)
+//     Tab 2 "Bar plot" → <StratifiedResistanceGraph mode="source" />
+//                        for organisms with One Health source data, or
+//                        a "no data" notice for the rest.
+//
+// The dev-only gate uses isProduction() so the prod build is unchanged.
+
+import { Box, Card, CardContent, Tab, Tabs, Typography } from '@mui/material';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAppSelector } from '../../../stores/hooks';
+import { isProduction } from '../../../util/env';
+import { Map } from '../Map';
+import { StratifiedResistanceGraph } from '../Graphs/StratifiedResistanceGraph';
+import { useStyles } from './GlobalOverviewTabsMUI';
+
+// Organisms that have source_niche / source_type populated in MongoDB.
+// Mirrors the AMR Insights One Health Source tab's onlyFor list.
+const ORGANISMS_WITH_SOURCE_DATA = ['senterica', 'sentericaints', 'ecoli', 'decoli', 'shige'];
+
+export const GlobalOverviewTabs = () => {
+  const classes = useStyles();
+  const { t } = useTranslation();
+
+  // Production keeps the current single-Map layout untouched.
+  if (isProduction()) {
+    return <Map />;
+  }
+
+  return <DevOverviewTabs classes={classes} t={t} />;
+};
+
+// Extracted so React hooks aren't called conditionally above.
+const DevOverviewTabs = ({ classes, t }) => {
+  const [tab, setTab] = useState('map');
+  const organism = useAppSelector(state => state.dashboard.organism);
+  const hasSourceData = ORGANISMS_WITH_SOURCE_DATA.includes(organism);
+
+  const handleChangeTab = (_event, newValue) => setTab(newValue);
+
+  return (
+    <Box className={classes.wrapper}>
+      <Tabs
+        value={tab}
+        onChange={handleChangeTab}
+        className={classes.tabsBar}
+        textColor="primary"
+        indicatorColor="primary"
+      >
+        <Tab value="map" label={t('globalOverview.tabs.map')} className={classes.tab} />
+        <Tab value="barplot" label={t('globalOverview.tabs.barplot')} className={classes.tab} />
+      </Tabs>
+
+      {/* Both panels stay mounted with display toggling so internal state
+          (e.g., map zoom, collapse) survives tab switches. */}
+      <Box sx={{ display: tab === 'map' ? 'block' : 'none' }}>
+        <Map />
+      </Box>
+      <Box sx={{ display: tab === 'barplot' ? 'block' : 'none' }}>
+        <Card className={classes.card}>
+          {hasSourceData ? (
+            <StratifiedResistanceGraph mode="source" />
+          ) : (
+            <CardContent className={classes.emptyState}>
+              <Typography color="text.secondary" align="center">
+                {t('globalOverview.tabs.barplotNoData')}
+              </Typography>
+            </CardContent>
+          )}
+        </Card>
+      </Box>
+    </Box>
+  );
+};

--- a/client/src/components/Elements/GlobalOverviewTabs/GlobalOverviewTabsMUI.js
+++ b/client/src/components/Elements/GlobalOverviewTabs/GlobalOverviewTabsMUI.js
@@ -1,0 +1,32 @@
+import { makeStyles } from '@mui/styles';
+
+export const useStyles = makeStyles(_theme => ({
+  wrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    rowGap: '8px',
+  },
+  tabsBar: {
+    minHeight: '36px',
+    '& .MuiTab-root': {
+      minHeight: '36px',
+      textTransform: 'none',
+      fontSize: '14px',
+      fontWeight: 500,
+    },
+  },
+  tab: {},
+  card: {
+    '&.MuiCard-root': {
+      borderRadius: '16px',
+      overflow: 'visible',
+    },
+  },
+  emptyState: {
+    padding: '48px 24px',
+    minHeight: '160px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+}));

--- a/client/src/components/Elements/GlobalOverviewTabs/index.js
+++ b/client/src/components/Elements/GlobalOverviewTabs/index.js
@@ -1,0 +1,1 @@
+export * from './GlobalOverviewTabs';

--- a/client/src/components/Elements/Graphs/ATBCorrelationGraph/ATBCorrelationGraph.js
+++ b/client/src/components/Elements/Graphs/ATBCorrelationGraph/ATBCorrelationGraph.js
@@ -71,7 +71,7 @@ const CustomTooltip = ({ active, payload }) => {
   return (
     <Box sx={{ backgroundColor: '#fff', padding: '8px 12px', border: '1px solid rgba(0,0,0,0.2)', borderRadius: '4px' }}>
       <Typography variant="body2" fontWeight={600}>{data.country}</Typography>
-      <Typography variant="caption" display="block">ATB consumption: {data.x?.toFixed(2)} DDD/1000/day ({data.consumptionYear})</Typography>
+      <Typography variant="caption" display="block">AM consumption: {data.x?.toFixed(2)} DDD/1000/day ({data.consumptionYear})</Typography>
       <Typography variant="caption" display="block">Resistance: {data.y?.toFixed(1)}% ({data.resistanceYear || ''})</Typography>
       {data.genomes > 0 && <Typography variant="caption" display="block">Samples tested: {data.genomes}</Typography>}
       <Typography variant="caption" display="block" color="textSecondary">Region: {data.region}</Typography>
@@ -311,7 +311,7 @@ export const ATBCorrelationGraph = ({ showFilter, setShowFilter }) => {
               <ScatterChart margin={{ top: 20, right: 20, bottom: 40, left: 20 }}>
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis type="number" dataKey="x" domain={['auto', 'auto']}>
-                  <Label value="ATB Consumption (DDD/1000 inhabitants/day)" position="bottom" offset={20} style={{ fontSize: 12 }} />
+                  <Label value="AM Consumption (DDD/1000 inhabitants/day)" position="bottom" offset={20} style={{ fontSize: 12 }} />
                 </XAxis>
                 <YAxis type="number" dataKey="y" domain={[0, 100]}>
                   <Label value="Genomic Resistance — WHO GLASS (%)" angle={-90} position="insideLeft" offset={10} style={{ fontSize: 11, textAnchor: 'middle' }} />
@@ -366,7 +366,7 @@ export const ATBCorrelationGraph = ({ showFilter, setShowFilter }) => {
           <Typography variant="body2" fontWeight={600} sx={{ marginTop: '8px' }}>Data Sources</Typography>
           <Box className={classes.tooltipWrapper}>
             <Typography variant="caption" sx={{ lineHeight: 1.5 }}>
-              <strong>ATB Consumption:</strong> {dataSource === 'glass'
+              <strong>AM Consumption:</strong> {dataSource === 'glass'
                 ? `WHO GLASS-AMC via GHO OData API (${glassData?.consumption?.length || 0} country-year records, 2016-2023). Total antibiotic consumption as DDD/1000/day.`
                 : 'Static dataset adapted from WHO GLASS AMC/AMU report and ECDC ESAC-Net (16 countries, 2020).'}
               <br /><br />

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -268,7 +268,7 @@
       "serotypeResistance": "Vaccine Coverage",
       "pmenClones": "PMEN Clones",
       "cooccurrence": "AMR Co-occurrence",
-      "atbCorrelation": "ATB Usage vs Resistance",
+      "atbCorrelation": "AM Usage vs Resistance",
       "oneHealthSource": "One Health source",
       "linCode": "LIN code lineages",
       "linGenotype": "LINcode × Genotype"

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -879,5 +879,12 @@
       ")",
       "4. Ciprofloxacin R, ciprofloxacin resistant (MIC >=0.5 mg/L, due to presence of multiple mutations and/or genes, see Carey et al, 2023 https://doi.org/10.7554/eLife.85867)"
     ]
+  },
+  "globalOverview": {
+    "tabs": {
+      "map": "Map",
+      "barplot": "Bar plot",
+      "barplotNoData": "No One Health source data available for this organism."
+    }
   }
 }

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -245,7 +245,7 @@
       "serotypeResistance": "Cobertura Vacunal",
       "pmenClones": "Clones PMEN",
       "cooccurrence": "Co-ocurrencia de RAM",
-      "atbCorrelation": "Uso de ATB vs Resistencia"
+      "atbCorrelation": "Uso de AM vs Resistencia"
     },
     "gvp": {
       "compareTooltip": "Compara las predicciones de resistencia derivadas del genoma de AMRnet con los datos de vigilancia fenotípica. Cada punto = un país. Puntos en la diagonal = concordancia perfecta. Barras de error = IC Wilson 95% sobre la estimación genómica.",

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -506,5 +506,12 @@
     "Ciprofloxacin": "Ciprofloxacino",
     "Susceptible": "Susceptible a medicamentos cat I/II",
     "Susceptible to cat I/II drugs": "Susceptible a medicamentos cat I/II"
+  },
+  "globalOverview": {
+    "tabs": {
+      "map": "Mapa",
+      "barplot": "Gráfico de barras",
+      "barplotNoData": "No hay datos de fuentes One Health disponibles para este organismo."
+    }
   }
 }

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -506,5 +506,12 @@
     "Ciprofloxacin": "Ciprofloxacine",
     "Susceptible": "Sensible aux antibiotiques cat I/II",
     "Susceptible to cat I/II drugs": "Sensible aux antibiotiques cat I/II"
+  },
+  "globalOverview": {
+    "tabs": {
+      "map": "Carte",
+      "barplot": "Graphique à barres",
+      "barplotNoData": "Aucune donnée de source One Health disponible pour cet organisme."
+    }
   }
 }

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -245,7 +245,7 @@
       "serotypeResistance": "Couverture Vaccinale",
       "pmenClones": "Clones PMEN",
       "cooccurrence": "Co-occurrence RAM",
-      "atbCorrelation": "Usage ATB vs Résistance"
+      "atbCorrelation": "Usage AM vs Résistance"
     },
     "gvp": {
       "compareTooltip": "Compare les prédictions de résistance dérivées du génome par AMRnet avec les données de surveillance phénotypique. Chaque point = un pays. Points sur la diagonale = concordance parfaite. Barres d’erreur = IC Wilson 95 % sur l’estimation génomique.",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -590,5 +590,12 @@
     "Beta-lactam": "Beta-lactâmico",
     "Phenicol": "Fenicol",
     "Carbapenem": "Carbapenem"
+  },
+  "globalOverview": {
+    "tabs": {
+      "map": "Mapa",
+      "barplot": "Gráfico de barras",
+      "barplotNoData": "Não há dados de fontes One Health disponíveis para este organismo."
+    }
   }
 }

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -245,7 +245,7 @@
       "serotypeResistance": "Cobertura Vacinal",
       "pmenClones": "Clones PMEN",
       "cooccurrence": "Co-ocorrência de RAM",
-      "atbCorrelation": "Uso de ATB vs Resistência",
+      "atbCorrelation": "Uso de AM vs Resistência",
       "oneHealthSource": "Fontes One Health",
       "linCode": "Linhagens LIN code"
     },


### PR DESCRIPTION
Smoke-tested on dev.amrnet.org. Promoting Phase 1 + Phase 2 of the dashboard reorganization to production.

## What's promoting

**Phase 1 (#383, merged):** rename ATB → AM in user-facing strings; remove PMEN Clones tab from AMR Insights.

**Phase 2 (#384, merged):** Global Overview tabs (Map / Bar plot), dev-only via `isProduction()` gate; One Health Source tab removed from AMR Insights (now reachable on dev's Global Overview Bar plot tab).

## Production impact

- **AM rename**: visible string change in the AM Usage vs Resistance tab + chart axis label. Same data underneath.
- **PMEN Clones tab gone**: AMR Insights is dev-only on prod, so prod users wouldn't have seen this anyway. No-op for prod users.
- **Global Overview**: `isProduction()` returns true on `www.amrnet.org` → `GlobalOverviewTabs` short-circuits to render `<Map />` exactly as before. **No new tab strip on prod.** Bundle hash will change because the new module is included, but runtime behaviour is identical to current production.
- **One Health Source removed from AMR Insights**: AMR Insights is dev-only on prod, so this is invisible to prod users.

## Deploy plan

After merge: `./deploy/deploy-production.sh` will rsync, build with `REACT_APP_ENVIRONMENT=production`, restart pm2.