### PR TITLE
diagnostic: revert PRs #389/#390/#391/#392 to bisect styphi NaN crash

### DIFF
--- a/client/src/components/Elements/Graphs/ATBCorrelationGraph/ATBCorrelationGraph.js
+++ b/client/src/components/Elements/Graphs/ATBCorrelationGraph/ATBCorrelationGraph.js
@@ -57,17 +57,8 @@ function linearRegression(data) {
   if (n < 2) return { slope: 0, intercept: 0, r2: 0 };
   let sumX = 0, sumY = 0, sumXY = 0, sumX2 = 0;
   data.forEach(d => { sumX += d.x; sumY += d.y; sumXY += d.x * d.y; sumX2 += d.x * d.x; });
-  // Guard against zero denominator (all x values equal) and any NaN/Infinity
-  // that could otherwise propagate into the chart and crash Recharts.
-  const denom = n * sumX2 - sumX * sumX;
-  if (!Number.isFinite(denom) || denom === 0) {
-    return { slope: 0, intercept: sumY / n, r2: 0 };
-  }
-  const slope = (n * sumXY - sumX * sumY) / denom;
+  const slope = (n * sumXY - sumX * sumY) / (n * sumX2 - sumX * sumX);
   const intercept = (sumY - slope * sumX) / n;
-  if (!Number.isFinite(slope) || !Number.isFinite(intercept)) {
-    return { slope: 0, intercept: 0, r2: 0 };
-  }
   const ssRes = data.reduce((s, d) => s + Math.pow(d.y - (slope * d.x + intercept), 2), 0);
   const ssTot = data.reduce((s, d) => s + Math.pow(d.y - sumY / n, 2), 0);
   return { slope, intercept, r2: ssTot > 0 ? 1 - ssRes / ssTot : 0 };
@@ -202,17 +193,11 @@ export const ATBCorrelationGraph = ({ showFilter, setShowFilter }) => {
     Object.entries(resistanceByCountry).forEach(([country, res]) => {
       const consumption = consumptionByCountry[country];
       if (consumption && res.value != null) {
-        const x = Number(consumption.value);
-        const y = Number(Number(res.value).toFixed(1));
-        // Drop points whose coordinates aren't finite — otherwise the
-        // XAxis (`domain={['auto','auto']}`) auto-domain reduces to NaN
-        // and Recharts' getNiceTickValues crashes.
-        if (!Number.isFinite(x) || !Number.isFinite(y)) return;
         const region = countryToRegion[country] || 'Unknown';
         points.push({
           country,
-          x,
-          y,
+          x: consumption.value,
+          y: Number(Number(res.value).toFixed(1)),
           genomes: res.tested || 0,
           region,
           color: regionColors[region] || regionColors['Unknown'],
@@ -253,14 +238,6 @@ export const ATBCorrelationGraph = ({ showFilter, setShowFilter }) => {
   const xMax = scatterData.length > 0 ? Math.max(...scatterData.map(d => d.x)) * 1.05 : 10;
   const trendY1 = Math.max(0, Math.min(100, regression.slope * xMin + regression.intercept));
   const trendY2 = Math.max(0, Math.min(100, regression.slope * xMax + regression.intercept));
-  // Only render the trend line when every coordinate is finite — passing
-  // NaN to a ReferenceLine forces Recharts to recompute axis ticks with a
-  // bad domain, which crashes the categorical chart with a DecimalError.
-  const trendLineFinite =
-    Number.isFinite(xMin) &&
-    Number.isFinite(xMax) &&
-    Number.isFinite(trendY1) &&
-    Number.isFinite(trendY2);
 
   return (
     <CardContent className={classes.atbCorrelationGraph}>
@@ -346,7 +323,7 @@ export const ATBCorrelationGraph = ({ showFilter, setShowFilter }) => {
                     <Cell key={`cell-${i}`} fill={entry.color} />
                   ))}
                 </Scatter>
-                {showTrendLine && scatterData.length >= 2 && trendLineFinite && (
+                {showTrendLine && scatterData.length >= 2 && (
                   <ReferenceLine
                     segment={[
                       { x: xMin, y: trendY1 },

--- a/client/src/components/Elements/Graphs/DeterminantsGraph/DeterminantsGraph.js
+++ b/client/src/components/Elements/Graphs/DeterminantsGraph/DeterminantsGraph.js
@@ -187,17 +187,7 @@ export const DeterminantsGraph = ({ showFilter, setShowFilter }) => {
         dispatch(setSliderList(keys.length));
 
         keys.forEach(key => {
-          const v = item[key];
-          if (v == null || !Number.isFinite(item.totalCount) || item.totalCount <= 0) {
-            delete item[key];
-            return;
-          }
-          const pct = Number(((v / item.totalCount) * 100).toFixed(2));
-          if (!Number.isFinite(pct)) {
-            delete item[key];
-            return;
-          }
-          item[key] = pct;
+          item[key] = Number(((item[key] / item.totalCount) * 100).toFixed(2));
         });
 
         return item;

--- a/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
+++ b/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
@@ -269,20 +269,7 @@ export const DistributionGraph = ({ showFilter, setShowFilter }) => {
     const percentageArray = structuredClone(baseArray).map(item => {
       const keys = Object.keys(item).filter(k => !exclusions.includes(k));
       keys.forEach(key => {
-        const v = item[key];
-        // Guard NaN from undefined/missing keys or zero-count years.
-        // Without this, the resulting NaN propagates into Recharts'
-        // axis-tick generator and crashes the chart.
-        if (v == null || !Number.isFinite(item.count) || item.count <= 0) {
-          delete item[key];
-          return;
-        }
-        const pct = Number(((v / item.count) * 100).toFixed(2));
-        if (!Number.isFinite(pct)) {
-          delete item[key];
-          return;
-        }
-        item[key] = pct;
+        item[key] = Number(((item[key] / item.count) * 100).toFixed(2));
       });
       return item;
     });

--- a/client/src/components/Elements/Graphs/DrugResistanceGraph/DrugResistanceGraph.js
+++ b/client/src/components/Elements/Graphs/DrugResistanceGraph/DrugResistanceGraph.js
@@ -141,21 +141,7 @@ export const DrugResistanceGraph = ({ showFilter, setShowFilter }) => {
 
       const keys = Object.keys(item).filter(x => !exclusions.includes(x));
       keys.forEach(key => {
-        const v = item[key];
-        // Drugs that have no entry for this year produce undefined here;
-        // dividing undefined by count yields NaN and crashes Recharts'
-        // tick generator (`getNiceTickValues`). Skip them so Recharts
-        // sees a missing data point instead of a NaN.
-        if (v == null || !Number.isFinite(item.count) || item.count <= 0) {
-          delete item[key];
-          return;
-        }
-        const pct = Number(((v / item.count) * 100).toFixed(2));
-        if (!Number.isFinite(pct)) {
-          delete item[key];
-          return;
-        }
-        item[key] = pct;
+        item[key] = Number(((item[key] / item.count) * 100).toFixed(2));
       });
 
       item.name = name;

--- a/client/src/components/Elements/Graphs/FrequenciesGraph/FrequenciesGraph.js
+++ b/client/src/components/Elements/Graphs/FrequenciesGraph/FrequenciesGraph.js
@@ -157,17 +157,7 @@ export const FrequenciesGraph = ({ showFilter, setShowFilter }) => {
       const keys = Object.keys(item).filter(x => !exclusions.includes(x));
 
       keys.forEach(key => {
-        const v = item[key];
-        if (v == null || !Number.isFinite(item.totalCount) || item.totalCount <= 0) {
-          delete item[key];
-          return;
-        }
-        const pct = Number(((v / item.totalCount) * 100).toFixed(2));
-        if (!Number.isFinite(pct)) {
-          delete item[key];
-          return;
-        }
-        item[key] = pct;
+        item[key] = Number(((item[key] / item.totalCount) * 100).toFixed(2));
       });
 
       return item;

--- a/client/src/components/Elements/Graphs/KOTrends/KOTrendsGraph.js
+++ b/client/src/components/Elements/Graphs/KOTrends/KOTrendsGraph.js
@@ -237,17 +237,7 @@ export const KOTrendsGraph = ({ showFilter, setShowFilter }) => {
       .map(item => {
         const keys = Object.keys(item).filter(k => !exclusions.includes(k));
         keys.forEach(key => {
-          const v = item[key];
-          if (v == null || !Number.isFinite(item.count) || item.count <= 0) {
-            delete item[key];
-            return;
-          }
-          const pct = Number(((v / item.count) * 100).toFixed(2));
-          if (!Number.isFinite(pct)) {
-            delete item[key];
-            return;
-          }
-          item[key] = pct;
+          item[key] = Number(((item[key] / item.count) * 100).toFixed(2));
         });
         return item;
       })

--- a/client/src/components/Elements/Graphs/MarkerTrendsGraph/MarkerTrendsGraph.js
+++ b/client/src/components/Elements/Graphs/MarkerTrendsGraph/MarkerTrendsGraph.js
@@ -263,19 +263,7 @@ export const MarkerTrendsGraph = ({ showFilter, setShowFilter }) => {
       const keys = Object.keys(item).filter(x => !exclusions.includes(x));
 
       keys.forEach(key => {
-        const v = item[key];
-        // Guard NaN from undefined/missing keys or zero-totalCount years
-        // (otherwise NaN propagates into Recharts' tick generator).
-        if (v == null || !Number.isFinite(item.totalCount) || item.totalCount <= 0) {
-          delete item[key];
-          return;
-        }
-        const pct = Number(((v / item.totalCount) * 100).toFixed(2));
-        if (!Number.isFinite(pct)) {
-          delete item[key];
-          return;
-        }
-        item[key] = pct;
+        item[key] = Number(((item[key] / item.totalCount) * 100).toFixed(2));
       });
 
       return item;

--- a/client/src/components/Elements/Graphs/TrendsGraph/TrendsGraph.js
+++ b/client/src/components/Elements/Graphs/TrendsGraph/TrendsGraph.js
@@ -229,17 +229,7 @@ export const TrendsGraph = ({ showFilter, setShowFilter }) => {
       const keys = Object.keys(item).filter(x => !exclusions.includes(x));
 
       keys.forEach(key => {
-        const v = item[key];
-        if (v == null || !Number.isFinite(item.totalCount) || item.totalCount <= 0) {
-          delete item[key];
-          return;
-        }
-        const pct = Number(((v / item.totalCount) * 100).toFixed(2));
-        if (!Number.isFinite(pct)) {
-          delete item[key];
-          return;
-        }
-        item[key] = pct;
+        item[key] = Number(((item[key] / item.totalCount) * 100).toFixed(2));
       });
 
       return item;


### PR DESCRIPTION
Diagnostic PR: reverting the four NaN-guard hotfixes so we can determine whether the residual styphi crash on dev (after Local toggle / Reset) comes from the hotfixes themselves or from Phase 3b (#388).

Production (main) works without these hotfixes. If reverting them on dev makes the crash go away, the hotfixes were the cause. If the crash persists after revert, Phase 3b is the cause and we'll revert that next.

Rollback path: each commit here is a clean `git revert` of a merge feature, so re-applying any subset is straightforward.