### PR TITLE
Dashboard cleanup batch: Vaccine Coverage panel, QRDR removal, AMR Insights reorder, full drug names

### DIFF
--- a/client/src/components/Elements/AMRInsights/AMRInsights.js
+++ b/client/src/components/Elements/AMRInsights/AMRInsights.js
@@ -22,15 +22,25 @@ import { CooccurrenceGraph } from '../Graphs/CooccurrenceGraph';
 import { ConvergenceMapGraph } from '../Graphs/ConvergenceMapGraph';
 import { GeneMapGraph } from '../Graphs/GeneMapGraph';
 import { GenomicVsPhenotypicGraph } from '../Graphs/GenomicVsPhenotypicGraph';
-import { StratifiedResistanceGraph } from '../Graphs/StratifiedResistanceGraph';
-import { LINcodeGenotypeGraph } from '../Graphs/LINcodeGenotypeGraph/LINcodeGenotypeGraph';
 import { useStyles } from './AMRInsightsMUI';
 
 const TABS = [
   {
+    labelKey: 'amrInsights.tabs.cooccurrence',
+    value: 'COO',
+    component: <CooccurrenceGraph />,
+    onlyFor: null,
+  },
+  {
     labelKey: 'amrInsights.tabs.genomicVsPhenotypic',
     value: 'GVP',
     component: <GenomicVsPhenotypicGraph />,
+    onlyFor: null,
+  },
+  {
+    labelKey: 'amrInsights.tabs.atbCorrelation',
+    value: 'ATB',
+    component: <ATBCorrelationGraph />,
     onlyFor: null,
   },
   {
@@ -45,36 +55,12 @@ const TABS = [
     component: <GeneMapGraph />,
     onlyFor: [],
   },
-  {
-    labelKey: 'amrInsights.tabs.linCode',
-    value: 'LIN',
-    component: <StratifiedResistanceGraph mode="lin" />,
-    onlyFor: ['ecoli', 'decoli', 'shige'],
-  },
-  {
-    labelKey: 'amrInsights.tabs.linGenotype',
-    value: 'LGT',
-    component: <LINcodeGenotypeGraph />,
-    onlyFor: ['ecoli', 'decoli', 'shige'],
-  },
-  {
-    labelKey: 'amrInsights.tabs.cooccurrence',
-    value: 'COO',
-    component: <CooccurrenceGraph />,
-    onlyFor: null,
-  },
-  {
-    labelKey: 'amrInsights.tabs.atbCorrelation',
-    value: 'ATB',
-    component: <ATBCorrelationGraph />,
-    onlyFor: null,
-  },
 ];
 
 export const AMRInsights = () => {
   const classes = useStyles();
   const matches500 = useMediaQuery('(max-width:500px)');
-  const [currentTab, setCurrentTab] = useState('GVP');
+  const [currentTab, setCurrentTab] = useState('COO');
   const [showFilter, setShowFilter] = useState(!matches500);
   const { t } = useTranslation();
 
@@ -97,7 +83,7 @@ export const AMRInsights = () => {
   // Reset to first visible tab when organism changes and current tab is no longer visible
   useEffect(() => {
     if (!filteredTabs.find(tab => tab.value === currentTab)) {
-      setCurrentTab(filteredTabs[0]?.value ?? 'GVP');
+      setCurrentTab(filteredTabs[0]?.value ?? 'COO');
     }
   }, [filteredTabs, currentTab]);
 

--- a/client/src/components/Elements/Graphs/BubbleHeatmapGraph2/BubbleHeatmapGraph2.js
+++ b/client/src/components/Elements/Graphs/BubbleHeatmapGraph2/BubbleHeatmapGraph2.js
@@ -197,9 +197,14 @@ export const BubbleHeatmapGraph2 = ({ showFilter, setShowFilter }) => {
     setYAxisSelected(yAxisOptions);
   }, [yAxisOptions]);
 
+  const formatDrugLabel = useCallback(
+    name => (yAxisType === 'resistance' ? drugAcronymsOpposite[drugAcronyms[name] ?? name] ?? name : name),
+    [yAxisType],
+  );
+
   const yAxisWidth = useMemo(() => {
-    return longestVisualWidth(xAxisSelected ?? []);
-  }, [xAxisSelected]);
+    return longestVisualWidth((yAxisSelected ?? []).map(formatDrugLabel));
+  }, [yAxisSelected, formatDrugLabel]);
 
   const getOptionLabel = useCallback(
     item => {
@@ -279,67 +284,80 @@ export const BubbleHeatmapGraph2 = ({ showFilter, setShowFilter }) => {
   }, []);
 
   const configuredMapData = useMemo(() => {
-    if (!selectedCRData || yAxisSelected.length === 0) {
+    if (!selectedCRData || yAxisSelected.length === 0 || xAxisSelected.length === 0) {
       return [];
     }
 
-    return selectedCRData?.stats[statColumn]?.items
-      ?.filter(item => xAxisSelected?.includes(item.name))
-      .map(item => {
-        const itemData = { name: item.name, items: [] };
+    const matchingItems =
+      selectedCRData?.stats[statColumn]?.items?.filter(item => xAxisSelected?.includes(item.name)) ?? [];
 
-        if (yAxisType === 'resistance') {
-          Object.entries(item.drugs).forEach(([key, value]) => {
-            if (yAxisSelected.includes(key)) {
-              const pct = item.count ? Number((((value?.count || 0) / item.count) * 100).toFixed(2)) : 0;
-              itemData.items.push({
-                itemName: drugAcronyms[key] ?? key,
-                percentage: pct,
-                count: value?.count || 0,
-                index: 1,
-                typeName: item.name, //typeName: ['senterica'].includes(organism) ? `ST ${item.name}` : item.name,
-                total: item.count,
-              });
-            }
+    if (yAxisType === 'resistance') {
+      const drugRows = yAxisSelected.map(drug => {
+        const row = { name: drug, items: [] };
+
+        matchingItems.forEach(item => {
+          const drugCount = item.drugs[drug]?.count ?? 0;
+          const pct = item.count ? Number(((drugCount / item.count) * 100).toFixed(2)) : 0;
+          row.items.push({
+            itemName: item.name,
+            percentage: pct,
+            count: drugCount,
+            index: 1,
+            typeName: item.name,
+            total: item.count,
+            drug,
           });
+        });
 
-          itemData.items.sort((a, b) => a.itemName.localeCompare(b.itemName));
-
-          const moveToStart = name => {
-            const i = itemData.items.findIndex(x => x.itemName === name);
-            if (i >= 0) itemData.items.unshift(...itemData.items.splice(i, 1));
-          };
-
-          const moveToEnd = name => {
-            const i = itemData.items.findIndex(x => x.itemName === name);
-            if (i >= 0) itemData.items.push(...itemData.items.splice(i, 1));
-          };
-
-          if (['styphi', 'sentericaints'].includes(organism)) {
-            ['CRO', 'CipR', 'CipNS'].forEach(moveToStart);
-          }
-
-          ['MDR', 'XDR', 'PAN', 'SUS'].forEach(moveToEnd);
-        }
-
-        if (yAxisType.includes('markers')) {
-          const drugGenes = item?.drugs[yAxisType.includes('esbl') ? 'ESBL' : 'Carbapenems']?.items;
-
-          yAxisSelected.forEach(gene => {
-            const currentGene = drugGenes.find(dg => dg.name === gene);
-
-            itemData.items.push({
-              itemName: (currentGene?.name ?? gene).replace(' + ', '/'),
-              percentage: currentGene?.percentage ?? 0,
-              index: 1,
-              typeName: item.name,
-              total: item.count,
-            });
-          });
-        }
-
-        return itemData;
+        return row;
       });
+
+      // Ordering rules previously applied to the drug column axis now apply
+      // to the drug row axis. Match by acronym so we stay consistent with the
+      // existing styphi/sentericaints rules (CRO/CipR/CipNS first) and the
+      // global rules (MDR/XDR/PAN/SUS last).
+      const acronymOf = name => drugAcronyms[name] ?? name;
+      drugRows.sort((a, b) => acronymOf(a.name).localeCompare(acronymOf(b.name)));
+
+      const moveToStart = acronym => {
+        const i = drugRows.findIndex(x => acronymOf(x.name) === acronym);
+        if (i >= 0) drugRows.unshift(...drugRows.splice(i, 1));
+      };
+
+      const moveToEnd = acronym => {
+        const i = drugRows.findIndex(x => acronymOf(x.name) === acronym);
+        if (i >= 0) drugRows.push(...drugRows.splice(i, 1));
+      };
+
+      if (['styphi', 'sentericaints'].includes(organism)) {
+        ['CRO', 'CipR', 'CipNS'].forEach(moveToStart);
+      }
+      ['MDR', 'XDR', 'PAN', 'SUS'].forEach(moveToEnd);
+
+      return drugRows;
+    }
+
+    if (yAxisType.includes('markers')) {
+      const drugKey = yAxisType.includes('esbl') ? 'ESBL' : 'Carbapenems';
+      return yAxisSelected.map(gene => {
+        const row = { name: gene.replace(' + ', '/'), items: [] };
+        matchingItems.forEach(item => {
+          const drugGenes = item?.drugs[drugKey]?.items ?? [];
+          const currentGene = drugGenes.find(dg => dg.name === gene);
+          row.items.push({
+            itemName: item.name,
+            percentage: currentGene?.percentage ?? 0,
+            index: 1,
+            typeName: item.name,
+            total: item.count,
+            drug: gene,
+          });
+        });
+        return row;
+      });
+    }
+
+    return [];
   }, [organism, selectedCRData, statColumn, xAxisSelected, yAxisSelected, yAxisType]);
 
   useEffect(() => {
@@ -351,7 +369,7 @@ export const BubbleHeatmapGraph2 = ({ showFilter, setShowFilter }) => {
               return (
                 <ResponsiveContainer
                   key={`heatmap-graph-${index}`}
-                  width={yAxisWidth + 65 * yAxisSelected.length}
+                  width={yAxisWidth + 65 * xAxisSelected.length}
                   height={index === 0 ? 105 : 65}
                   style={{ paddingTop: index === 0 ? 40 : 0 }}
                 >
@@ -397,7 +415,7 @@ export const BubbleHeatmapGraph2 = ({ showFilter, setShowFilter }) => {
                       tickLine={false}
                       axisLine={false}
                       domain={[1, 1]}
-                      label={{ value: item.name, position: 'insideRight' }}
+                      label={{ value: formatDrugLabel(item.name), position: 'insideRight' }}
                       width={yAxisWidth}
                     />
 
@@ -409,7 +427,7 @@ export const BubbleHeatmapGraph2 = ({ showFilter, setShowFilter }) => {
                       offset={40}
                       content={({ payload, active }) => {
                         if (payload !== null && active) {
-                          const title = getTitle(payload[0]?.payload.itemName);
+                          const title = getTitle(payload[0]?.payload.drug ?? payload[0]?.payload.itemName);
                           return (
                             <div
                               className={classes.chartTooltipLabel}

--- a/client/src/components/Elements/Graphs/RadarProfileGraph/RadarProfileGraph.js
+++ b/client/src/components/Elements/Graphs/RadarProfileGraph/RadarProfileGraph.js
@@ -120,7 +120,6 @@ export const RadarProfileGraph = ({ showFilter, setShowFilter }) => {
     return drugNames.map(drug => {
       const entry = {
         drug,
-        shortDrug: drugAcronyms[drug] || drug.substring(0, 6),
       };
 
       selectedCountries.forEach(country => {
@@ -281,7 +280,7 @@ export const RadarProfileGraph = ({ showFilter, setShowFilter }) => {
             <ResponsiveContainer width="100%" height="100%">
               <RadarChart cx="50%" cy="50%" outerRadius="75%" data={radarData}>
                 <PolarGrid stroke="#ccc" />
-                <PolarAngleAxis dataKey="shortDrug" tick={{ fontSize: 11, fill: '#333' }} />
+                <PolarAngleAxis dataKey="drug" tick={{ fontSize: 10, fill: '#333' }} />
                 <PolarRadiusAxis angle={90} domain={[0, 100]} tick={{ fontSize: 10 }} tickCount={6} />
                 {selectedCountries.map((country, index) => (
                   <Radar

--- a/client/src/components/Elements/Graphs/SerotypeResistanceGraph/SerotypeResistanceGraph.js
+++ b/client/src/components/Elements/Graphs/SerotypeResistanceGraph/SerotypeResistanceGraph.js
@@ -1,8 +1,10 @@
 import { InfoOutlined } from '@mui/icons-material';
-import { Box, CardContent, MenuItem, Select, Tooltip, Typography } from '@mui/material';
+import { Box, Card, CardContent, MenuItem, Select, Tooltip, Typography } from '@mui/material';
 import { useMemo, useState } from 'react';
 import { useAppSelector } from '../../../../stores/hooks';
 import { drugsSP } from '../../../../util/drugs';
+import { PlottingOptionsHeader } from '../../Shared/PlottingOptionsHeader';
+import { SelectCountry } from '../../SelectCountry';
 import { useStyles } from './SerotypeResistanceGraphMUI';
 
 const MIN_SEROTYPE_COUNT = 10;
@@ -78,7 +80,26 @@ export const SerotypeResistanceGraph = ({ showFilter, setShowFilter }) => {
 
   const organism = useAppSelector(state => state.dashboard.organism);
   const canGetData = useAppSelector(state => state.dashboard.canGetData);
-  const rawData = useAppSelector(state => state.graph.rawOrganismData);
+  const rawDataAll = useAppSelector(state => state.graph.rawOrganismData);
+  const actualCountry = useAppSelector(state => state.dashboard.actualCountry);
+  const actualRegion = useAppSelector(state => state.dashboard.actualRegion);
+  const economicRegions = useAppSelector(state => state.dashboard.economicRegions);
+
+  // Filter rawData by selected country / region from the floating
+  // plotting-options panel. The SelectCountry component writes
+  // actualCountry / actualRegion into Redux on user selection.
+  const rawData = useMemo(() => {
+    if (!Array.isArray(rawDataAll) || rawDataAll.length === 0) return [];
+    if (actualCountry && actualCountry !== 'All') {
+      return rawDataAll.filter(item => item.COUNTRY_ONLY === actualCountry);
+    }
+    if (actualRegion && actualRegion !== 'All') {
+      const regionCountries = economicRegions?.[actualRegion] ?? [];
+      const inRegion = new Set(regionCountries);
+      return rawDataAll.filter(item => inRegion.has(item.COUNTRY_ONLY));
+    }
+    return rawDataAll;
+  }, [rawDataAll, actualCountry, actualRegion, economicRegions]);
 
   const drugs = useMemo(() => drugsSP.filter(d => d !== 'Pansusceptible'), []);
 
@@ -198,43 +219,8 @@ export const SerotypeResistanceGraph = ({ showFilter, setShowFilter }) => {
             </Tooltip>
           </Box>
         </Box>
-
-        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-          <Typography variant="caption" fontWeight={600}>
-            Vaccine filter
-          </Typography>
-          <Select
-            value={vaccineFilter}
-            onChange={e => setVaccineFilter(e.target.value)}
-            size="small"
-            sx={{ minWidth: 150, fontSize: '13px' }}
-          >
-            <MenuItem value="all">All serotypes</MenuItem>
-            <MenuItem value="pcv7">PCV7 only</MenuItem>
-            <MenuItem value="pcv10">PCV10 only</MenuItem>
-            <MenuItem value="pcv13">PCV13 only</MenuItem>
-            <MenuItem value="pcv15">PCV15 only</MenuItem>
-            <MenuItem value="pcv20">PCV20 only</MenuItem>
-            <MenuItem value="non-vaccine">Non-vaccine types</MenuItem>
-          </Select>
-        </Box>
-
-        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-          <Typography variant="caption" fontWeight={600}>
-            Sort by
-          </Typography>
-          <Select
-            value={sortBy}
-            onChange={e => setSortBy(e.target.value)}
-            size="small"
-            sx={{ minWidth: 150, fontSize: '13px' }}
-          >
-            <MenuItem value="count">Sample count</MenuItem>
-            <MenuItem value="resistance">Avg. resistance</MenuItem>
-            <MenuItem value="mdr">MDR rate</MenuItem>
-            <MenuItem value="alphabetical">Alphabetical</MenuItem>
-          </Select>
-        </Box>
+        {/* Vaccine filter and Sort by dropdowns moved to the right-hand
+            floating plotting-options panel (see end of return). */}
       </Box>
 
       {/* Legend */}
@@ -440,6 +426,57 @@ export const SerotypeResistanceGraph = ({ showFilter, setShowFilter }) => {
           </Box>
         </Box>
       </Box>
+
+      {showFilter && (
+        <Box className={classes.floatingFilter}>
+          <Card elevation={3}>
+            <CardContent>
+              <PlottingOptionsHeader
+                onClose={() => setShowFilter && setShowFilter(false)}
+                className={classes.titleWrapper}
+              />
+              <SelectCountry />
+              <Box className={classes.panelSelectWrapper}>
+                <Typography variant="caption" className={classes.panelLabel}>
+                  Vaccine filter
+                </Typography>
+                <Select
+                  value={vaccineFilter}
+                  onChange={e => setVaccineFilter(e.target.value)}
+                  size="small"
+                  fullWidth
+                  sx={{ fontSize: '13px' }}
+                >
+                  <MenuItem value="all">All serotypes</MenuItem>
+                  <MenuItem value="pcv7">PCV7 only</MenuItem>
+                  <MenuItem value="pcv10">PCV10 only</MenuItem>
+                  <MenuItem value="pcv13">PCV13 only</MenuItem>
+                  <MenuItem value="pcv15">PCV15 only</MenuItem>
+                  <MenuItem value="pcv20">PCV20 only</MenuItem>
+                  <MenuItem value="non-vaccine">Non-vaccine types</MenuItem>
+                </Select>
+              </Box>
+              <Box className={classes.panelSelectWrapper}>
+                <Typography variant="caption" className={classes.panelLabel}>
+                  Sort by
+                </Typography>
+                <Select
+                  value={sortBy}
+                  onChange={e => setSortBy(e.target.value)}
+                  size="small"
+                  fullWidth
+                  sx={{ fontSize: '13px' }}
+                >
+                  <MenuItem value="count">Sample count</MenuItem>
+                  <MenuItem value="resistance">Avg. resistance</MenuItem>
+                  <MenuItem value="mdr">MDR rate</MenuItem>
+                  <MenuItem value="alphabetical">Alphabetical</MenuItem>
+                </Select>
+              </Box>
+            </CardContent>
+          </Card>
+        </Box>
+      )}
     </CardContent>
   );
 };

--- a/client/src/components/Elements/Graphs/SerotypeResistanceGraph/SerotypeResistanceGraphMUI.js
+++ b/client/src/components/Elements/Graphs/SerotypeResistanceGraph/SerotypeResistanceGraphMUI.js
@@ -114,6 +114,34 @@ const useStyles = makeStyles((_theme) => ({
     alignItems: 'flex-end',
     paddingTop: '8px',
   },
+  // ── Floating plotting-options panel (matches DrugResistanceGraph pattern) ──
+  floatingFilter: {
+    position: 'absolute',
+    top: 16,
+    right: -(280 + 16),
+    width: '280px',
+    zIndex: 1,
+
+    '@media (max-width: 1900px)': {
+      right: 16,
+    },
+  },
+  titleWrapper: {
+    paddingBottom: '8px',
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  panelSelectWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    paddingTop: '8px',
+  },
+  panelLabel: {
+    fontWeight: 600,
+    paddingBottom: '4px',
+  },
 }));
 
 export { useStyles };

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -886,7 +886,7 @@
     "tabs": {
       "map": "Map",
       "barplot": "Bar plot",
-      "barplotNoData": "No One Health source data available for this organism."
+      "barplotNoData": "No data available for this organism."
     }
   }
 }

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -513,7 +513,7 @@
     "tabs": {
       "map": "Mapa",
       "barplot": "Gráfico de barras",
-      "barplotNoData": "No hay datos de fuentes One Health disponibles para este organismo."
+      "barplotNoData": "No hay datos disponibles para este organismo."
     }
   }
 }

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -513,7 +513,7 @@
     "tabs": {
       "map": "Carte",
       "barplot": "Graphique à barres",
-      "barplotNoData": "Aucune donnée de source One Health disponible pour cet organisme."
+      "barplotNoData": "Aucune donnée disponible pour cet organisme."
     }
   }
 }

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -597,7 +597,7 @@
     "tabs": {
       "map": "Mapa",
       "barplot": "Gráfico de barras",
-      "barplotNoData": "Não há dados de fontes One Health disponíveis para este organismo."
+      "barplotNoData": "Não há dados disponíveis para este organismo."
     }
   }
 }

--- a/client/src/util/graphCards.js
+++ b/client/src/util/graphCards.js
@@ -1,4 +1,4 @@
-import { BubbleChart, GridOn, ShowChart, StackedBarChart, Timeline, ViewModule, Science, Vaccines } from '@mui/icons-material';
+import { BubbleChart, GridOn, ShowChart, StackedBarChart, Timeline, ViewModule, Vaccines } from '@mui/icons-material';
 import { BubbleHeatmapGraph2 } from '../components/Elements/Graphs/BubbleHeatmapGraph2';
 import { BubbleKOHeatmapGraph } from '../components/Elements/Graphs/BubbleKOHeatmapGraph';
 import { BubbleMarkersHeatmapGraph } from '../components/Elements/Graphs/BubbleMarkersHeatmapGraph';
@@ -8,13 +8,11 @@ import { DistributionGraph } from '../components/Elements/Graphs/DistributionGra
 import { DrugResistanceGraph } from '../components/Elements/Graphs/DrugResistanceGraph';
 import { KOTrendsGraph } from '../components/Elements/Graphs/KOTrends';
 import { MarkerTrendsGraph } from '../components/Elements/Graphs/MarkerTrendsGraph';
-import { QRDRPathwayGraph } from '../components/Elements/Graphs/QRDRPathwayGraph';
 import { SerotypeResistanceGraph } from '../components/Elements/Graphs/SerotypeResistanceGraph';
 import { TemporalHeatmapGraph } from '../components/Elements/Graphs/TemporalHeatmapGraph';
 import { EmergenceRateGraph } from '../components/Elements/Graphs/EmergenceRateGraph';
 import { amrLikeOrganisms, organismsCards } from './organismsCards';
 import { BubbleHPGraph } from '../components/Elements/ContinentPathotypeGraphs/BubbleHPGraph/BubbleHPGraph';
-import { isProduction } from './env';
 import { useTranslation } from 'react-i18next';
 import { t } from 'react-i18next';
 
@@ -169,17 +167,6 @@ export function getGraphCards(t){
       id: 'BHP',
       organisms: ['senterica'],
       component: <BubbleHPGraph />,
-    },
-    {
-      title: t('graphs.qrdrMutations'),
-      description: [''],
-      icon: <Science color="primary" />,
-      id: 'QRDR',
-      // Dev-only: collapsing the organism list to [] in production hides
-      // the tab via the existing `card.organisms.includes(organism)` filter
-      // in Graphs.js. Same gating philosophy as the Radar Profile tab.
-      organisms: isProduction() ? [] : ['styphi', 'ngono', 'senterica', 'sentericaints'],
-      component: <QRDRPathwayGraph />,
     },
     {
       title: t('graphs.vaccineCoverage'),


### PR DESCRIPTION
## Summary

Consolidated cleanup batch combining the safe parts of PR #399 with six additional dashboard tasks. Each task is a separate commit on this branch.

- **Vaccine Coverage country/region floating panel** — cherry-picked the Phase 3b SerotypeResistanceGraph changes from #399 (SelectCountry + Vaccine filter + Sort by, plus matching MUI floating-panel styles). QRDR pieces of #399 were intentionally **not** taken; this branch supersedes #399.
- **QRDR Mutations dropped from Summary Plots** for every organism that previously listed it. The QRDRPathwayGraph component file is left in place in case it is referenced elsewhere; only the card entry, the `QRDRPathwayGraph` and `Science` icon imports, and the now-unused `isProduction` helper import are removed.
- **Simplified barplot empty-state copy** — `globalOverview.tabs.barplotNoData` now reads "No data available for this organism." (and translated equivalents) across en / es / fr / pt. The previous "One Health source" qualifier was misleading on organisms without that pipeline.
- **AMR Insights tab order updated** to AMR Co-occurrence (COO), Genomic vs Phenotypic (GVP), AM Usage vs Resistance (ATB), then the organism-specific Convergence Map (kpneumo only) and Gene Map (currently hidden). Default tab and the `filteredTabs` fallback now both target COO since it is the new first tab and is always visible.
- **LIN Code Lineages (LIN) and LIN code + Genotype (LGT) tabs removed** from AMR Insights, along with the no-longer-needed `StratifiedResistanceGraph` and `LINcodeGenotypeGraph` imports. The `StratifiedResistanceGraph` component itself is preserved because `GlobalOverviewTabs` still consumes it.
- **Radar plot now shows full drug names** on the `PolarAngleAxis` (`dataKey="drug"` instead of `dataKey="shortDrug"`, tick font nudged to 10px). The acronyms map is still used in the legend below the chart so the abbreviation reference is preserved.
- **BubbleHeatmapGraph2 transposed: drug rows × genotype columns**, with full drug names on each row label. Acronym-only entries (CipR, MDR, XDR, SUS) are expanded via `drugAcronymsOpposite` so the row label matches what the user picks in the Select Drug dropdown. The previous drug-axis ordering rules (CRO / CipR / CipNS first for styphi & sentericaints, MDR / XDR / PAN / SUS last) are preserved by matching against the acronym mapping when sorting rows. The cell tooltip reads the per-item `drug` payload to resolve the full drug name for the value line.

Closes #399 (superseded — Vaccine Coverage pieces cherry-picked, QRDR pieces intentionally not taken).

## Test plan

- [ ] Vaccine Coverage tab (strepneumo, dev environment): floating panel renders, country / region selects narrow `rawOrganismData`, Vaccine filter and Sort-by behave as in #399.
- [ ] QRDR Mutations card is no longer listed on Summary Plots for styphi / ngono / senterica / sentericaints in either environment.
- [ ] Global Overview barplot empty-state copy reads "No data available for this organism." in en / es / fr / pt.
- [ ] AMR Insights opens with **AMR Co-occurrence** selected; tab order is COO → GVP → ATB → (CVM on kpneumo) → (GMP hidden, empty `onlyFor`).
- [ ] LIN Code Lineages and LIN code + Genotype tabs no longer appear on ecoli / decoli / shige.
- [ ] Geographic Comparisons → Radar Profile shows full drug names around the polar axis (dev only; the tab itself stays hidden in production via existing `DEV_ONLY_ORGANISMS` gating).
- [ ] BubbleHeatmapGraph2 (Summary Plots Heatmap View) renders drug rows down and genotype columns across; row labels show "Ciprofloxacin (resistant)", "Multidrug resistant (MDR)" etc.; tooltip shows genotype as header and full drug name on the value line.