### PR TITLE
debug: ChartErrorBoundary around each chart tab to identify the styphi crash

### DIFF
--- a/client/src/components/Elements/AMRInsights/AMRInsights.js
+++ b/client/src/components/Elements/AMRInsights/AMRInsights.js
@@ -15,6 +15,7 @@ import { useTranslation } from 'react-i18next';
 import { useAppDispatch, useAppSelector } from '../../../stores/hooks';
 import { setCollapse } from '../../../stores/slices/graphSlice';
 import { isTouchDevice } from '../../../util/isTouchDevice';
+import { ChartErrorBoundary } from '../Graphs/../Shared/ChartErrorBoundary';
 import { InsightsActions } from './InsightsActions';
 import { ATBCorrelationGraph } from '../Graphs/ATBCorrelationGraph';
 import { CooccurrenceGraph } from '../Graphs/CooccurrenceGraph';
@@ -210,7 +211,9 @@ export const AMRInsights = () => {
                 }}
                 zIndex={currentTab === card.value ? 1 : -100}
               >
-                {cloneElement(card.component, { showFilter: showFilterFull, setShowFilter })}
+                <ChartErrorBoundary label={`AMRInsights:${card.value}:${card.component.type?.name || 'Tab'}`}>
+                  {cloneElement(card.component, { showFilter: showFilterFull, setShowFilter })}
+                </ChartErrorBoundary>
               </Box>
             ))}
           </Box>

--- a/client/src/components/Elements/ContinentGraphs/ContinentGraphs.js
+++ b/client/src/components/Elements/ContinentGraphs/ContinentGraphs.js
@@ -29,6 +29,7 @@ import { DownloadMapViewData } from '../Map/MapActions/DownloadMapViewData';
 import { BubbleGeographicGraph } from './BubbleGeographicGraph';
 import { useStyles } from './ContinentGraphsMUI';
 import { RadarProfileGraph } from '../Graphs/RadarProfileGraph/RadarProfileGraph';
+import { ChartErrorBoundary } from '../Shared/ChartErrorBoundary';
 import { isProduction } from '../../../util/env';
 
 const TABS = [
@@ -373,7 +374,9 @@ export const ContinentGraphs = () => {
                   }}
                   zIndex={currentTab === card.value ? 1 : -100}
                 >
-                  {cloneElement(card.component, { showFilter: showFilterFull, setShowFilter })}
+                  <ChartErrorBoundary label={`ContinentGraphs:${card.value}:${card.component.type?.name || 'Tab'}`}>
+                    {cloneElement(card.component, { showFilter: showFilterFull, setShowFilter })}
+                  </ChartErrorBoundary>
                 </Box>
               );
             })}

--- a/client/src/components/Elements/Graphs/Graphs.js
+++ b/client/src/components/Elements/Graphs/Graphs.js
@@ -22,6 +22,7 @@ import { useTranslation } from 'react-i18next';
 import { Circles } from 'react-loader-spinner';
 import LogoImg from '../../../assets/img/logo-prod.png';
 import { useAppDispatch, useAppSelector } from '../../../stores/hooks';
+import { ChartErrorBoundary } from '../Shared/ChartErrorBoundary';
 import { setCollapse, setDownload } from '../../../stores/slices/graphSlice';
 import { colorForDrugClassesNG, colorForDrugClassesST, colorForMarkers } from '../../../util/colorHelper';
 import { variablesOptions } from '../../../util/convergenceVariablesOptions';
@@ -888,7 +889,11 @@ export const Graphs = () => {
                         }),
                   }}
                 >
-                  {shouldRender && cloneElement(card.component, { showFilter: showFilterFull, setShowFilter })}
+                  {shouldRender && (
+                    <ChartErrorBoundary label={`Graphs:${card.id}:${card.component.type?.name || 'Chart'}`}>
+                      {cloneElement(card.component, { showFilter: showFilterFull, setShowFilter })}
+                    </ChartErrorBoundary>
+                  )}
                 </Box>
               );
             })}

--- a/client/src/components/Elements/Shared/ChartErrorBoundary.js
+++ b/client/src/components/Elements/Shared/ChartErrorBoundary.js
@@ -1,0 +1,45 @@
+import { Box, Typography } from '@mui/material';
+import { Component } from 'react';
+
+// Diagnostic error boundary for charts. Catches synchronous render errors
+// (e.g. Recharts NaN crashes) and shows a placeholder instead of taking
+// the whole React tree down. The error is also logged to console with
+// a clearly-tagged label so we can see which chart blew up.
+//
+// Usage: <ChartErrorBoundary label="DistributionGraph"><Chart ... /></ChartErrorBoundary>
+export class ChartErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  componentDidCatch(error, info) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `[ChartErrorBoundary] ${this.props.label || 'unlabelled chart'} crashed:`,
+      error,
+      '\nReact stack:',
+      info.componentStack,
+    );
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <Box sx={{ padding: 2, border: '1px dashed rgba(244,67,54,0.5)', borderRadius: 1, backgroundColor: 'rgba(244,67,54,0.04)' }}>
+          <Typography variant="body2" color="error" fontWeight={600}>
+            Chart failed to render: {this.props.label || 'unknown'}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            {String(this.state.error?.message ?? this.state.error)}
+          </Typography>
+        </Box>
+      );
+    }
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
Diagnostic-only PR: adds a small error boundary component around each tab in Summary Plots, AMR Insights, and Geographic Comparisons.

When the user reproduces the styphi Local→Reset crash with this deployed:
- Instead of a blank page, only the failing chart's spot shows a labelled placeholder
- Console logs `[ChartErrorBoundary] Graphs:DRT:DrugResistanceGraph crashed: ...` (or similar) so we know exactly which chart and component is the culprit

Once we identify the failing chart we can target it directly. The boundary itself is cheap UX-wise and could stay even after the bug is fixed.