### PR TITLE
feat(graphs): GD plot 100% fix + DATE int normalisation (rebased from #403 with cleanup)

### DIFF
--- a/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
+++ b/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
@@ -253,7 +253,13 @@ export const DistributionGraph = ({ showFilter, setShowFilter }) => {
       let count = 0;
 
       for (const key in item) {
-        if (!topXGenotype.includes(key) && !exclusions.includes(key)) {
+        // For "Other" category, we want to sum up the counts of all genotypes that are NOT in the topXGenotype list
+        // if (!topXGenotype.includes(key) && !exclusions.includes(key)) {
+        //   count += item[key];
+        // }
+
+        // For the main categories (those in topXGenotype)
+        if (topXGenotype.includes(key)) {
           count += item[key];
         }
 
@@ -262,7 +268,7 @@ export const DistributionGraph = ({ showFilter, setShowFilter }) => {
         }
       }
 
-      return { name: item.name, count: item.count, ...(organism === 'styphi' ? item : filteredItems), Other: count };
+      return { name: item.name, count: item.count, ...(organism === 'styphi' ? item : filteredItems), Other: item.count - count }; // Add an "Other" field that sums up the counts of genotypes not in the topXGenotype list
     });
     // .filter(x => x.count >= 10);
 

--- a/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
+++ b/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
@@ -253,12 +253,9 @@ export const DistributionGraph = ({ showFilter, setShowFilter }) => {
       let count = 0;
 
       for (const key in item) {
-        // For "Other" category, we want to sum up the counts of all genotypes that are NOT in the topXGenotype list
-        // if (!topXGenotype.includes(key) && !exclusions.includes(key)) {
-        //   count += item[key];
-        // }
-
-        // For the main categories (those in topXGenotype)
+        // Sum the counts of the top-N genotypes; "Other" is the
+        // complement (item.count − count), which guarantees the stacked
+        // bar always totals 100% per year.
         if (topXGenotype.includes(key)) {
           count += item[key];
         }
@@ -268,9 +265,13 @@ export const DistributionGraph = ({ showFilter, setShowFilter }) => {
         }
       }
 
-      return { name: item.name, count: item.count, ...(organism === 'styphi' ? item : filteredItems), Other: item.count - count }; // Add an "Other" field that sums up the counts of genotypes not in the topXGenotype list
+      return {
+        name: item.name,
+        count: item.count,
+        ...(organism === 'styphi' ? item : filteredItems),
+        Other: item.count - count,
+      };
     });
-    // .filter(x => x.count >= 10);
 
     const percentageArray = structuredClone(baseArray).map(item => {
       const keys = Object.keys(item).filter(k => !exclusions.includes(k));

--- a/routes/api/aggregations.js
+++ b/routes/api/aggregations.js
@@ -507,11 +507,14 @@ function buildMatchStage(organism, query) {
  * Drug columns are now in new format (Aminoglycoside, Beta-lactam, etc.) for all organisms.
  */
 function getPrepipelineStages(organism) {
+  const normaliseDateStage = { $addFields: { DATE: { $toInt: '$DATE' } } };
+
   switch (organism) {
     case 'senterica':
       return [
         {
           $addFields: {
+            DATE: { $toInt: '$DATE' },
             GENOTYPE: {
               $cond: {
                 if: { $ne: ['$GENOTYPE', null] },
@@ -525,10 +528,10 @@ function getPrepipelineStages(organism) {
 
     case 'sentericaints':
       // Drug columns are now directly in amrnetdb_ints — no $lookup needed
-      return [];
+      return [normaliseDateStage];
 
     default:
-      return [];
+      return [normaliseDateStage];
   }
 }
 


### PR DESCRIPTION
Cherry-picks Vandana's 2 commits from #403 onto the latest `development` and applies a cleanup pass.

## Substantive changes (from Vandana)

1. **DistributionGraph 'Other' fix** — `Other = item.count - count` (where `count` is the sum of top-N genotypes), so the stacked bar totals 100% per year. Previously the chart could show <100% for genotypes outside the top-N.
2. **Backend `$toInt: '$DATE'` normalisation** in `routes/api/aggregations.js` — prevents string-vs-number double-counting when DATE is stored inconsistently across organisms. Applied to all organisms except `senterica` (which had a similar transformation already).

## Cleanup commit on top

- Deletes the commented-out 'Other = sum of non-top' loop in DistributionGraph (same antipattern as #378/#402 — dead comments shouldn't ship)
- Replaces with a one-line comment explaining *why* Other is the complement
- Expands the return object across multiple lines for readability

Vandana's 2 substantive commits keep her authorship; the cleanup is a single follow-up commit on top.

Closes #403.