### PR TITLE
Promote development → main: Phase 3a (move QRDR + Vaccine Coverage to Summary Plots)

### DIFF
--- a/client/src/components/Elements/AMRInsights/AMRInsights.js
+++ b/client/src/components/Elements/AMRInsights/AMRInsights.js
@@ -21,8 +21,6 @@ import { CooccurrenceGraph } from '../Graphs/CooccurrenceGraph';
 import { ConvergenceMapGraph } from '../Graphs/ConvergenceMapGraph';
 import { GeneMapGraph } from '../Graphs/GeneMapGraph';
 import { GenomicVsPhenotypicGraph } from '../Graphs/GenomicVsPhenotypicGraph';
-import { QRDRPathwayGraph } from '../Graphs/QRDRPathwayGraph';
-import { SerotypeResistanceGraph } from '../Graphs/SerotypeResistanceGraph';
 import { StratifiedResistanceGraph } from '../Graphs/StratifiedResistanceGraph';
 import { LINcodeGenotypeGraph } from '../Graphs/LINcodeGenotypeGraph/LINcodeGenotypeGraph';
 import { useStyles } from './AMRInsightsMUI';
@@ -45,18 +43,6 @@ const TABS = [
     value: 'GMP',
     component: <GeneMapGraph />,
     onlyFor: [],
-  },
-  {
-    labelKey: 'amrInsights.tabs.qrdrPathway',
-    value: 'QRDR',
-    component: <QRDRPathwayGraph />,
-    onlyFor: ['styphi', 'ngono', 'senterica', 'sentericaints'],
-  },
-  {
-    labelKey: 'amrInsights.tabs.serotypeResistance',
-    value: 'SRT',
-    component: <SerotypeResistanceGraph />,
-    onlyFor: ['strepneumo'],
   },
   {
     labelKey: 'amrInsights.tabs.linCode',
@@ -147,8 +133,6 @@ export const AMRInsights = () => {
         return Array.isArray(drugsCountriesData[firstKey]) ? drugsCountriesData[firstKey] : [];
       }
       case 'GMP': // Gene map — export raw kpneumo data with gene fields
-      case 'QRDR': // QRDR — export raw styphi data
-      case 'SRT': // Serotype — export raw strepneumo data
       case 'CVM': // Convergence map — export raw kpneumo data
         return Array.isArray(rawOrganismData) ? rawOrganismData.slice(0, 5000) : []; // Cap at 5k rows for CSV
       default:

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -233,7 +233,9 @@
     "topGenotypesUpTo10": "Top Genotypes (up to 10)",
     "topGenotypesUpTo30": "Top Genotypes (up to 30)",
     "emergenceRate": "Resistance Emergence Rate",
-    "emergenceRateDescription": "Average annual change in resistance prevalence (%/year) — identifies accelerating resistance"
+    "emergenceRateDescription": "Average annual change in resistance prevalence (%/year) — identifies accelerating resistance",
+    "qrdrMutations": "QRDR Mutations",
+    "vaccineCoverage": "Vaccine Coverage"
   },
   "floatingGlobalFilters": {
     "title": "Global Filters",

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -233,7 +233,9 @@
     "temporalHeatmap": "Mapa de Calor Temporal",
     "temporalHeatmapDescription": "Prevalencia de resistencia por país a lo largo del tiempo para un antibiótico seleccionado",
     "emergenceRate": "Tasa de Emergencia de Resistencia",
-    "emergenceRateDescription": "Cambio anual promedio en la prevalencia de resistencia (%/año) — identifica resistencias en aceleración"
+    "emergenceRateDescription": "Cambio anual promedio en la prevalencia de resistencia (%/año) — identifica resistencias en aceleración",
+    "qrdrMutations": "Mutaciones QRDR",
+    "vaccineCoverage": "Cobertura de vacunas"
   },
   "amrInsights": {
     "title": "Análisis de RAM",

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -233,7 +233,9 @@
     "temporalHeatmap": "Carte Thermique Temporelle",
     "temporalHeatmapDescription": "Prévalence de la résistance par pays au fil du temps pour un antibiotique sélectionné",
     "emergenceRate": "Taux d'Émergence de la Résistance",
-    "emergenceRateDescription": "Changement annuel moyen de la prévalence de résistance (%/an) — identifie les résistances en accélération"
+    "emergenceRateDescription": "Changement annuel moyen de la prévalence de résistance (%/an) — identifie les résistances en accélération",
+    "qrdrMutations": "Mutations QRDR",
+    "vaccineCoverage": "Couverture vaccinale"
   },
   "amrInsights": {
     "title": "Analyses RAM",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -233,7 +233,9 @@
     "temporalHeatmap": "Mapa de Calor Temporal",
     "temporalHeatmapDescription": "Prevalência de resistência por país ao longo do tempo para uma droga selecionada",
     "emergenceRate": "Taxa de Emergência de Resistência",
-    "emergenceRateDescription": "Mudança anual média na prevalência de resistência (%/ano) — identifica resistência em aceleração"
+    "emergenceRateDescription": "Mudança anual média na prevalência de resistência (%/ano) — identifica resistência em aceleração",
+    "qrdrMutations": "Mutações QRDR",
+    "vaccineCoverage": "Cobertura vacinal"
   },
   "amrInsights": {
     "title": "Análises de RAM",

--- a/client/src/util/graphCards.js
+++ b/client/src/util/graphCards.js
@@ -1,4 +1,4 @@
-import { BubbleChart, GridOn, ShowChart, StackedBarChart, Timeline, ViewModule } from '@mui/icons-material';
+import { BubbleChart, GridOn, ShowChart, StackedBarChart, Timeline, ViewModule, Science, Vaccines } from '@mui/icons-material';
 import { BubbleHeatmapGraph2 } from '../components/Elements/Graphs/BubbleHeatmapGraph2';
 import { BubbleKOHeatmapGraph } from '../components/Elements/Graphs/BubbleKOHeatmapGraph';
 import { BubbleMarkersHeatmapGraph } from '../components/Elements/Graphs/BubbleMarkersHeatmapGraph';
@@ -8,10 +8,13 @@ import { DistributionGraph } from '../components/Elements/Graphs/DistributionGra
 import { DrugResistanceGraph } from '../components/Elements/Graphs/DrugResistanceGraph';
 import { KOTrendsGraph } from '../components/Elements/Graphs/KOTrends';
 import { MarkerTrendsGraph } from '../components/Elements/Graphs/MarkerTrendsGraph';
+import { QRDRPathwayGraph } from '../components/Elements/Graphs/QRDRPathwayGraph';
+import { SerotypeResistanceGraph } from '../components/Elements/Graphs/SerotypeResistanceGraph';
 import { TemporalHeatmapGraph } from '../components/Elements/Graphs/TemporalHeatmapGraph';
 import { EmergenceRateGraph } from '../components/Elements/Graphs/EmergenceRateGraph';
 import { amrLikeOrganisms, organismsCards } from './organismsCards';
 import { BubbleHPGraph } from '../components/Elements/ContinentPathotypeGraphs/BubbleHPGraph/BubbleHPGraph';
+import { isProduction } from './env';
 import { useTranslation } from 'react-i18next';
 import { t } from 'react-i18next';
 
@@ -166,6 +169,27 @@ export function getGraphCards(t){
       id: 'BHP',
       organisms: ['senterica'],
       component: <BubbleHPGraph />,
+    },
+    {
+      title: t('graphs.qrdrMutations'),
+      description: [''],
+      icon: <Science color="primary" />,
+      id: 'QRDR',
+      // Dev-only: collapsing the organism list to [] in production hides
+      // the tab via the existing `card.organisms.includes(organism)` filter
+      // in Graphs.js. Same gating philosophy as the Radar Profile tab.
+      organisms: isProduction() ? [] : ['styphi', 'ngono', 'senterica', 'sentericaints'],
+      component: <QRDRPathwayGraph />,
+    },
+    {
+      title: t('graphs.vaccineCoverage'),
+      description: [''],
+      icon: <Vaccines color="primary" />,
+      id: 'VAC',
+      // strepneumo is itself in DEV_ONLY_ORGANISMS, so this tab is
+      // unreachable on production regardless of the gate above.
+      organisms: ['strepneumo'],
+      component: <SerotypeResistanceGraph />,
     },
   ];
 };


### PR DESCRIPTION
Phase 3a, smoke-tested on dev.amrnet.org. Promoting to production.

## What's promoting

**#386 — feat(graphs): move QRDR Mutations + Vaccine Coverage to Summary Plots**

- New `QRDR Mutations` tab in Summary Plots for `styphi`/`ngono`/`senterica`/`sentericaints` — **dev-only** via `isProduction()` collapsing the organism list to `[]`.
- New `Vaccine Coverage` tab for `strepneumo` — `strepneumo` is in `DEV_ONLY_ORGANISMS` so it's unreachable on prod.
- Removed corresponding `QRDR` + `SRT` tabs from AMR Insights (also dev-only on prod).

## Production impact: zero

- QRDR's organism list is `[]` on prod → tab filtered out by `Graphs.js`
- Vaccine Coverage's organism is unreachable on prod
- AMR Insights itself is dev-only

The bundle hash will change because of the new module imports, but no behavioural diff for prod users.

## Deploy plan

After merge: `./deploy/deploy-production.sh` (rsync, build, pm2 restart).