### PR TITLE
feat(graphs): move QRDR Mutations + Vaccine Coverage to Summary Plots (Phase 3a)

### DIFF
--- a/client/src/components/Elements/AMRInsights/AMRInsights.js
+++ b/client/src/components/Elements/AMRInsights/AMRInsights.js
@@ -21,8 +21,6 @@ import { CooccurrenceGraph } from '../Graphs/CooccurrenceGraph';
 import { ConvergenceMapGraph } from '../Graphs/ConvergenceMapGraph';
 import { GeneMapGraph } from '../Graphs/GeneMapGraph';
 import { GenomicVsPhenotypicGraph } from '../Graphs/GenomicVsPhenotypicGraph';
-import { QRDRPathwayGraph } from '../Graphs/QRDRPathwayGraph';
-import { SerotypeResistanceGraph } from '../Graphs/SerotypeResistanceGraph';
 import { StratifiedResistanceGraph } from '../Graphs/StratifiedResistanceGraph';
 import { LINcodeGenotypeGraph } from '../Graphs/LINcodeGenotypeGraph/LINcodeGenotypeGraph';
 import { useStyles } from './AMRInsightsMUI';
@@ -45,18 +43,6 @@ const TABS = [
     value: 'GMP',
     component: <GeneMapGraph />,
     onlyFor: [],
-  },
-  {
-    labelKey: 'amrInsights.tabs.qrdrPathway',
-    value: 'QRDR',
-    component: <QRDRPathwayGraph />,
-    onlyFor: ['styphi', 'ngono', 'senterica', 'sentericaints'],
-  },
-  {
-    labelKey: 'amrInsights.tabs.serotypeResistance',
-    value: 'SRT',
-    component: <SerotypeResistanceGraph />,
-    onlyFor: ['strepneumo'],
   },
   {
     labelKey: 'amrInsights.tabs.linCode',
@@ -147,8 +133,6 @@ export const AMRInsights = () => {
         return Array.isArray(drugsCountriesData[firstKey]) ? drugsCountriesData[firstKey] : [];
       }
       case 'GMP': // Gene map — export raw kpneumo data with gene fields
-      case 'QRDR': // QRDR — export raw styphi data
-      case 'SRT': // Serotype — export raw strepneumo data
       case 'CVM': // Convergence map — export raw kpneumo data
         return Array.isArray(rawOrganismData) ? rawOrganismData.slice(0, 5000) : []; // Cap at 5k rows for CSV
       default:

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -233,7 +233,9 @@
     "topGenotypesUpTo10": "Top Genotypes (up to 10)",
     "topGenotypesUpTo30": "Top Genotypes (up to 30)",
     "emergenceRate": "Resistance Emergence Rate",
-    "emergenceRateDescription": "Average annual change in resistance prevalence (%/year) — identifies accelerating resistance"
+    "emergenceRateDescription": "Average annual change in resistance prevalence (%/year) — identifies accelerating resistance",
+    "qrdrMutations": "QRDR Mutations",
+    "vaccineCoverage": "Vaccine Coverage"
   },
   "floatingGlobalFilters": {
     "title": "Global Filters",

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -233,7 +233,9 @@
     "temporalHeatmap": "Mapa de Calor Temporal",
     "temporalHeatmapDescription": "Prevalencia de resistencia por país a lo largo del tiempo para un antibiótico seleccionado",
     "emergenceRate": "Tasa de Emergencia de Resistencia",
-    "emergenceRateDescription": "Cambio anual promedio en la prevalencia de resistencia (%/año) — identifica resistencias en aceleración"
+    "emergenceRateDescription": "Cambio anual promedio en la prevalencia de resistencia (%/año) — identifica resistencias en aceleración",
+    "qrdrMutations": "Mutaciones QRDR",
+    "vaccineCoverage": "Cobertura de vacunas"
   },
   "amrInsights": {
     "title": "Análisis de RAM",

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -233,7 +233,9 @@
     "temporalHeatmap": "Carte Thermique Temporelle",
     "temporalHeatmapDescription": "Prévalence de la résistance par pays au fil du temps pour un antibiotique sélectionné",
     "emergenceRate": "Taux d'Émergence de la Résistance",
-    "emergenceRateDescription": "Changement annuel moyen de la prévalence de résistance (%/an) — identifie les résistances en accélération"
+    "emergenceRateDescription": "Changement annuel moyen de la prévalence de résistance (%/an) — identifie les résistances en accélération",
+    "qrdrMutations": "Mutations QRDR",
+    "vaccineCoverage": "Couverture vaccinale"
   },
   "amrInsights": {
     "title": "Analyses RAM",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -233,7 +233,9 @@
     "temporalHeatmap": "Mapa de Calor Temporal",
     "temporalHeatmapDescription": "Prevalência de resistência por país ao longo do tempo para uma droga selecionada",
     "emergenceRate": "Taxa de Emergência de Resistência",
-    "emergenceRateDescription": "Mudança anual média na prevalência de resistência (%/ano) — identifica resistência em aceleração"
+    "emergenceRateDescription": "Mudança anual média na prevalência de resistência (%/ano) — identifica resistência em aceleração",
+    "qrdrMutations": "Mutações QRDR",
+    "vaccineCoverage": "Cobertura vacinal"
   },
   "amrInsights": {
     "title": "Análises de RAM",

--- a/client/src/util/graphCards.js
+++ b/client/src/util/graphCards.js
@@ -1,4 +1,4 @@
-import { BubbleChart, GridOn, ShowChart, StackedBarChart, Timeline, ViewModule } from '@mui/icons-material';
+import { BubbleChart, GridOn, ShowChart, StackedBarChart, Timeline, ViewModule, Science, Vaccines } from '@mui/icons-material';
 import { BubbleHeatmapGraph2 } from '../components/Elements/Graphs/BubbleHeatmapGraph2';
 import { BubbleKOHeatmapGraph } from '../components/Elements/Graphs/BubbleKOHeatmapGraph';
 import { BubbleMarkersHeatmapGraph } from '../components/Elements/Graphs/BubbleMarkersHeatmapGraph';
@@ -8,10 +8,13 @@ import { DistributionGraph } from '../components/Elements/Graphs/DistributionGra
 import { DrugResistanceGraph } from '../components/Elements/Graphs/DrugResistanceGraph';
 import { KOTrendsGraph } from '../components/Elements/Graphs/KOTrends';
 import { MarkerTrendsGraph } from '../components/Elements/Graphs/MarkerTrendsGraph';
+import { QRDRPathwayGraph } from '../components/Elements/Graphs/QRDRPathwayGraph';
+import { SerotypeResistanceGraph } from '../components/Elements/Graphs/SerotypeResistanceGraph';
 import { TemporalHeatmapGraph } from '../components/Elements/Graphs/TemporalHeatmapGraph';
 import { EmergenceRateGraph } from '../components/Elements/Graphs/EmergenceRateGraph';
 import { amrLikeOrganisms, organismsCards } from './organismsCards';
 import { BubbleHPGraph } from '../components/Elements/ContinentPathotypeGraphs/BubbleHPGraph/BubbleHPGraph';
+import { isProduction } from './env';
 import { useTranslation } from 'react-i18next';
 import { t } from 'react-i18next';
 
@@ -166,6 +169,27 @@ export function getGraphCards(t){
       id: 'BHP',
       organisms: ['senterica'],
       component: <BubbleHPGraph />,
+    },
+    {
+      title: t('graphs.qrdrMutations'),
+      description: [''],
+      icon: <Science color="primary" />,
+      id: 'QRDR',
+      // Dev-only: collapsing the organism list to [] in production hides
+      // the tab via the existing `card.organisms.includes(organism)` filter
+      // in Graphs.js. Same gating philosophy as the Radar Profile tab.
+      organisms: isProduction() ? [] : ['styphi', 'ngono', 'senterica', 'sentericaints'],
+      component: <QRDRPathwayGraph />,
+    },
+    {
+      title: t('graphs.vaccineCoverage'),
+      description: [''],
+      icon: <Vaccines color="primary" />,
+      id: 'VAC',
+      // strepneumo is itself in DEV_ONLY_ORGANISMS, so this tab is
+      // unreachable on production regardless of the gate above.
+      organisms: ['strepneumo'],
+      component: <SerotypeResistanceGraph />,
     },
   ];
 };


### PR DESCRIPTION
First half of Phase 3 — pure relocation, no behavior change inside the components themselves.

## What this PR does

Relocates two charts from **AMR Insights** to **Summary Plots**:

| Tab | id | Organisms | Visible on prod? |
|---|---|---|---|
| QRDR Mutations | `QRDR` | `styphi`, `ngono`, `senterica`, `sentericaints` | ❌ dev-only via `isProduction()` collapsing the list to `[]` |
| Vaccine Coverage | `VAC` | `strepneumo` | ❌ `strepneumo` ∈ `DEV_ONLY_ORGANISMS` so it's unreachable on prod regardless |

The dev-only mechanism for QRDR is the same one used by the Radar Profile tab — `organisms: isProduction() ? [] : [...]` — so the tab is filtered out of `Graphs.js` by the existing `card.organisms.includes(organism)` check.

## Files touched

- `client/src/util/graphCards.js` — adds two new tab cards and the corresponding component imports
- `client/src/components/Elements/AMRInsights/AMRInsights.js` — removes the `QRDR` + `SRT` tab entries, the now-unused imports, and the dead cases in the `csvData` switch
- `client/src/locales/{en,es,fr,pt}.json` — adds `graphs.qrdrMutations` and `graphs.vaccineCoverage`

## Production impact

None.

- AMR Insights itself is dev-only on prod, so the removals from it aren't visible to prod users
- QRDR's organism list collapses to `[]` on prod → tab not rendered
- Vaccine Coverage's organism (`strepneumo`) is unreachable on prod → tab not rendered

## What's NOT in this PR (Phase 3b, larger follow-up)

- Floating right-hand plotting-options panel for QRDR + Vaccine Coverage (using the existing `showFilter` prop pattern from `DrugResistanceGraph`)
- Country / region selector via the existing `<SelectCountry />` component
- Vaccine filter and Sort by dropdowns lifted out of `SerotypeResistanceGraph` internal state into the floating panel
- Both charts adapted to filter `rawOrganismData` by selected country / region

## Verification suggested before merge

On `dev.amrnet.org` after deploy:

- [ ] **Summary Plots → styphi / ngono / senterica / sentericaints**: new "QRDR Mutations" tab appears and renders the same content as before (when it was inside AMR Insights)
- [ ] **Summary Plots → strepneumo**: new "Vaccine Coverage" tab appears and renders the same content
- [ ] **AMR Insights → styphi / ngono / senterica / sentericaints**: the "QRDR Pathway" tab is **gone**
- [ ] **AMR Insights → strepneumo**: the "Serotype Resistance" tab is **gone**
- [ ] **AMR Insights → strepneumo**: only "Genomic vs Phenotypic" / "Gene Map" / "AMR Co-occurrence" / "AM Usage vs Resistance" remain (PMEN was removed in #383)

Local prod build (`REACT_APP_ENVIRONMENT=production npm run build`):

- [ ] **Summary Plots → styphi**: no "QRDR Mutations" tab
- [ ] **Summary Plots → strepneumo**: not reachable (organism filtered out by `DEV_ONLY_ORGANISMS`)