### PR TITLE
fix(graphs): extend NaN guard to Distribution + Marker Trends charts

### DIFF
--- a/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
+++ b/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
@@ -269,7 +269,20 @@ export const DistributionGraph = ({ showFilter, setShowFilter }) => {
     const percentageArray = structuredClone(baseArray).map(item => {
       const keys = Object.keys(item).filter(k => !exclusions.includes(k));
       keys.forEach(key => {
-        item[key] = Number(((item[key] / item.count) * 100).toFixed(2));
+        const v = item[key];
+        // Guard NaN from undefined/missing keys or zero-count years.
+        // Without this, the resulting NaN propagates into Recharts'
+        // axis-tick generator and crashes the chart.
+        if (v == null || !Number.isFinite(item.count) || item.count <= 0) {
+          delete item[key];
+          return;
+        }
+        const pct = Number(((v / item.count) * 100).toFixed(2));
+        if (!Number.isFinite(pct)) {
+          delete item[key];
+          return;
+        }
+        item[key] = pct;
       });
       return item;
     });

--- a/client/src/components/Elements/Graphs/MarkerTrendsGraph/MarkerTrendsGraph.js
+++ b/client/src/components/Elements/Graphs/MarkerTrendsGraph/MarkerTrendsGraph.js
@@ -263,7 +263,19 @@ export const MarkerTrendsGraph = ({ showFilter, setShowFilter }) => {
       const keys = Object.keys(item).filter(x => !exclusions.includes(x));
 
       keys.forEach(key => {
-        item[key] = Number(((item[key] / item.totalCount) * 100).toFixed(2));
+        const v = item[key];
+        // Guard NaN from undefined/missing keys or zero-totalCount years
+        // (otherwise NaN propagates into Recharts' tick generator).
+        if (v == null || !Number.isFinite(item.totalCount) || item.totalCount <= 0) {
+          delete item[key];
+          return;
+        }
+        const pct = Number(((v / item.totalCount) * 100).toFixed(2));
+        if (!Number.isFinite(pct)) {
+          delete item[key];
+          return;
+        }
+        item[key] = pct;
       });
 
       return item;


### PR DESCRIPTION
Follow-up to #389. Same Recharts axis-tick crash pattern in two more charts that styphi exposes via the Local/Global dataset toggle and RESET button:\n\n- DistributionGraph (Genotype Trends) — line 272\n- MarkerTrendsGraph (AMR Marker Trends) — line 266\n\nApplies the same defensive fix: skip / delete the key when the value is missing or the count is non-positive, so Recharts sees a missing data point instead of NaN.