### PR TITLE
Promote development → main: GD plot 100% fix + DATE int normalisation (#411)

### DIFF
--- a/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
+++ b/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
@@ -253,7 +253,13 @@ export const DistributionGraph = ({ showFilter, setShowFilter }) => {
       let count = 0;
 
       for (const key in item) {
-        if (!topXGenotype.includes(key) && !exclusions.includes(key)) {
+        // For "Other" category, we want to sum up the counts of all genotypes that are NOT in the topXGenotype list
+        // if (!topXGenotype.includes(key) && !exclusions.includes(key)) {
+        //   count += item[key];
+        // }
+
+        // For the main categories (those in topXGenotype)
+        if (topXGenotype.includes(key)) {
           count += item[key];
         }
 
@@ -262,7 +268,7 @@ export const DistributionGraph = ({ showFilter, setShowFilter }) => {
         }
       }
 
-      return { name: item.name, count: item.count, ...(organism === 'styphi' ? item : filteredItems), Other: count };
+      return { name: item.name, count: item.count, ...(organism === 'styphi' ? item : filteredItems), Other: item.count - count }; // Add an "Other" field that sums up the counts of genotypes not in the topXGenotype list
     });
     // .filter(x => x.count >= 10);
 

--- a/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
+++ b/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
@@ -253,12 +253,9 @@ export const DistributionGraph = ({ showFilter, setShowFilter }) => {
       let count = 0;
 
       for (const key in item) {
-        // For "Other" category, we want to sum up the counts of all genotypes that are NOT in the topXGenotype list
-        // if (!topXGenotype.includes(key) && !exclusions.includes(key)) {
-        //   count += item[key];
-        // }
-
-        // For the main categories (those in topXGenotype)
+        // Sum the counts of the top-N genotypes; "Other" is the
+        // complement (item.count − count), which guarantees the stacked
+        // bar always totals 100% per year.
         if (topXGenotype.includes(key)) {
           count += item[key];
         }
@@ -268,9 +265,13 @@ export const DistributionGraph = ({ showFilter, setShowFilter }) => {
         }
       }
 
-      return { name: item.name, count: item.count, ...(organism === 'styphi' ? item : filteredItems), Other: item.count - count }; // Add an "Other" field that sums up the counts of genotypes not in the topXGenotype list
+      return {
+        name: item.name,
+        count: item.count,
+        ...(organism === 'styphi' ? item : filteredItems),
+        Other: item.count - count,
+      };
     });
-    // .filter(x => x.count >= 10);
 
     const percentageArray = structuredClone(baseArray).map(item => {
       const keys = Object.keys(item).filter(k => !exclusions.includes(k));

--- a/routes/api/aggregations.js
+++ b/routes/api/aggregations.js
@@ -507,11 +507,14 @@ function buildMatchStage(organism, query) {
  * Drug columns are now in new format (Aminoglycoside, Beta-lactam, etc.) for all organisms.
  */
 function getPrepipelineStages(organism) {
+  const normaliseDateStage = { $addFields: { DATE: { $toInt: '$DATE' } } };
+
   switch (organism) {
     case 'senterica':
       return [
         {
           $addFields: {
+            DATE: { $toInt: '$DATE' },
             GENOTYPE: {
               $cond: {
                 if: { $ne: ['$GENOTYPE', null] },
@@ -525,10 +528,10 @@ function getPrepipelineStages(organism) {
 
     case 'sentericaints':
       // Drug columns are now directly in amrnetdb_ints — no $lookup needed
-      return [];
+      return [normaliseDateStage];
 
     default:
-      return [];
+      return [normaliseDateStage];
   }
 }
 


### PR DESCRIPTION
Smoke-tested on dev. Promoting:

- **GD plot 'Other' fix** — stacked bars now total 100% per year (Other = item.count − sum(top genotypes))
- **Backend `$toInt: '$DATE'` normalisation** in aggregation pipeline — prevents string-vs-number double-counting across all organisms

Cleanup pass also applied (deleted commented-out old logic in DistributionGraph).