### PR TITLE
fix(graphs): guard NaN in DRT percentage calc to stop Recharts crash on styphi

### DIFF
--- a/client/src/components/Elements/Graphs/DrugResistanceGraph/DrugResistanceGraph.js
+++ b/client/src/components/Elements/Graphs/DrugResistanceGraph/DrugResistanceGraph.js
@@ -141,7 +141,21 @@ export const DrugResistanceGraph = ({ showFilter, setShowFilter }) => {
 
       const keys = Object.keys(item).filter(x => !exclusions.includes(x));
       keys.forEach(key => {
-        item[key] = Number(((item[key] / item.count) * 100).toFixed(2));
+        const v = item[key];
+        // Drugs that have no entry for this year produce undefined here;
+        // dividing undefined by count yields NaN and crashes Recharts'
+        // tick generator (`getNiceTickValues`). Skip them so Recharts
+        // sees a missing data point instead of a NaN.
+        if (v == null || !Number.isFinite(item.count) || item.count <= 0) {
+          delete item[key];
+          return;
+        }
+        const pct = Number(((v / item.count) * 100).toFixed(2));
+        if (!Number.isFinite(pct)) {
+          delete item[key];
+          return;
+        }
+        item[key] = pct;
       });
 
       item.name = name;


### PR DESCRIPTION
## Bug

On the Salmonella Typhi dashboard, toggling the **Local / Global** dataset option in the global filter, or pressing the **RESET** button, produced:

```
react-dom.production.min.js:188
[DecimalError] Invalid argument: NaN
    at getNiceTickValues.js:299
    at utils.js:129
    at Fk (ChartUtils.js:868)
    at CartesianUtils.js:90
    at _j (CartesianUtils.js:43)
    at generateCategoricalChart.js:843
```

Recharts' axis tick generator can't compute "nice" tick values when the chart data array contains NaN.

## Root cause

In `DrugResistanceGraph.js`'s `trendsData` memo, each year bucket gets converted to percentages:

```js
keys.forEach(key => {
  item[key] = Number(((item[key] / item.count) * 100).toFixed(2));
});
```

When a year bucket lacks an entry for a particular drug (which happens for styphi after the dataset toggle reshapes the underlying year-grouping), `item[key]` is `undefined`. `undefined / N * 100` evaluates to `NaN`. That NaN flows into the Recharts data array and crashes the tick generator.

The bug existed in principle for any organism, but only the styphi Local / Global dataset toggle reliably reshapes year buckets in a way that exposes it — that's why it's only reproduced on styphi.

## Fix

Skip / delete the drug key when the value is missing, when the count is non-positive, or when the resulting percentage is not finite:

```js
keys.forEach(key => {
  const v = item[key];
  if (v == null || !Number.isFinite(item.count) || item.count <= 0) {
    delete item[key];
    return;
  }
  const pct = Number(((v / item.count) * 100).toFixed(2));
  if (!Number.isFinite(pct)) {
    delete item[key];
    return;
  }
  item[key] = pct;
});
```

Recharts handles missing-data points cleanly (renders a gap), which is the intended behaviour anyway.

## Verification suggested before merge

On `dev.amrnet.org` after deploy, with organism = `styphi`:
- [ ] Press the **RESET** button → no crash, AMR Trends chart re-renders
- [ ] Toggle **Local** / **Global** in the global filter → no crash, chart updates with new data
- [ ] Other organisms behave the same as before
- [ ] No regression in DRT legend / line behaviour from #377

## What's NOT in this PR

This is a targeted hotfix for the NaN-in-axis-tick crash. The country/region plotting options for QRDR + Vaccine Coverage from #388 are unaffected and remain available on Summary Plots.