### PR TITLE
diagnostic: revert Phase 3b (#388) to confirm cause of styphi crash

### DIFF
--- a/client/src/components/Elements/Graphs/QRDRPathwayGraph/QRDRPathwayGraph.js
+++ b/client/src/components/Elements/Graphs/QRDRPathwayGraph/QRDRPathwayGraph.js
@@ -1,7 +1,6 @@
 import { InfoOutlined } from '@mui/icons-material';
 import {
   Box,
-  Card,
   CardContent,
   Tooltip,
   Typography,
@@ -21,8 +20,6 @@ import {
   ComposedChart,
 } from 'recharts';
 import { useAppSelector } from '../../../../stores/hooks';
-import { PlottingOptionsHeader } from '../../Shared/PlottingOptionsHeader';
-import { SelectCountry } from '../../SelectCountry';
 import { useStyles } from './QRDRPathwayGraphMUI';
 
 // All QRDR mutation fields in S. Typhi
@@ -183,25 +180,7 @@ export const QRDRPathwayGraph = ({ showFilter, setShowFilter }) => {
 
   const organism = useAppSelector(state => state.dashboard.organism);
   const canGetData = useAppSelector(state => state.dashboard.canGetData);
-  const rawDataAll = useAppSelector(state => state.graph.rawOrganismData);
-  const actualCountry = useAppSelector(state => state.dashboard.actualCountry);
-  const actualRegion = useAppSelector(state => state.dashboard.actualRegion);
-  const economicRegions = useAppSelector(state => state.dashboard.economicRegions);
-
-  // Filter rawData by selected country / region. The dropdown for these
-  // selections lives in the floating plotting-options panel below.
-  const rawData = useMemo(() => {
-    if (!Array.isArray(rawDataAll) || rawDataAll.length === 0) return [];
-    if (actualCountry && actualCountry !== 'All') {
-      return rawDataAll.filter(item => item.COUNTRY_ONLY === actualCountry);
-    }
-    if (actualRegion && actualRegion !== 'All') {
-      const regionCountries = economicRegions?.[actualRegion] ?? [];
-      const inRegion = new Set(regionCountries);
-      return rawDataAll.filter(item => inRegion.has(item.COUNTRY_ONLY));
-    }
-    return rawDataAll;
-  }, [rawDataAll, actualCountry, actualRegion, economicRegions]);
+  const rawData = useAppSelector(state => state.graph.rawOrganismData);
 
   const isSalmonella = organism === 'senterica' || organism === 'sentericaints';
 
@@ -528,20 +507,6 @@ export const QRDRPathwayGraph = ({ showFilter, setShowFilter }) => {
           </Box>
         </Box>
       </Box>
-
-      {showFilter && (
-        <Box className={classes.floatingFilter}>
-          <Card elevation={3}>
-            <CardContent>
-              <PlottingOptionsHeader
-                onClose={() => setShowFilter && setShowFilter(false)}
-                className={classes.titleWrapper}
-              />
-              <SelectCountry />
-            </CardContent>
-          </Card>
-        </Box>
-      )}
     </CardContent>
   );
 };

--- a/client/src/components/Elements/Graphs/QRDRPathwayGraph/QRDRPathwayGraphMUI.js
+++ b/client/src/components/Elements/Graphs/QRDRPathwayGraph/QRDRPathwayGraphMUI.js
@@ -67,25 +67,6 @@ const useStyles = makeStyles((_theme) => ({
     borderRadius: '4px',
     fontSize: '10px',
   },
-  // ── Floating plotting-options panel (matches DrugResistanceGraph pattern) ──
-  floatingFilter: {
-    position: 'absolute',
-    top: 16,
-    right: -(280 + 16),
-    width: '280px',
-    zIndex: 1,
-
-    '@media (max-width: 1900px)': {
-      right: 16,
-    },
-  },
-  titleWrapper: {
-    paddingBottom: '8px',
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
 }));
 
 export { useStyles };

--- a/client/src/components/Elements/Graphs/SerotypeResistanceGraph/SerotypeResistanceGraph.js
+++ b/client/src/components/Elements/Graphs/SerotypeResistanceGraph/SerotypeResistanceGraph.js
@@ -1,10 +1,8 @@
 import { InfoOutlined } from '@mui/icons-material';
-import { Box, Card, CardContent, MenuItem, Select, Tooltip, Typography } from '@mui/material';
+import { Box, CardContent, MenuItem, Select, Tooltip, Typography } from '@mui/material';
 import { useMemo, useState } from 'react';
 import { useAppSelector } from '../../../../stores/hooks';
 import { drugsSP } from '../../../../util/drugs';
-import { PlottingOptionsHeader } from '../../Shared/PlottingOptionsHeader';
-import { SelectCountry } from '../../SelectCountry';
 import { useStyles } from './SerotypeResistanceGraphMUI';
 
 const MIN_SEROTYPE_COUNT = 10;
@@ -80,26 +78,7 @@ export const SerotypeResistanceGraph = ({ showFilter, setShowFilter }) => {
 
   const organism = useAppSelector(state => state.dashboard.organism);
   const canGetData = useAppSelector(state => state.dashboard.canGetData);
-  const rawDataAll = useAppSelector(state => state.graph.rawOrganismData);
-  const actualCountry = useAppSelector(state => state.dashboard.actualCountry);
-  const actualRegion = useAppSelector(state => state.dashboard.actualRegion);
-  const economicRegions = useAppSelector(state => state.dashboard.economicRegions);
-
-  // Filter rawData by selected country / region from the floating
-  // plotting-options panel. The SelectCountry component writes
-  // actualCountry / actualRegion into Redux on user selection.
-  const rawData = useMemo(() => {
-    if (!Array.isArray(rawDataAll) || rawDataAll.length === 0) return [];
-    if (actualCountry && actualCountry !== 'All') {
-      return rawDataAll.filter(item => item.COUNTRY_ONLY === actualCountry);
-    }
-    if (actualRegion && actualRegion !== 'All') {
-      const regionCountries = economicRegions?.[actualRegion] ?? [];
-      const inRegion = new Set(regionCountries);
-      return rawDataAll.filter(item => inRegion.has(item.COUNTRY_ONLY));
-    }
-    return rawDataAll;
-  }, [rawDataAll, actualCountry, actualRegion, economicRegions]);
+  const rawData = useAppSelector(state => state.graph.rawOrganismData);
 
   const drugs = useMemo(() => drugsSP.filter(d => d !== 'Pansusceptible'), []);
 
@@ -219,8 +198,43 @@ export const SerotypeResistanceGraph = ({ showFilter, setShowFilter }) => {
             </Tooltip>
           </Box>
         </Box>
-        {/* Vaccine filter and Sort by dropdowns moved to the right-hand
-            floating plotting-options panel (see end of return). */}
+
+        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+          <Typography variant="caption" fontWeight={600}>
+            Vaccine filter
+          </Typography>
+          <Select
+            value={vaccineFilter}
+            onChange={e => setVaccineFilter(e.target.value)}
+            size="small"
+            sx={{ minWidth: 150, fontSize: '13px' }}
+          >
+            <MenuItem value="all">All serotypes</MenuItem>
+            <MenuItem value="pcv7">PCV7 only</MenuItem>
+            <MenuItem value="pcv10">PCV10 only</MenuItem>
+            <MenuItem value="pcv13">PCV13 only</MenuItem>
+            <MenuItem value="pcv15">PCV15 only</MenuItem>
+            <MenuItem value="pcv20">PCV20 only</MenuItem>
+            <MenuItem value="non-vaccine">Non-vaccine types</MenuItem>
+          </Select>
+        </Box>
+
+        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+          <Typography variant="caption" fontWeight={600}>
+            Sort by
+          </Typography>
+          <Select
+            value={sortBy}
+            onChange={e => setSortBy(e.target.value)}
+            size="small"
+            sx={{ minWidth: 150, fontSize: '13px' }}
+          >
+            <MenuItem value="count">Sample count</MenuItem>
+            <MenuItem value="resistance">Avg. resistance</MenuItem>
+            <MenuItem value="mdr">MDR rate</MenuItem>
+            <MenuItem value="alphabetical">Alphabetical</MenuItem>
+          </Select>
+        </Box>
       </Box>
 
       {/* Legend */}
@@ -426,57 +440,6 @@ export const SerotypeResistanceGraph = ({ showFilter, setShowFilter }) => {
           </Box>
         </Box>
       </Box>
-
-      {showFilter && (
-        <Box className={classes.floatingFilter}>
-          <Card elevation={3}>
-            <CardContent>
-              <PlottingOptionsHeader
-                onClose={() => setShowFilter && setShowFilter(false)}
-                className={classes.titleWrapper}
-              />
-              <SelectCountry />
-              <Box className={classes.panelSelectWrapper}>
-                <Typography variant="caption" className={classes.panelLabel}>
-                  Vaccine filter
-                </Typography>
-                <Select
-                  value={vaccineFilter}
-                  onChange={e => setVaccineFilter(e.target.value)}
-                  size="small"
-                  fullWidth
-                  sx={{ fontSize: '13px' }}
-                >
-                  <MenuItem value="all">All serotypes</MenuItem>
-                  <MenuItem value="pcv7">PCV7 only</MenuItem>
-                  <MenuItem value="pcv10">PCV10 only</MenuItem>
-                  <MenuItem value="pcv13">PCV13 only</MenuItem>
-                  <MenuItem value="pcv15">PCV15 only</MenuItem>
-                  <MenuItem value="pcv20">PCV20 only</MenuItem>
-                  <MenuItem value="non-vaccine">Non-vaccine types</MenuItem>
-                </Select>
-              </Box>
-              <Box className={classes.panelSelectWrapper}>
-                <Typography variant="caption" className={classes.panelLabel}>
-                  Sort by
-                </Typography>
-                <Select
-                  value={sortBy}
-                  onChange={e => setSortBy(e.target.value)}
-                  size="small"
-                  fullWidth
-                  sx={{ fontSize: '13px' }}
-                >
-                  <MenuItem value="count">Sample count</MenuItem>
-                  <MenuItem value="resistance">Avg. resistance</MenuItem>
-                  <MenuItem value="mdr">MDR rate</MenuItem>
-                  <MenuItem value="alphabetical">Alphabetical</MenuItem>
-                </Select>
-              </Box>
-            </CardContent>
-          </Card>
-        </Box>
-      )}
     </CardContent>
   );
 };

--- a/client/src/components/Elements/Graphs/SerotypeResistanceGraph/SerotypeResistanceGraphMUI.js
+++ b/client/src/components/Elements/Graphs/SerotypeResistanceGraph/SerotypeResistanceGraphMUI.js
@@ -114,34 +114,6 @@ const useStyles = makeStyles((_theme) => ({
     alignItems: 'flex-end',
     paddingTop: '8px',
   },
-  // ── Floating plotting-options panel (matches DrugResistanceGraph pattern) ──
-  floatingFilter: {
-    position: 'absolute',
-    top: 16,
-    right: -(280 + 16),
-    width: '280px',
-    zIndex: 1,
-
-    '@media (max-width: 1900px)': {
-      right: 16,
-    },
-  },
-  titleWrapper: {
-    paddingBottom: '8px',
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  panelSelectWrapper: {
-    display: 'flex',
-    flexDirection: 'column',
-    paddingTop: '8px',
-  },
-  panelLabel: {
-    fontWeight: 600,
-    paddingBottom: '4px',
-  },
 }));
 
 export { useStyles };


### PR DESCRIPTION
Hotfixes #389/#390/#391/#392 already reverted in #393 — crash persists. Reverting Phase 3b (#388) now to confirm it's the cause.

After this lands, the dev codebase will be functionally equivalent to main for QRDR + Vaccine Coverage charts (no country/region floating panel, no in-graph filter). User reports prod works; if dev now works too, Phase 3b's implementation has the bug we need to redo carefully.

If crash persists after this revert too, it's environmental (data, mongo state, browser cache, etc.) and we'll dig there.