### PR TITLE
Move Convergence Map (CVM) to Summary Plots; wire to global filters + floating panel

### DIFF
--- a/client/src/components/Elements/AMRInsights/AMRInsights.js
+++ b/client/src/components/Elements/AMRInsights/AMRInsights.js
@@ -18,7 +18,6 @@ import { isTouchDevice } from '../../../util/isTouchDevice';
 import { ChartErrorBoundary } from '../Graphs/../Shared/ChartErrorBoundary';
 import { InsightsActions } from './InsightsActions';
 import { ATBCorrelationGraph } from '../Graphs/ATBCorrelationGraph';
-import { ConvergenceMapGraph } from '../Graphs/ConvergenceMapGraph';
 import { CooccurrenceGraph } from '../Graphs/CooccurrenceGraph';
 import { GeneMapGraph } from '../Graphs/GeneMapGraph';
 import { GenomicVsPhenotypicGraph } from '../Graphs/GenomicVsPhenotypicGraph';
@@ -42,12 +41,6 @@ const TABS = [
     value: 'ATB',
     component: <ATBCorrelationGraph />,
     onlyFor: null,
-  },
-  {
-    labelKey: 'amrInsights.tabs.convergenceMap',
-    value: 'CVM',
-    component: <ConvergenceMapGraph />,
-    onlyFor: ['kpneumo'],
   },
   {
     labelKey: 'amrInsights.tabs.geneMap',
@@ -120,7 +113,6 @@ export const AMRInsights = () => {
         return Array.isArray(drugsCountriesData[firstKey]) ? drugsCountriesData[firstKey] : [];
       }
       case 'GMP': // Gene map — export raw kpneumo data with gene fields
-      case 'CVM': // Convergence map — export raw kpneumo data
         return Array.isArray(rawOrganismData) ? rawOrganismData.slice(0, 5000) : []; // Cap at 5k rows for CSV
       default:
         return [];

--- a/client/src/components/Elements/Graphs/ConvergenceMapGraph/ConvergenceMapGraph.js
+++ b/client/src/components/Elements/Graphs/ConvergenceMapGraph/ConvergenceMapGraph.js
@@ -1,6 +1,7 @@
 import { InfoOutlined, Warning } from '@mui/icons-material';
 import {
   Box,
+  Card,
   CardContent,
   MenuItem,
   Select,
@@ -10,6 +11,8 @@ import {
 import { useMemo, useState } from 'react';
 import { useAppSelector } from '../../../../stores/hooks';
 import { getCountryDisplayName } from '../../../Dashboard/filters';
+import { SelectCountry } from '../../SelectCountry';
+import { PlottingOptionsHeader } from '../../Shared/PlottingOptionsHeader';
 import { useStyles } from './ConvergenceMapGraphMUI';
 
 const MIN_SAMPLES = 20;
@@ -74,17 +77,23 @@ export const ConvergenceMapGraph = ({ showFilter, setShowFilter }) => {
   const rawData = useAppSelector(state => state.graph.rawOrganismData);
   const economicRegions = useAppSelector(state => state.dashboard.economicRegions);
   const canGetData = useAppSelector(state => state.dashboard.canGetData);
+  const actualCountry = useAppSelector(state => state.dashboard.actualCountry);
+  const actualRegion = useAppSelector(state => state.dashboard.actualRegion);
+  const actualTimeInitial = useAppSelector(state => state.dashboard.actualTimeInitial);
+  const actualTimeFinal = useAppSelector(state => state.dashboard.actualTimeFinal);
 
   const { locationStats, locations, globalStats } = useMemo(() => {
     if (!Array.isArray(rawData) || rawData.length === 0 || organism !== 'kpneumo') {
       return { locationStats: {}, locations: [], globalStats: null };
     }
 
-    // Build country-to-region map with normalized key lookup
+    // Build country-to-region map with normalized key lookup. Always build it
+    // (not just for xAxisType==='region') so we can also apply the dashboard's
+    // actualRegion filter regardless of how the user is grouping the chart.
     const countryToRegion = {};
     const normalizedRegionLookup = {};
     const normalize = s => s?.toLowerCase().replace(/[^a-z]/g, '') || '';
-    if (xAxisType === 'region' && economicRegions) {
+    if (economicRegions) {
       Object.entries(economicRegions).forEach(([region, countries]) => {
         if (Array.isArray(countries)) countries.forEach(c => {
           countryToRegion[c] = region;
@@ -92,6 +101,19 @@ export const ConvergenceMapGraph = ({ showFilter, setShowFilter }) => {
         });
       });
     }
+
+    const resolveRegion = country =>
+      countryToRegion[country] || normalizedRegionLookup[normalize(country)] || FALLBACK_REGIONS[country];
+
+    // Apply the dashboard's global filters (country / region / year range)
+    // before aggregating. Keeps the plot in sync with the rest of Summary
+    // Plots — same data subset the rest of the dashboard sees.
+    const inDateRange = item => item.DATE >= actualTimeInitial && item.DATE <= actualTimeFinal;
+    const inLocation = (country, region) => {
+      if (actualCountry !== 'All') return country === actualCountry;
+      if (actualRegion !== 'All') return region === actualRegion;
+      return true;
+    };
 
     // Group by location
     const byLocation = {};
@@ -101,9 +123,12 @@ export const ConvergenceMapGraph = ({ showFilter, setShowFilter }) => {
       const vir = parseFloat(item.virulence_score);
       const res = parseInt(item.num_resistance_classes);
       if (isNaN(vir) || isNaN(res)) return;
+      if (!inDateRange(item)) return;
 
       const country = getCountryDisplayName(item.COUNTRY_ONLY);
-      const region = countryToRegion[country] || normalizedRegionLookup[normalize(country)] || FALLBACK_REGIONS[country];
+      const region = resolveRegion(country);
+      if (!inLocation(country, region)) return;
+
       const loc = xAxisType === 'region' ? (region || 'Unknown') : (country || 'Unknown');
 
       if (!byLocation[loc]) byLocation[loc] = { total: 0, convergent: 0, highVir: 0, highRes: 0 };
@@ -144,41 +169,23 @@ export const ConvergenceMapGraph = ({ showFilter, setShowFilter }) => {
     } : null;
 
     return { locationStats: stats, locations: sorted, globalStats: gStats };
-  }, [rawData, organism, virThreshold, resThreshold, xAxisType, economicRegions]);
+  }, [
+    rawData,
+    organism,
+    virThreshold,
+    resThreshold,
+    xAxisType,
+    economicRegions,
+    actualCountry,
+    actualRegion,
+    actualTimeInitial,
+    actualTimeFinal,
+  ]);
 
   if (!canGetData || organism !== 'kpneumo') return null;
 
   return (
     <CardContent className={classes.convergenceMapGraph}>
-      <Box className={classes.controlsRow}>
-        <Box>
-          <Typography variant="caption" fontWeight={600}>Virulence threshold</Typography>
-          <Select value={virThreshold} onChange={e => setVirThreshold(e.target.value)} size="small" sx={{ minWidth: 200, fontSize: '13px', display: 'block' }}>
-            {VIRULENCE_THRESHOLDS.map(t => (
-              <MenuItem key={t.value} value={t.value}>{t.label}</MenuItem>
-            ))}
-          </Select>
-        </Box>
-        <Box>
-          <Typography variant="caption" fontWeight={600}>Resistance threshold</Typography>
-          <Select value={resThreshold} onChange={e => setResThreshold(e.target.value)} size="small" sx={{ minWidth: 200, fontSize: '13px', display: 'block' }}>
-            {RESISTANCE_THRESHOLDS.map(t => (
-              <MenuItem key={t.value} value={t.value}>{t.label}</MenuItem>
-            ))}
-          </Select>
-        </Box>
-        <Box>
-          <Typography variant="caption" fontWeight={600}>Group by</Typography>
-          <Select value={xAxisType} onChange={e => setXAxisType(e.target.value)} size="small" sx={{ minWidth: 120, fontSize: '13px', display: 'block' }}>
-            <MenuItem value="country">Country</MenuItem>
-            <MenuItem value="region">Region</MenuItem>
-          </Select>
-        </Box>
-        <Tooltip title="Shows the percentage of K. pneumoniae isolates that are BOTH hypervirulent AND multidrug-resistant. These convergent strains are the most clinically dangerous.">
-          <InfoOutlined fontSize="small" sx={{ cursor: 'pointer', color: 'rgba(0,0,0,0.5)', marginBottom: '8px' }} />
-        </Tooltip>
-      </Box>
-
       {/* Legend */}
       <Box className={classes.legendBar}>
         <Typography variant="caption">0%</Typography>
@@ -291,6 +298,74 @@ export const ConvergenceMapGraph = ({ showFilter, setShowFilter }) => {
           </Box>
         </Box>
       </Box>
+
+      {/* Floating plotting-options panel — mirrors BubbleHeatmapGraph2 /
+          SerotypeResistanceGraph. Pairs the dashboard's global country /
+          region selector with the chart-local virulence / resistance
+          thresholds and the Country-vs-Region grouping toggle. */}
+      {showFilter && (
+        <Box className={classes.floatingFilter}>
+          <Card elevation={3}>
+            <CardContent>
+              <PlottingOptionsHeader onClose={() => setShowFilter(false)} className={classes.titleWrapper} />
+
+              <SelectCountry />
+
+              <Box className={classes.panelSelectWrapper}>
+                <Typography variant="caption" className={classes.panelLabel}>
+                  Virulence threshold
+                </Typography>
+                <Select
+                  value={virThreshold}
+                  onChange={e => setVirThreshold(e.target.value)}
+                  size="small"
+                  fullWidth
+                >
+                  {VIRULENCE_THRESHOLDS.map(t => (
+                    <MenuItem key={t.value} value={t.value}>{t.label}</MenuItem>
+                  ))}
+                </Select>
+              </Box>
+
+              <Box className={classes.panelSelectWrapper}>
+                <Typography variant="caption" className={classes.panelLabel}>
+                  Resistance threshold
+                </Typography>
+                <Select
+                  value={resThreshold}
+                  onChange={e => setResThreshold(e.target.value)}
+                  size="small"
+                  fullWidth
+                >
+                  {RESISTANCE_THRESHOLDS.map(t => (
+                    <MenuItem key={t.value} value={t.value}>{t.label}</MenuItem>
+                  ))}
+                </Select>
+              </Box>
+
+              <Box className={classes.panelSelectWrapper}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                  <Typography variant="caption" className={classes.panelLabel}>
+                    Group by
+                  </Typography>
+                  <Tooltip title="Shows the percentage of K. pneumoniae isolates that are BOTH hypervirulent AND multidrug-resistant. These convergent strains are the most clinically dangerous.">
+                    <InfoOutlined fontSize="small" sx={{ cursor: 'pointer', color: 'rgba(0,0,0,0.5)' }} />
+                  </Tooltip>
+                </Box>
+                <Select
+                  value={xAxisType}
+                  onChange={e => setXAxisType(e.target.value)}
+                  size="small"
+                  fullWidth
+                >
+                  <MenuItem value="country">Country</MenuItem>
+                  <MenuItem value="region">Region</MenuItem>
+                </Select>
+              </Box>
+            </CardContent>
+          </Card>
+        </Box>
+      )}
     </CardContent>
   );
 };

--- a/client/src/components/Elements/Graphs/ConvergenceMapGraph/ConvergenceMapGraphMUI.js
+++ b/client/src/components/Elements/Graphs/ConvergenceMapGraph/ConvergenceMapGraphMUI.js
@@ -5,6 +5,7 @@ const useStyles = makeStyles((_theme) => ({
     display: 'flex',
     flexDirection: 'column',
     borderTop: '1px solid rgba(0, 0, 0, 0.12)',
+    position: 'relative',
   },
   controlsRow: {
     display: 'flex',
@@ -80,6 +81,35 @@ const useStyles = makeStyles((_theme) => ({
     paddingRight: '8px',
     textAlign: 'right',
     flexShrink: 0,
+  },
+  // Floating plotting-options panel (matches DrugResistanceGraph /
+  // BubbleHeatmapGraph2 / SerotypeResistanceGraph pattern).
+  floatingFilter: {
+    position: 'absolute',
+    top: 16,
+    right: -(280 + 16),
+    width: '280px',
+    zIndex: 1,
+
+    '@media (max-width: 1900px)': {
+      right: 16,
+    },
+  },
+  titleWrapper: {
+    paddingBottom: '8px',
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  panelSelectWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    paddingTop: '8px',
+  },
+  panelLabel: {
+    fontWeight: 600,
+    paddingBottom: '4px',
   },
 }));
 

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -235,7 +235,8 @@
     "emergenceRate": "Resistance Emergence Rate",
     "emergenceRateDescription": "Average annual change in resistance prevalence (%/year) — identifies accelerating resistance",
     "qrdrMutations": "QRDR Mutations",
-    "vaccineCoverage": "Vaccine Coverage"
+    "vaccineCoverage": "Vaccine Coverage",
+    "convergenceMap": "Virulence × Resistance Convergence"
   },
   "floatingGlobalFilters": {
     "title": "Global Filters",

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -235,7 +235,8 @@
     "emergenceRate": "Tasa de Emergencia de Resistencia",
     "emergenceRateDescription": "Cambio anual promedio en la prevalencia de resistencia (%/año) — identifica resistencias en aceleración",
     "qrdrMutations": "Mutaciones QRDR",
-    "vaccineCoverage": "Cobertura de vacunas"
+    "vaccineCoverage": "Cobertura de vacunas",
+    "convergenceMap": "Convergencia de virulencia × resistencia"
   },
   "amrInsights": {
     "title": "Análisis de RAM",

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -235,7 +235,8 @@
     "emergenceRate": "Taux d'Émergence de la Résistance",
     "emergenceRateDescription": "Changement annuel moyen de la prévalence de résistance (%/an) — identifie les résistances en accélération",
     "qrdrMutations": "Mutations QRDR",
-    "vaccineCoverage": "Couverture vaccinale"
+    "vaccineCoverage": "Couverture vaccinale",
+    "convergenceMap": "Convergence virulence × résistance"
   },
   "amrInsights": {
     "title": "Analyses RAM",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -235,7 +235,8 @@
     "emergenceRate": "Taxa de Emergência de Resistência",
     "emergenceRateDescription": "Mudança anual média na prevalência de resistência (%/ano) — identifica resistência em aceleração",
     "qrdrMutations": "Mutações QRDR",
-    "vaccineCoverage": "Cobertura vacinal"
+    "vaccineCoverage": "Cobertura vacinal",
+    "convergenceMap": "Convergência virulência × resistência"
   },
   "amrInsights": {
     "title": "Análises de RAM",

--- a/client/src/util/graphCards.js
+++ b/client/src/util/graphCards.js
@@ -1,8 +1,9 @@
-import { BubbleChart, GridOn, ShowChart, StackedBarChart, Timeline, ViewModule, Vaccines } from '@mui/icons-material';
+import { BubbleChart, GridOn, ShowChart, StackedBarChart, Timeline, ViewModule, Vaccines, Coronavirus } from '@mui/icons-material';
 import { BubbleHeatmapGraph2 } from '../components/Elements/Graphs/BubbleHeatmapGraph2';
 import { BubbleKOHeatmapGraph } from '../components/Elements/Graphs/BubbleKOHeatmapGraph';
 import { BubbleMarkersHeatmapGraph } from '../components/Elements/Graphs/BubbleMarkersHeatmapGraph';
 import { ConvergenceGraph } from '../components/Elements/Graphs/ConvergenceGraph';
+import { ConvergenceMapGraph } from '../components/Elements/Graphs/ConvergenceMapGraph';
 import { DeterminantsGraph } from '../components/Elements/Graphs/DeterminantsGraph';
 import { DistributionGraph } from '../components/Elements/Graphs/DistributionGraph';
 import { DrugResistanceGraph } from '../components/Elements/Graphs/DrugResistanceGraph';
@@ -111,6 +112,14 @@ export function getGraphCards(t){
       id: 'convergence-graph',
       organisms: ['kpneumo'],
       component: <ConvergenceGraph />,
+    },
+    {
+      title: t('graphs.convergenceMap'),
+      description: [''],
+      icon: <Coronavirus color="primary" />,
+      id: 'CVM',
+      organisms: ['kpneumo'],
+      component: <ConvergenceMapGraph />,
     },
     {
       title: t('graphs.genotypeTrends'),


### PR DESCRIPTION
## Summary

First slice of the AMR Insights cleanup. Per the discussion, the ATB / GVP fixes (true geno %R, multi-drug selector, source-link panel) land in a separate follow-up PR — this one only moves the Convergence Map.

### What changes

- **Convergence Map (CVM)** — kpneumo-only — moves out of **AMR Insights** and becomes its own **Summary Plots** card titled **"Virulence × Resistance Convergence"**. The plot is genome-derived (Kleborate `virulence_score` + `num_resistance_classes`), so it now sits alongside the other genome-only cards under Summary Plots.
- **Global filters now apply.** `rawOrganismData` is filtered by `actualCountry` / `actualRegion` (via `economicRegions`) / `actualTimeInitial..actualTimeFinal` before per-location aggregation. Previously the plot ignored these filters and always showed a global picture. Same model used by Co-occurrence and Vaccine Coverage.
- **Floating Plotting Options panel.** The three inline controls — Virulence threshold, Resistance threshold, Group-by (Country / Region) — move into a floating panel on the right, alongside a `SelectCountry` dropdown so the user can change the country / region from the same panel. Pattern mirrors BubbleHeatmapGraph2 and SerotypeResistanceGraph.
- **AMR Insights cleanup.** CVM tab + `ConvergenceMapGraph` import + the CVM case in the CSV-export switch are removed. The kpneumo-only CVM card is added to `graphCards.js` with a new `graphs.convergenceMap` i18n key (en / es / fr / pt). `Coronavirus` icon picked since it pairs visually with the existing `BubbleChart`-iconned "AMR + virulence" card.

### Not in this PR (deferred per agreement)

- **ATB (AM Usage vs Resistance) — true geno %R from AMRnet data + class aggregation + WHO GLASS attribution link.**
- **GVP (Genomic vs Phenotypic) — multi-drug selector (drugs with both geno + pheno coverage) + source-attribution panel + extended explanation copy.**
- **GLASS license review, GVP literature-data provenance docs, GRAM evaluation.** Doc / data-curation tasks.

I'll open the follow-up PR once you've smoke-tested this one on dev.

## Test plan

- [ ] AMR Insights tabs: COO, GVP, ATB (and GMP when populated). **No CVM tab.**
- [ ] Summary Plots → kpneumo: new **Virulence × Resistance Convergence** card appears between the **Resistance + virulence** convergence (Top genotypes) card and the rest.
- [ ] Click the filter button on the CVM card → floating panel appears on the right with: SelectCountry, Virulence threshold, Resistance threshold, Group by.
- [ ] Picking a country in the panel narrows the chart to that country (one row). Picking a region narrows to countries in that region. The dashboard's top filter and the panel dropdown stay in sync (same Redux state).
- [ ] Changing Group by between Country and Region switches the row labels without flicker; thresholds re-aggregate the % convergent column in place.