### PR TITLE
fix(graphs): blanket NaN guard across remaining chart files (#389/#390/#391 follow-up)

### DIFF
--- a/client/src/components/Elements/Graphs/DeterminantsGraph/DeterminantsGraph.js
+++ b/client/src/components/Elements/Graphs/DeterminantsGraph/DeterminantsGraph.js
@@ -187,7 +187,17 @@ export const DeterminantsGraph = ({ showFilter, setShowFilter }) => {
         dispatch(setSliderList(keys.length));
 
         keys.forEach(key => {
-          item[key] = Number(((item[key] / item.totalCount) * 100).toFixed(2));
+          const v = item[key];
+          if (v == null || !Number.isFinite(item.totalCount) || item.totalCount <= 0) {
+            delete item[key];
+            return;
+          }
+          const pct = Number(((v / item.totalCount) * 100).toFixed(2));
+          if (!Number.isFinite(pct)) {
+            delete item[key];
+            return;
+          }
+          item[key] = pct;
         });
 
         return item;

--- a/client/src/components/Elements/Graphs/FrequenciesGraph/FrequenciesGraph.js
+++ b/client/src/components/Elements/Graphs/FrequenciesGraph/FrequenciesGraph.js
@@ -157,7 +157,17 @@ export const FrequenciesGraph = ({ showFilter, setShowFilter }) => {
       const keys = Object.keys(item).filter(x => !exclusions.includes(x));
 
       keys.forEach(key => {
-        item[key] = Number(((item[key] / item.totalCount) * 100).toFixed(2));
+        const v = item[key];
+        if (v == null || !Number.isFinite(item.totalCount) || item.totalCount <= 0) {
+          delete item[key];
+          return;
+        }
+        const pct = Number(((v / item.totalCount) * 100).toFixed(2));
+        if (!Number.isFinite(pct)) {
+          delete item[key];
+          return;
+        }
+        item[key] = pct;
       });
 
       return item;

--- a/client/src/components/Elements/Graphs/KOTrends/KOTrendsGraph.js
+++ b/client/src/components/Elements/Graphs/KOTrends/KOTrendsGraph.js
@@ -237,7 +237,17 @@ export const KOTrendsGraph = ({ showFilter, setShowFilter }) => {
       .map(item => {
         const keys = Object.keys(item).filter(k => !exclusions.includes(k));
         keys.forEach(key => {
-          item[key] = Number(((item[key] / item.count) * 100).toFixed(2));
+          const v = item[key];
+          if (v == null || !Number.isFinite(item.count) || item.count <= 0) {
+            delete item[key];
+            return;
+          }
+          const pct = Number(((v / item.count) * 100).toFixed(2));
+          if (!Number.isFinite(pct)) {
+            delete item[key];
+            return;
+          }
+          item[key] = pct;
         });
         return item;
       })

--- a/client/src/components/Elements/Graphs/TrendsGraph/TrendsGraph.js
+++ b/client/src/components/Elements/Graphs/TrendsGraph/TrendsGraph.js
@@ -229,7 +229,17 @@ export const TrendsGraph = ({ showFilter, setShowFilter }) => {
       const keys = Object.keys(item).filter(x => !exclusions.includes(x));
 
       keys.forEach(key => {
-        item[key] = Number(((item[key] / item.totalCount) * 100).toFixed(2));
+        const v = item[key];
+        if (v == null || !Number.isFinite(item.totalCount) || item.totalCount <= 0) {
+          delete item[key];
+          return;
+        }
+        const pct = Number(((v / item.totalCount) * 100).toFixed(2));
+        if (!Number.isFinite(pct)) {
+          delete item[key];
+          return;
+        }
+        item[key] = pct;
       });
 
       return item;


### PR DESCRIPTION
Same defensive pattern as the previous three NaN-guard hotfixes, applied to four more chart files: DeterminantsGraph, FrequenciesGraph, KOTrendsGraph, TrendsGraph. RadarProfileGraph already has its own count guard so isn't touched.