### PR TITLE
Promote development to main: ATB true geno %R, GVP drug selector + time-alignment + floating sidebar (#419)

### DIFF
--- a/client/src/components/Elements/AMRInsights/AMRInsights.js
+++ b/client/src/components/Elements/AMRInsights/AMRInsights.js
@@ -1,4 +1,4 @@
-import { ExpandLess, ExpandMore, TipsAndUpdates } from '@mui/icons-material';
+import { ExpandLess, ExpandMore, FilterList, FilterListOff, TipsAndUpdates } from '@mui/icons-material';
 import {
   Box,
   Card,
@@ -7,6 +7,7 @@ import {
   IconButton,
   Tab,
   Tabs,
+  Tooltip,
   Typography,
   useMediaQuery,
 } from '@mui/material';
@@ -29,24 +30,28 @@ const TABS = [
     value: 'COO',
     component: <CooccurrenceGraph />,
     onlyFor: null,
+    hasFilter: false,
   },
   {
     labelKey: 'amrInsights.tabs.genomicVsPhenotypic',
     value: 'GVP',
     component: <GenomicVsPhenotypicGraph />,
     onlyFor: null,
+    hasFilter: true,
   },
   {
     labelKey: 'amrInsights.tabs.atbCorrelation',
     value: 'ATB',
     component: <ATBCorrelationGraph />,
     onlyFor: null,
+    hasFilter: true,
   },
   {
     labelKey: 'amrInsights.tabs.geneMap',
     value: 'GMP',
     component: <GeneMapGraph />,
     onlyFor: [],
+    hasFilter: false,
   },
 ];
 
@@ -163,6 +168,17 @@ export const AMRInsights = () => {
                 currentTab={currentTab}
                 tabLabel={currentTabLabel}
               />
+            )}
+            {/* Filter / Plotting Options toggle — only shown for tabs that
+                actually render a floating panel (ATB and GVP today). Without
+                it, once a user closed the panel via its X there was no way
+                to re-open it. */}
+            {isExpanded && currentTabConfig?.hasFilter && (
+              <Tooltip title={showFilter ? 'Hide plotting options' : 'Show plotting options'} placement="top">
+                <IconButton onClick={handleClickFilter}>
+                  {showFilter ? <FilterListOff /> : <FilterList />}
+                </IconButton>
+              </Tooltip>
             )}
             <IconButton>{isExpanded ? <ExpandLess /> : <ExpandMore />}</IconButton>
           </div>

--- a/client/src/components/Elements/Graphs/ATBCorrelationGraph/ATBCorrelationGraph.js
+++ b/client/src/components/Elements/Graphs/ATBCorrelationGraph/ATBCorrelationGraph.js
@@ -1,6 +1,7 @@
 import { InfoOutlined, FileDownload } from '@mui/icons-material';
 import {
   Box,
+  Card,
   CardContent,
   Chip,
   CircularProgress,
@@ -12,6 +13,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
+import { PlottingOptionsHeader } from '../../Shared/PlottingOptionsHeader';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   CartesianGrid,
@@ -431,26 +433,40 @@ export const ATBCorrelationGraph = ({ showFilter, setShowFilter }) => {
               ))}
           </Box>
 
-          <Typography variant="body2" fontWeight={600} sx={{ marginTop: '8px' }}>Data Sources</Typography>
-          <Box className={classes.tooltipWrapper}>
-            <Typography variant="caption" sx={{ lineHeight: 1.5 }} component="div">
-              <strong>AM Consumption (X):</strong>{' '}
-              <a href={GLASS_AMU_URL} target="_blank" rel="noopener noreferrer">WHO GLASS-AMC via GHO OData API</a>{' '}
-              ({dataSource === 'glass'
-                ? `${glassData?.consumption?.length || 0} country-year records, 2016–2023`
-                : 'static fallback, 16 countries, 2020'}). Total antibiotic consumption in DDD/1000 inhabitants/day. GLASS publishes TOTAL consumption, not per-class — so the X value is the same for every ATB class for a given country.
-              <br /><br />
-              <strong>Genomic Resistance (Y):</strong>{' '}
-              <a href={AMRNET_DOCS_URL} target="_blank" rel="noopener noreferrer">AMRnet</a> genome-derived call. Per country: count of genomes resistant to <em>any</em> AMRnet drug in the selected ATB class
-              {' '}({getAmrnetDrugsForATBClass(organism, selectedATBClass).join(', ') || '—'}), divided by total genomes (year range respects the dashboard filter). Countries with &lt;20 genomes are excluded.
-              <br /><br />
-              <strong>Matching:</strong> N={scatterData.length} countries with both GLASS consumption AND ≥20 AMRnet genomes. Country names are matched on a normalized lowercase-alpha form to bridge WHO/AMRnet label differences.
-              <br /><br />
-              <strong>Caveat:</strong> ecological correlation — does not imply causation. Different ATB classes share the same X (total consumption); the Y value is what changes per class.
-            </Typography>
-          </Box>
         </Box>
       </Box>
+
+      {/* Floating reference panel — Data Sources content. The inline right
+          panel keeps the live chart stats (R², Region Legend) so the dense
+          attribution text doesn't compete with them for vertical space. */}
+      {showFilter && (
+        <Box className={classes.floatingFilter}>
+          <Card elevation={3}>
+            <CardContent>
+              <PlottingOptionsHeader onClose={() => setShowFilter(false)} className={classes.titleWrapper} />
+
+              <Typography variant="body2" fontWeight={600}>Data Sources</Typography>
+              <Box className={classes.tooltipWrapper} sx={{ marginTop: '4px' }}>
+                <Typography variant="caption" sx={{ lineHeight: 1.5 }} component="div">
+                  <strong>AM Consumption (X):</strong>{' '}
+                  <a href={GLASS_AMU_URL} target="_blank" rel="noopener noreferrer">WHO GLASS-AMC via GHO OData API</a>{' '}
+                  ({dataSource === 'glass'
+                    ? `${glassData?.consumption?.length || 0} country-year records, 2016–2023`
+                    : 'static fallback, 16 countries, 2020'}). Total antibiotic consumption in DDD/1000 inhabitants/day. GLASS publishes TOTAL consumption, not per-class — so the X value is the same for every ATB class for a given country.
+                  <br /><br />
+                  <strong>Genomic Resistance (Y):</strong>{' '}
+                  <a href={AMRNET_DOCS_URL} target="_blank" rel="noopener noreferrer">AMRnet</a> genome-derived call. Per country: count of genomes resistant to <em>any</em> AMRnet drug in the selected ATB class
+                  {' '}({getAmrnetDrugsForATBClass(organism, selectedATBClass).join(', ') || '—'}), divided by total genomes (year range respects the dashboard filter). Countries with &lt;20 genomes are excluded.
+                  <br /><br />
+                  <strong>Matching:</strong> N={scatterData.length} countries with both GLASS consumption AND ≥20 AMRnet genomes. Country names are matched on a normalized lowercase-alpha form to bridge WHO/AMRnet label differences.
+                  <br /><br />
+                  <strong>Caveat:</strong> ecological correlation — does not imply causation. Different ATB classes share the same X (total consumption); the Y value is what changes per class.
+                </Typography>
+              </Box>
+            </CardContent>
+          </Card>
+        </Box>
+      )}
     </CardContent>
   );
 };

--- a/client/src/components/Elements/Graphs/ATBCorrelationGraph/ATBCorrelationGraph.js
+++ b/client/src/components/Elements/Graphs/ATBCorrelationGraph/ATBCorrelationGraph.js
@@ -27,9 +27,15 @@ import {
   Cell,
 } from 'recharts';
 import { useAppSelector } from '../../../../stores/hooks';
-import { fetchGLASSData, getGLASSIndicatorForATBClass, getGLASSPhenotypicByOrganismDrug } from '../../../../data/glass_data';
+import { fetchGLASSData } from '../../../../data/glass_data';
 import { getATBClassesForOrganism, getAmrnetDrugsForATBClass } from '../../../../util/atbDrugMapping';
+import { getResistantDrugs } from '../../../../util/resistance';
+import { getCountryDisplayName } from '../../../Dashboard/filters';
 import { useStyles } from './ATBCorrelationGraphMUI';
+
+// WHO GLASS public-facing landing pages — used for the Data Sources panel.
+const GLASS_AMU_URL = 'https://www.who.int/data/gho/data/themes/topics/global-antimicrobial-resistance-and-use-surveillance-system-glass-database';
+const AMRNET_DOCS_URL = 'https://amrnet.readthedocs.io';
 
 // Dynamic color palette for regions (AMRnet uses UN sub-regions from UNR data)
 const REGION_COLOR_PALETTE = [
@@ -80,11 +86,18 @@ const CustomTooltip = ({ active, payload }) => {
   return (
     <Box sx={{ backgroundColor: '#fff', padding: '8px 12px', border: '1px solid rgba(0,0,0,0.2)', borderRadius: '4px' }}>
       <Typography variant="body2" fontWeight={600}>{data.country}</Typography>
-      <Typography variant="caption" display="block">AM consumption: {data.x?.toFixed(2)} DDD/1000/day ({data.consumptionYear})</Typography>
-      <Typography variant="caption" display="block">Resistance: {data.y?.toFixed(1)}% ({data.resistanceYear || ''})</Typography>
-      {data.genomes > 0 && <Typography variant="caption" display="block">Samples tested: {data.genomes}</Typography>}
+      <Typography variant="caption" display="block">
+        AM consumption (WHO GLASS): {data.x?.toFixed(2)} DDD/1000/day ({data.consumptionYear})
+      </Typography>
+      <Typography variant="caption" display="block">
+        Genomic %R (AMRnet): {data.y?.toFixed(1)}% — {data.resistant}/{data.genomes} genomes
+      </Typography>
+      {data.classDrugs?.length > 0 && (
+        <Typography variant="caption" display="block" color="textSecondary">
+          Aggregated over: {data.classDrugs.join(', ')}
+        </Typography>
+      )}
       <Typography variant="caption" display="block" color="textSecondary">Region: {data.region}</Typography>
-      <Typography variant="caption" display="block" color="textSecondary">Source: {data.source}</Typography>
     </Box>
   );
 };
@@ -98,9 +111,11 @@ export const ATBCorrelationGraph = ({ showFilter, setShowFilter }) => {
   const [dataSource, setDataSource] = useState('glass');
 
   const organism = useAppSelector(state => state.dashboard.organism);
-  const drugsCountriesData = useAppSelector(state => state.graph.drugsCountriesData);
+  const rawOrganismData = useAppSelector(state => state.graph.rawOrganismData);
   const economicRegions = useAppSelector(state => state.dashboard.economicRegions);
   const canGetData = useAppSelector(state => state.dashboard.canGetData);
+  const actualTimeInitial = useAppSelector(state => state.dashboard.actualTimeInitial);
+  const actualTimeFinal = useAppSelector(state => state.dashboard.actualTimeFinal);
 
   // Build country→region lookup from AMRnet's own region mapping
   const countryToRegion = useMemo(() => buildCountryToRegion(economicRegions), [economicRegions]);
@@ -115,8 +130,13 @@ export const ATBCorrelationGraph = ({ showFilter, setShowFilter }) => {
   }, [countryToRegion]);
 
   const atbClasses = useMemo(() => {
-    // Only show ATB classes that have GLASS resistance data
-    return getATBClassesForOrganism(organism).filter(cls => getGLASSIndicatorForATBClass(organism, cls));
+    // Show every ATB class that has an AMRnet drug mapping for this organism.
+    // Previously this filter only kept classes with a matching GLASS pheno
+    // indicator; the Y-axis now uses AMRnet genomic data so the filter no
+    // longer needs to gate on GLASS pheno coverage.
+    return getATBClassesForOrganism(organism).filter(
+      cls => getAmrnetDrugsForATBClass(organism, cls).length > 0,
+    );
   }, [organism]);
 
   // Reset selected class when organism changes
@@ -146,9 +166,11 @@ export const ATBCorrelationGraph = ({ showFilter, setShowFilter }) => {
     return () => { cancelled = true; };
   }, []);
 
-  // Build scatter data
+  // Build scatter data — Y axis is AMRnet genomic %R per ATB class
+  // (computed from rawOrganismData using the same drug-rules engine the
+  // rest of AMRnet uses). X axis stays as WHO GLASS AM consumption.
   const { scatterData, regression } = useMemo(() => {
-    if (!drugsCountriesData || typeof drugsCountriesData !== 'object' || !selectedATBClass) {
+    if (!selectedATBClass) {
       return { scatterData: [], regression: { slope: 0, intercept: 0, r2: 0 } };
     }
 
@@ -157,83 +179,106 @@ export const ATBCorrelationGraph = ({ showFilter, setShowFilter }) => {
       return { scatterData: [], regression: { slope: 0, intercept: 0, r2: 0 } };
     }
 
-    // ── X-axis: WHO GLASS consumption ──
-    const consumptionByCountry = {};
+    // Fuzzy country-name matching: GLASS uses one set of country labels and
+    // AMRnet uses another. Build both keyed by a normalized form so a country
+    // that appears in both datasets matches even if the label is slightly
+    // different (e.g. "Korea, Republic of" vs "South Korea").
+    const normalize = s => s?.toLowerCase().replace(/[^a-z]/g, '') || '';
+
+    // ── X-axis: WHO GLASS consumption (latest year per country) ──
+    const consumptionByKey = {};
     if (glassData?.consumption) {
-      const byCountry = {};
       glassData.consumption.forEach(r => {
-        if (!byCountry[r.country] || r.year > byCountry[r.country].year) {
-          byCountry[r.country] = r;
+        const key = normalize(r.country);
+        if (!consumptionByKey[key] || r.year > consumptionByKey[key].year) {
+          consumptionByKey[key] = { value: r.value, year: r.year, displayName: r.country };
         }
-      });
-      Object.values(byCountry).forEach(r => {
-        consumptionByCountry[r.country] = { value: r.value, year: r.year };
       });
     }
 
-    // ── Y-axis: WHO GLASS resistance (per ATB class) ──
-    const indicator = getGLASSIndicatorForATBClass(organism, selectedATBClass);
-    const resistanceByCountry = {};
-
-    if (indicator && glassData) {
-      if (indicator.source === 'csv') {
-        const phenoData = getGLASSPhenotypicByOrganismDrug(
-          glassData, indicator.pathogen, indicator.antibiotic, indicator.specimen,
-        );
-        phenoData.forEach(r => {
-          if (!resistanceByCountry[r.country] || r.year > resistanceByCountry[r.country].year) {
-            resistanceByCountry[r.country] = { value: r.value, year: r.year, tested: r.tested };
+    // ── Y-axis: AMRnet genomic %R per class, per country ──
+    // Per country: count genomes resistant to ANY drug in the class (union
+    // semantics) over total genomes in the year range. This matches
+    // intuitive "class resistance" — i.e. resistance to at least one drug
+    // in the class — and is computed identically to how the rest of the
+    // dashboard derives per-class flags.
+    const classDrugSet = new Set(amrnetDrugs);
+    const amrnetByKey = {};
+    if (Array.isArray(rawOrganismData)) {
+      rawOrganismData.forEach(genome => {
+        const date = genome.DATE;
+        if (date && (date < actualTimeInitial || date > actualTimeFinal)) return;
+        const country = getCountryDisplayName(genome.COUNTRY_ONLY);
+        if (!country) return;
+        const key = normalize(country);
+        if (!amrnetByKey[key]) amrnetByKey[key] = { total: 0, resistant: 0, displayName: country };
+        amrnetByKey[key].total++;
+        const resistantSet = getResistantDrugs(genome, organism);
+        for (const drug of classDrugSet) {
+          if (resistantSet.has(drug)) {
+            amrnetByKey[key].resistant++;
+            break;
           }
-        });
-      } else if (indicator.source === 'gho') {
-        const ghoKey = indicator.ghoKey;
-        if (ghoKey && glassData.resistance?.[ghoKey]) {
-          glassData.resistance[ghoKey].forEach(r => {
-            if (!resistanceByCountry[r.country] || r.year > resistanceByCountry[r.country].year) {
-              resistanceByCountry[r.country] = { value: r.value, year: r.year, tested: 0 };
-            }
-          });
         }
-      }
+      });
     }
 
-    // ── Build scatter points: match countries with both consumption + resistance ──
+    // ── Build scatter points: countries with both AMRnet genomes (N>=20) and GLASS consumption ──
     const points = [];
-    Object.entries(resistanceByCountry).forEach(([country, res]) => {
-      const consumption = consumptionByCountry[country];
-      if (consumption && res.value != null) {
-        const x = Number(consumption.value);
-        const y = Number(Number(res.value).toFixed(1));
-        // Drop points whose coordinates aren't finite — otherwise the
-        // XAxis (`domain={['auto','auto']}`) auto-domain reduces to NaN
-        // and Recharts' getNiceTickValues crashes.
-        if (!Number.isFinite(x) || !Number.isFinite(y)) return;
-        const region = countryToRegion[country] || 'Unknown';
-        points.push({
-          country,
-          x,
-          y,
-          genomes: res.tested || 0,
-          region,
-          color: regionColors[region] || regionColors['Unknown'],
-          consumptionYear: consumption.year,
-          resistanceYear: res.year,
-          source: 'WHO GLASS',
-        });
-      }
+    Object.entries(amrnetByKey).forEach(([key, agg]) => {
+      if (agg.total < 20) return; // same min-N gate used elsewhere in the dashboard
+      const consumption = consumptionByKey[key];
+      if (!consumption) return;
+      const x = Number(consumption.value);
+      const y = Number(((agg.resistant / agg.total) * 100).toFixed(1));
+      if (!Number.isFinite(x) || !Number.isFinite(y)) return;
+      const country = agg.displayName;
+      const region = countryToRegion[country] || 'Unknown';
+      points.push({
+        country,
+        x,
+        y,
+        genomes: agg.total,
+        resistant: agg.resistant,
+        classDrugs: amrnetDrugs,
+        region,
+        color: regionColors[region] || regionColors['Unknown'],
+        consumptionYear: consumption.year,
+      });
     });
 
     return { scatterData: points, regression: linearRegression(points) };
-  }, [selectedATBClass, organism, glassData, countryToRegion, regionColors]);
+  }, [
+    selectedATBClass,
+    organism,
+    rawOrganismData,
+    glassData,
+    countryToRegion,
+    regionColors,
+    actualTimeInitial,
+    actualTimeFinal,
+  ]);
 
   const downloadCSV = useCallback(() => {
     if (!scatterData.length) return;
     const amrnetDrugs = getAmrnetDrugsForATBClass(organism, selectedATBClass);
     const escape = v => `"${String(v ?? '').replace(/"/g, '""')}"`;
-    const headers = ['country', 'region', 'atb_class', 'amrnet_drug', 'consumption_ddd_per_1000_day', 'consumption_year', 'consumption_source', 'resistance_pct', 'n_genomes'];
+    const headers = [
+      'country',
+      'region',
+      'atb_class',
+      'amrnet_class_drugs',
+      'consumption_ddd_per_1000_day',
+      'consumption_year',
+      'consumption_source',
+      'genomic_resistance_pct',
+      'n_genomes_resistant',
+      'n_genomes_total',
+      'genomic_source',
+    ];
     const rows = scatterData.map(d => [
       d.country, d.region, selectedATBClass, amrnetDrugs.join(';'),
-      d.x, d.consumptionYear, d.source, d.y, d.genomes,
+      d.x, d.consumptionYear, 'WHO GLASS', d.y, d.resistant, d.genomes, 'AMRnet',
     ]);
     const csv = [headers, ...rows].map(r => r.map(escape).join(',')).join('\n');
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
@@ -302,12 +347,14 @@ export const ATBCorrelationGraph = ({ showFilter, setShowFilter }) => {
           {loadingGlass ? (
             <Chip label="Loading GLASS data..." size="small" icon={<CircularProgress size={12} />} />
           ) : (
-            <Chip
-              label={`WHO GLASS — consumption + resistance (${scatterData.length} countries)`}
-              size="small"
-              color="success"
-              variant="outlined"
-            />
+            <Tooltip title="X: WHO GLASS antimicrobial consumption (DDD/1000/day). Y: AMRnet genomic %R, computed per ATB class by aggregating the resistance calls for every AMRnet drug in that class (union — resistant to ≥1 drug). Click for source links in the Data Sources panel.">
+              <Chip
+                label={`WHO GLASS × AMRnet — ${scatterData.length} countries`}
+                size="small"
+                color="success"
+                variant="outlined"
+              />
+            </Tooltip>
           )}
           <Tooltip title={`Download plotted data as CSV (${scatterData.length} countries, ${selectedATBClass})`}>
             <span>
@@ -324,9 +371,7 @@ export const ATBCorrelationGraph = ({ showFilter, setShowFilter }) => {
           {scatterData.length === 0 ? (
             <Box className={classes.noSelection}>
               <Typography variant="body2" color="textSecondary">
-                No matching data between WHO GLASS consumption and resistance for this selection.
-                <br />
-                No countries have both consumption and resistance data available for this antibiotic class. Try selecting a different class.
+                No countries have both WHO GLASS consumption and ≥20 AMRnet genomes for this antibiotic class. Try a different class or widen the dashboard's year range.
               </Typography>
             </Box>
           ) : (
@@ -337,7 +382,7 @@ export const ATBCorrelationGraph = ({ showFilter, setShowFilter }) => {
                   <Label value="AM Consumption (DDD/1000 inhabitants/day)" position="bottom" offset={20} style={{ fontSize: 12 }} />
                 </XAxis>
                 <YAxis type="number" dataKey="y" domain={[0, 100]}>
-                  <Label value="Genomic Resistance — WHO GLASS (%)" angle={-90} position="insideLeft" offset={10} style={{ fontSize: 11, textAnchor: 'middle' }} />
+                  <Label value="Genomic Resistance — AMRnet (%)" angle={-90} position="insideLeft" offset={10} style={{ fontSize: 11, textAnchor: 'middle' }} />
                 </YAxis>
                 <ZAxis type="number" dataKey="genomes" range={[60, 400]} />
                 <ChartTooltip content={<CustomTooltip />} />
@@ -388,16 +433,20 @@ export const ATBCorrelationGraph = ({ showFilter, setShowFilter }) => {
 
           <Typography variant="body2" fontWeight={600} sx={{ marginTop: '8px' }}>Data Sources</Typography>
           <Box className={classes.tooltipWrapper}>
-            <Typography variant="caption" sx={{ lineHeight: 1.5 }}>
-              <strong>AM Consumption:</strong> {dataSource === 'glass'
-                ? `WHO GLASS-AMC via GHO OData API (${glassData?.consumption?.length || 0} country-year records, 2016-2023). Total antibiotic consumption as DDD/1000/day.`
-                : 'Static dataset adapted from WHO GLASS AMC/AMU report and ECDC ESAC-Net (16 countries, 2020).'}
+            <Typography variant="caption" sx={{ lineHeight: 1.5 }} component="div">
+              <strong>AM Consumption (X):</strong>{' '}
+              <a href={GLASS_AMU_URL} target="_blank" rel="noopener noreferrer">WHO GLASS-AMC via GHO OData API</a>{' '}
+              ({dataSource === 'glass'
+                ? `${glassData?.consumption?.length || 0} country-year records, 2016–2023`
+                : 'static fallback, 16 countries, 2020'}). Total antibiotic consumption in DDD/1000 inhabitants/day. GLASS publishes TOTAL consumption, not per-class — so the X value is the same for every ATB class for a given country.
               <br /><br />
-              <strong>Resistance:</strong> WHO GLASS phenotypic resistance surveillance data ({selectedATBClass}).
+              <strong>Genomic Resistance (Y):</strong>{' '}
+              <a href={AMRNET_DOCS_URL} target="_blank" rel="noopener noreferrer">AMRnet</a> genome-derived call. Per country: count of genomes resistant to <em>any</em> AMRnet drug in the selected ATB class
+              {' '}({getAmrnetDrugsForATBClass(organism, selectedATBClass).join(', ') || '—'}), divided by total genomes (year range respects the dashboard filter). Countries with &lt;20 genomes are excluded.
               <br /><br />
-              <strong>Matching:</strong> N={scatterData.length} countries with both consumption AND resistance data from WHO GLASS.
+              <strong>Matching:</strong> N={scatterData.length} countries with both GLASS consumption AND ≥20 AMRnet genomes. Country names are matched on a normalized lowercase-alpha form to bridge WHO/AMRnet label differences.
               <br /><br />
-              <strong>Note:</strong> Ecological correlation — does not imply causation. GLASS provides TOTAL antibiotic consumption (not per class), so the X-axis values are the same across all antibiotic classes.
+              <strong>Caveat:</strong> ecological correlation — does not imply causation. Different ATB classes share the same X (total consumption); the Y value is what changes per class.
             </Typography>
           </Box>
         </Box>

--- a/client/src/components/Elements/Graphs/ATBCorrelationGraph/ATBCorrelationGraphMUI.js
+++ b/client/src/components/Elements/Graphs/ATBCorrelationGraph/ATBCorrelationGraphMUI.js
@@ -5,6 +5,7 @@ const useStyles = makeStyles((_theme) => ({
     display: 'flex',
     flexDirection: 'column',
     borderTop: '1px solid rgba(0, 0, 0, 0.12)',
+    position: 'relative',
   },
   controlsRow: {
     display: 'flex',
@@ -77,6 +78,26 @@ const useStyles = makeStyles((_theme) => ({
     alignItems: 'center',
     gap: '8px',
     padding: '8px 0',
+  },
+  // Floating reference panel — Data Sources content lives here so the
+  // chart area stays focused on the live stats (R², region legend).
+  floatingFilter: {
+    position: 'absolute',
+    top: 16,
+    right: -(320 + 16),
+    width: '320px',
+    zIndex: 1,
+
+    '@media (max-width: 1900px)': {
+      right: 16,
+    },
+  },
+  titleWrapper: {
+    paddingBottom: '8px',
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
   },
 }));
 

--- a/client/src/components/Elements/Graphs/CooccurrenceGraph/CooccurrenceGraph.js
+++ b/client/src/components/Elements/Graphs/CooccurrenceGraph/CooccurrenceGraph.js
@@ -2,14 +2,7 @@ import { InfoOutlined } from '@mui/icons-material';
 import { Box, CardContent, FormControlLabel, Slider, Switch, Tooltip, Typography } from '@mui/material';
 import { useMemo, useState } from 'react';
 import { useAppSelector } from '../../../../stores/hooks';
-import {
-  drugRulesKP,
-  drugRulesNG,
-  drugRulesSA,
-  drugRulesSP,
-  drugRulesST,
-  statKeysECOLI,
-} from '../../../../util/drugClassesRules';
+import { getResistantDrugs } from '../../../../util/resistance';
 import { getCountryDisplayName } from '../../../Dashboard/filters';
 import { useStyles } from './CooccurrenceGraphMUI';
 
@@ -33,87 +26,6 @@ function getLineageKey(genome, organism) {
     return genome.LINcode_7;
   }
   return genome.GENOTYPE;
-}
-const EXCLUSIONS = [
-  'MDR',
-  'XDR',
-  'Pansusceptible',
-  'Susceptible',
-  'Susceptible to cat I/II drugs',
-  'H58',
-  'Ciprofloxacin NS',
-  'Ciprofloxacin R',
-  'Trimethoprim-sulfamethoxazole',
-  'Trimethoprim-Sulfamethoxazole',
-];
-
-/**
- * Determine which drugs a single genome is resistant to.
- * Returns a Set of drug names.
- */
-function getResistantDrugs(genome, organism) {
-  const resistant = new Set();
-
-  if (organism === 'styphi') {
-    drugRulesST.forEach(rule => {
-      if (EXCLUSIONS.includes(rule.key)) return;
-      if (rule.values.some(v => genome[rule.columnID]?.toString() === v.toString())) {
-        resistant.add(rule.key);
-      }
-    });
-  } else if (organism === 'kpneumo') {
-    drugRulesKP.forEach(rule => {
-      if (EXCLUSIONS.includes(rule.key)) return;
-      const hasResistance = rule.columnIDs.some(id => genome[id] && genome[id] !== '-' && genome[id] !== 'ND');
-      if ('every' in rule) {
-        const allPresent = rule.columnIDs.every(id => genome[id] && genome[id] !== '-' && genome[id] !== 'ND');
-        if (allPresent) resistant.add(rule.key);
-      } else if (hasResistance) {
-        resistant.add(rule.key);
-      }
-    });
-  } else if (organism === 'ngono') {
-    drugRulesNG.forEach(rule => {
-      if (EXCLUSIONS.includes(rule.key)) return;
-      if (Array.isArray(rule.columnID)) {
-        if (rule.values.some(v => rule.columnID.some(col => genome[col]?.toString() === v.toString()))) {
-          resistant.add(rule.key);
-        }
-      } else if (rule.values.some(v => genome[rule.columnID]?.toString() === v.toString())) {
-        resistant.add(rule.key);
-      }
-    });
-  } else if (['senterica', 'sentericaints', 'ecoli', 'decoli', 'shige'].includes(organism)) {
-    statKeysECOLI.forEach(drug => {
-      if (EXCLUSIONS.includes(drug.name) || !drug.resistanceView || drug.computed) return;
-      if (!drug.rules || drug.rules.length === 0) return;
-      const matchRule = rule => {
-        const raw = genome[rule.column];
-        const isEmpty = raw == null || raw === '' || raw === '-';
-        // equal: true → susceptible check (value IS empty/'-')
-        // equal: false → resistance check (value has actual gene content)
-        return rule.equal ? isEmpty : !isEmpty;
-      };
-      const isResistant = drug.every ? drug.rules.every(matchRule) : drug.rules.some(matchRule);
-      if (isResistant) resistant.add(drug.name);
-    });
-  } else if (organism === 'saureus') {
-    drugRulesSA.forEach(rule => {
-      if (EXCLUSIONS.includes(rule.key) || rule.pansusceptible) return;
-      if (rule.values.some(v => genome[rule.columnID]?.toString() === v.toString())) {
-        resistant.add(rule.key);
-      }
-    });
-  } else if (organism === 'strepneumo') {
-    drugRulesSP.forEach(rule => {
-      if (EXCLUSIONS.includes(rule.key) || rule.pansusceptible) return;
-      if (rule.values.some(v => genome[rule.columnID]?.toString() === v.toString())) {
-        resistant.add(rule.key);
-      }
-    });
-  }
-
-  return resistant;
 }
 
 function getCooccurrenceColor(value) {

--- a/client/src/components/Elements/Graphs/GenomicVsPhenotypicGraph/GenomicVsPhenotypicGraph.js
+++ b/client/src/components/Elements/Graphs/GenomicVsPhenotypicGraph/GenomicVsPhenotypicGraph.js
@@ -37,8 +37,21 @@ import {
   Cell,
 } from 'recharts';
 import { useAppSelector } from '../../../../stores/hooks';
-import { fetchGLASSData, getGLASSIndicatorForOrganism, getGLASSPhenotypicByOrganismDrug } from '../../../../data/glass_data';
+import {
+  fetchGLASSData,
+  getGLASSIndicatorForATBClass,
+  getGLASSIndicatorForOrganism,
+  getGLASSPhenotypicByOrganismDrug,
+} from '../../../../data/glass_data';
+import { atbToAmrnetMapping, getAmrnetDrugsForATBClass } from '../../../../util/atbDrugMapping';
 import { useStyles } from './GenomicVsPhenotypicGraphMUI';
+
+// Public-facing source landing pages used by the Data Sources panel.
+const SOURCE_URLS = {
+  glass: 'https://www.who.int/data/gho/data/themes/topics/global-antimicrobial-resistance-and-use-surveillance-system-glass-database',
+  ecdc: 'https://www.ecdc.europa.eu/en/antimicrobial-resistance/surveillance-and-disease-data/data-ecdc',
+  amrnet: 'https://amrnet.readthedocs.io',
+};
 
 // Organisms that have bundled literature surveillance data
 const LITERATURE_ORGANISMS = new Set([
@@ -200,21 +213,89 @@ export const GenomicVsPhenotypicGraph = ({ showFilter, setShowFilter }) => {
   const { t } = useTranslation();
   const [glassData, setGlassData] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [phenoSource, setPhenoSource] = useState('glass');
 
   const organism = useAppSelector(state => state.dashboard.organism);
-
-  // Reset phenoSource when organism changes
-  useEffect(() => {
-    setPhenoSource(defaultPhenoSource(organism));
-  }, [organism]);
   const drugsCountriesData = useAppSelector(state => state.graph.drugsCountriesData);
   const rawOrganismData = useAppSelector(state => state.graph.rawOrganismData);
   const timeInitial = useAppSelector(state => state.dashboard.timeInitial);
   const timeFinal = useAppSelector(state => state.dashboard.timeFinal);
   const canGetData = useAppSelector(state => state.dashboard.canGetData);
 
-  const glassIndicator = useMemo(() => getGLASSIndicatorForOrganism(organism), [organism]);
+  // Enumerate every (drug, phenotype-source) pair for which we have BOTH
+  // an AMRnet genomic record (drugsCountriesData entry) AND a phenotypic
+  // source (WHO GLASS indicator or bundled literature dataset). This drives
+  // the explicit Drug selector below — previously the drug was hardcoded
+  // per organism and there was no visible indicator of what was being
+  // plotted.
+  const availableDrugs = useMemo(() => {
+    const list = [];
+
+    // GLASS-backed entries: one per ATB class with an indicator + an AMRnet
+    // drug mapping. For most organisms this yields multiple options
+    // (kpneumo: Carbapenems, Fluoroquinolones, Cephalosporins, …).
+    const atbClasses = Object.keys(atbToAmrnetMapping[organism] || {});
+    atbClasses.forEach(cls => {
+      const indicator = getGLASSIndicatorForATBClass(organism, cls);
+      const amrnetDrugs = getAmrnetDrugsForATBClass(organism, cls);
+      if (indicator && amrnetDrugs.length > 0) {
+        list.push({
+          id: `glass:${cls}`,
+          label: `${amrnetDrugs[0]} — WHO GLASS (${cls})`,
+          source: 'glass',
+          atbClass: cls,
+          amrnetDrug: amrnetDrugs[0],
+          indicator,
+        });
+      }
+    });
+
+    // Literature-backed entry (currently 1 per organism — the bundled JSON).
+    // Surfaced as a separate row so the user can compare GLASS pheno vs
+    // literature pheno for the same AMRnet drug.
+    if (LITERATURE_ORGANISMS.has(organism)) {
+      const primaryIndicator = getGLASSIndicatorForOrganism(organism);
+      if (primaryIndicator) {
+        list.push({
+          id: 'literature',
+          label: `${primaryIndicator.drug} — Literature`,
+          source: organism === 'styphi' ? 'typhi_literature' : 'literature',
+          atbClass: null,
+          amrnetDrug: primaryIndicator.drug,
+          indicator: primaryIndicator,
+        });
+      }
+    }
+
+    return list;
+  }, [organism]);
+
+  // Default selection: literature for organisms that have it (matches
+  // previous defaultPhenoSource behaviour), otherwise the first GLASS row.
+  const [selectedDrugId, setSelectedDrugId] = useState(null);
+  useEffect(() => {
+    if (availableDrugs.length === 0) {
+      setSelectedDrugId(null);
+      return;
+    }
+    const defaultId = LITERATURE_ORGANISMS.has(organism)
+      ? (availableDrugs.find(d => d.id === 'literature')?.id ?? availableDrugs[0].id)
+      : availableDrugs[0].id;
+    setSelectedDrugId(defaultId);
+  }, [organism, availableDrugs]);
+
+  const selectedDrug = useMemo(
+    () => availableDrugs.find(d => d.id === selectedDrugId) ?? availableDrugs[0] ?? null,
+    [availableDrugs, selectedDrugId],
+  );
+
+  // phenoSource / glassIndicator are now derived from the selected entry so
+  // the rest of the component (which switches on phenoSource string values)
+  // doesn't need to change.
+  const phenoSource = selectedDrug?.source ?? defaultPhenoSource(organism);
+  const glassIndicator = useMemo(
+    () => selectedDrug?.indicator ?? getGLASSIndicatorForOrganism(organism),
+    [selectedDrug, organism],
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -500,21 +581,23 @@ export const GenomicVsPhenotypicGraph = ({ showFilter, setShowFilter }) => {
           <InfoOutlined fontSize="small" sx={{ cursor: 'pointer', color: 'rgba(0,0,0,0.5)' }} />
         </Tooltip>
 
-        {/* Phenotypic data source selector — organisms with literature data */}
-        {LITERATURE_ORGANISMS.has(organism) && (
+        {/* Drug + phenotype-source selector — populated from availableDrugs.
+            Replaces the previous LITERATURE_ORGANISMS-only toggle and makes
+            the drug currently being plotted explicit. */}
+        {availableDrugs.length > 0 && (
           <Box sx={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-            <Typography variant="caption" fontWeight={600} sx={{ whiteSpace: 'nowrap' }}>{t('amrInsights.gvp.phenotypicSource.label')}</Typography>
+            <Typography variant="caption" fontWeight={600} sx={{ whiteSpace: 'nowrap' }}>
+              Drug
+            </Typography>
             <Select
-              value={phenoSource}
-              onChange={e => setPhenoSource(e.target.value)}
+              value={selectedDrugId ?? availableDrugs[0].id}
+              onChange={e => setSelectedDrugId(e.target.value)}
               size="small"
-              sx={{ fontSize: '12px', minWidth: 240 }}
+              sx={{ fontSize: '12px', minWidth: 280 }}
             >
-              {organism === 'styphi' && <MenuItem value="typhi_literature">{t('amrInsights.gvp.phenotypicSource.typhiLiterature')}</MenuItem>}
-              {organism !== 'styphi' && <MenuItem value="literature">{t('amrInsights.gvp.phenotypicSource.literature')}</MenuItem>}
-              {organism === 'styphi'
-                ? <MenuItem value="glass">WHO GLASS (Salmonella, includes NTS)</MenuItem>
-                : <MenuItem value="glass">WHO GLASS</MenuItem>}
+              {availableDrugs.map(d => (
+                <MenuItem key={d.id} value={d.id}>{d.label}</MenuItem>
+              ))}
             </Select>
             <Tooltip title={t('amrInsights.gvp.phenotypicSource.downloadCSV')}>
               <span>
@@ -527,20 +610,8 @@ export const GenomicVsPhenotypicGraph = ({ showFilter, setShowFilter }) => {
           </Box>
         )}
 
-        {loading && (!LITERATURE_ORGANISMS.has(organism) || phenoSource === 'glass') && <CircularProgress size={16} />}
-        {!loading && glassIndicator && !LITERATURE_ORGANISMS.has(organism) && (
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-            <Chip label={glassIndicator.label} size="small" variant="outlined" color="primary" />
-            <Tooltip title={t('amrInsights.gvp.phenotypicSource.downloadCSVGlass')}>
-              <span>
-                <IconButton size="small" onClick={downloadPhenoCSV} disabled={!rawPhenoData?.length}>
-                  <FileDownload fontSize="small" />
-                </IconButton>
-              </span>
-            </Tooltip>
-          </Box>
-        )}
-        {!loading && !glassIndicator && (
+        {loading && phenoSource === 'glass' && <CircularProgress size={16} />}
+        {!loading && availableDrugs.length === 0 && (
           <Chip label="No phenotypic data available for this organism" size="small" variant="outlined" color="warning" />
         )}
       </Box>
@@ -750,6 +821,44 @@ export const GenomicVsPhenotypicGraph = ({ showFilter, setShowFilter }) => {
               }
               <br /><br />
               <strong>{t('amrInsights.gvp.bubbleSizeLabel')}</strong> ∝ {t('amrInsights.gvp.bubbleSize').replace(/^.*?∝\s*/, '')}
+            </Typography>
+          </Box>
+
+          {/* Data Sources panel — clickable citations for the current pheno source
+              and the AMRnet genomic side. Per-organism literature curators are
+              named where the JSON metadata supplies them. */}
+          <Typography variant="body2" fontWeight={600} sx={{ marginTop: '8px' }}>Data Sources</Typography>
+          <Box className={classes.tooltipWrapper}>
+            <Typography variant="caption" sx={{ lineHeight: 1.5 }} component="div">
+              <strong>Phenotypic (X):</strong>{' '}
+              {phenoSource === 'glass' || phenoSource === 'typhi_literature' && organism !== 'styphi' ? (
+                <>
+                  <a href={SOURCE_URLS.glass} target="_blank" rel="noopener noreferrer">
+                    WHO GLASS
+                  </a> — {glassIndicator?.label || 'Global Antimicrobial Resistance and Use Surveillance System'}.
+                </>
+              ) : (
+                <>
+                  Bundled surveillance literature (ECDC EARS-Net 2021 + national reports / WHO GASP / GEMS, depending on
+                  the organism). The JSON metadata files in {' '}
+                  <code>client/src/assets/</code> carry per-source citations (year ranges, breakpoints, specimen) and a{' '}
+                  <code>doi_or_url</code> field for each entry. The download button above exports the full JSON as a CSV.
+                  {' '}
+                  <a href={SOURCE_URLS.ecdc} target="_blank" rel="noopener noreferrer">
+                    See ECDC AMR data hub
+                  </a> for primary EARS-Net releases.
+                </>
+              )}
+              <br /><br />
+              <strong>Genomic (Y):</strong>{' '}
+              <a href={SOURCE_URLS.amrnet} target="_blank" rel="noopener noreferrer">AMRnet</a> genome-derived call
+              for <em>{glassIndicator?.drug || '—'}</em> using the standard AMRnet drug-rules engine. Per-country %R is
+              computed across genomes that pass the dashboard's current global filters; the matching N is reported in
+              each tooltip.
+              <br /><br />
+              <strong>Caveat:</strong> phenotypic and genotypic resistance definitions are not always identical (e.g.
+              EUCAST clinical breakpoints vs gene-presence calls), and time periods may not overlap perfectly. See the
+              year-overlap line in each tooltip.
             </Typography>
           </Box>
         </Box>

--- a/client/src/components/Elements/Graphs/GenomicVsPhenotypicGraph/GenomicVsPhenotypicGraph.js
+++ b/client/src/components/Elements/Graphs/GenomicVsPhenotypicGraph/GenomicVsPhenotypicGraph.js
@@ -5,9 +5,11 @@ import {
   CardContent,
   Chip,
   CircularProgress,
+  FormControlLabel,
   IconButton,
   MenuItem,
   Select,
+  Switch,
   Tooltip,
   Typography,
 } from '@mui/material';
@@ -219,7 +221,22 @@ export const GenomicVsPhenotypicGraph = ({ showFilter, setShowFilter }) => {
   const rawOrganismData = useAppSelector(state => state.graph.rawOrganismData);
   const timeInitial = useAppSelector(state => state.dashboard.timeInitial);
   const timeFinal = useAppSelector(state => state.dashboard.timeFinal);
+  const actualTimeInitial = useAppSelector(state => state.dashboard.actualTimeInitial);
+  const actualTimeFinal = useAppSelector(state => state.dashboard.actualTimeFinal);
   const canGetData = useAppSelector(state => state.dashboard.canGetData);
+
+  // Default ON: only consider phenotypic rows whose year falls inside the
+  // dashboard's current genomic year range. Without this it's possible to
+  // unknowingly compare 15-year-pooled genomic %R against a single 2021
+  // phenotype point. The toggle lives in the controls row.
+  const [restrictByYear, setRestrictByYear] = useState(true);
+
+  // The dashboard's applied year range is what the genomic side actually uses
+  // (drugsCountriesData is aggregated against actualTimeInitial..actualTimeFinal).
+  // Cast to integers up front so the per-record year comparisons aren't
+  // string-vs-number.
+  const genoYearStart = Number(actualTimeInitial ?? timeInitial) || 0;
+  const genoYearEnd = Number(actualTimeFinal ?? timeFinal) || 9999;
 
   // Enumerate every (drug, phenotype-source) pair for which we have BOTH
   // an AMRnet genomic record (drugsCountriesData entry) AND a phenotypic
@@ -370,9 +387,22 @@ export const GenomicVsPhenotypicGraph = ({ showFilter, setShowFilter }) => {
 
     if (phenoData.length === 0) return empty;
 
-    // Build phenotypic lookup: latest year per country
+    // Build phenotypic lookup: latest year per country. When the
+    // 'Restrict pheno to genomic year range' toggle is on, drop pheno rows
+    // whose year falls outside [genoYearStart, genoYearEnd] BEFORE picking
+    // the latest — so the chart only ever compares time-aligned data.
+    // Note: pheno rows may carry either a single `year` (GLASS) or a
+    // `yearRange` (literature). For year-range rows we already extract the
+    // end-year into `r.year` upstream, so a single comparison works for
+    // both shapes.
+    let phenoExcludedCount = 0;
     const phenoByCountry = {};
     phenoData.forEach(r => {
+      const ry = Number(r.year);
+      if (restrictByYear && Number.isFinite(ry) && (ry < genoYearStart || ry > genoYearEnd)) {
+        phenoExcludedCount++;
+        return;
+      }
       if (!phenoByCountry[r.country] || r.year > phenoByCountry[r.country].year) {
         phenoByCountry[r.country] = r;
       }
@@ -427,17 +457,22 @@ export const GenomicVsPhenotypicGraph = ({ showFilter, setShowFilter }) => {
         // Wilson score 95% CI for genomic estimate
         const ci = wilsonCI(resistant, total);
 
-        // Assess temporal overlap
+        // Assess temporal overlap. When restrictByYear is on the build step
+        // above has already dropped out-of-range pheno rows, so anything
+        // that survives is in-range; with the toggle off we still want to
+        // surface mismatched points so they're not invisible.
         const phenoYear = pheno.year;
         const phenoYearDisplay = pheno.yearRange || String(phenoYear);
-        const amrnetRange = `${timeInitial || '?'}–${timeFinal || '?'}`;
-        const yearOverlap = (phenoYear >= (timeInitial || 0) && phenoYear <= (timeFinal || 9999))
+        const amrnetRange = `${genoYearStart}–${genoYearEnd}`;
+        const inRange = Number.isFinite(Number(phenoYear)) && phenoYear >= genoYearStart && phenoYear <= genoYearEnd;
+        const yearOverlap = inRange
           ? `Yes (${phenoYearDisplay} within ${amrnetRange})`
-          : `Limited (${phenoSourceLabel} ${phenoYearDisplay}, AMRnet ${amrnetRange})`;
+          : `No — pheno ${phenoSourceLabel} ${phenoYearDisplay}, genomic ${amrnetRange}`;
 
         // Concordance: phenotypic value falls within the genomic 95% Wilson CI
         const ciConcordant = phenoValueNum >= ci.lower && phenoValueNum <= ci.upper;
         const category = ciConcordant ? 'concordant' : diff > 0 ? 'overestimate' : 'underestimate';
+        const timeMismatch = !inRange;
 
         const yVal = Number(genomicPct.toFixed(1));
         const ciLower = Number(ci.lower.toFixed(1));
@@ -469,11 +504,12 @@ export const GenomicVsPhenotypicGraph = ({ showFilter, setShowFilter }) => {
           ciConcordant,
           color: CONCORDANCE_COLORS[category],
           yearOverlap,
+          timeMismatch,
         });
       }
     });
 
-    if (points.length < 2) return { ...empty, scatterData: points };
+    if (points.length < 2) return { ...empty, scatterData: points, stats: { phenoExcludedCount, total: points.length } };
 
     // Compute statistics — all counts derived from the same `category` field (CI overlap only)
     const concordant = points.filter(p => p.category === 'concordant').length;
@@ -507,18 +543,57 @@ export const GenomicVsPhenotypicGraph = ({ showFilter, setShowFilter }) => {
         meanAbsDiff: meanAbsDiff.toFixed(1),
         medianAbsDiff: medianAbsDiff.toFixed(1),
         weightedMAD: weightedMAD.toFixed(1),
+        phenoExcludedCount,
       },
       correlations: {
         pearson: pears,
         spearman: spear,
       },
     };
-  }, [glassData, glassIndicator, drugsCountriesData, rawOrganismData, organism, timeInitial, timeFinal, phenoSource]);
+  }, [
+    glassData,
+    glassIndicator,
+    drugsCountriesData,
+    rawOrganismData,
+    organism,
+    timeInitial,
+    timeFinal,
+    phenoSource,
+    restrictByYear,
+    genoYearStart,
+    genoYearEnd,
+  ]);
 
   const downloadPhenoCSV = useCallback(() => {
     const escape = v => `"${String(v ?? '').replace(/"/g, '""')}"`;
+    // Prepend a header block of '#'-prefixed comment lines that name the
+    // primary source and reproduce its attribution. Most CSV readers (Excel,
+    // pandas with comment='#', R with comment.char='#') treat these as
+    // comments — but they're also human-readable when the file is opened in
+    // a plain editor. Per-organism citations live alongside each row in the
+    // 'source' and 'doi_or_url' columns.
+    const buildAttribution = () => {
+      const ts = new Date().toISOString().slice(0, 10);
+      if (phenoSource === 'glass') {
+        return [
+          '# Phenotypic resistance data: WHO Global Antimicrobial Resistance and Use Surveillance System (GLASS).',
+          '# Redistributed via AMRnet under WHO data terms — attribution required. Source:',
+          '#   https://www.who.int/data/gho/data/themes/topics/global-antimicrobial-resistance-and-use-surveillance-system-glass-database',
+          `# Indicator: ${glassIndicator?.label || '—'}`,
+          `# Downloaded via amrnet.org on ${ts}.`,
+          '#',
+        ].join('\n');
+      }
+      return [
+        '# Phenotypic resistance data: aggregated from published surveillance literature',
+        '# (ECDC EARS-Net, WHO GASP/GLASS, national reports, GEMS, etc. — see per-row `source` and `doi_or_url`).',
+        '# Re-use must cite the original publication(s) listed in each row, not AMRnet.',
+        `# Downloaded via amrnet.org on ${ts}.`,
+        '#',
+      ].join('\n');
+    };
     const toCSV = (headers, rows) =>
-      [headers, ...rows].map(r => r.map(escape).join(',')).join('\n');
+      buildAttribution() + '\n' + [headers, ...rows].map(r => r.map(escape).join(',')).join('\n');
 
     let csv, filename;
 
@@ -614,7 +689,36 @@ export const GenomicVsPhenotypicGraph = ({ showFilter, setShowFilter }) => {
         {!loading && availableDrugs.length === 0 && (
           <Chip label="No phenotypic data available for this organism" size="small" variant="outlined" color="warning" />
         )}
+
+        {/* Time-alignment guard: default ON. When ON, only phenotypic
+            records whose year falls inside the dashboard's genomic year
+            range are considered. Prevents accidentally comparing a single
+            2021 pheno point against a 2010–2025-pooled geno %R. */}
+        <FormControlLabel
+          control={<Switch checked={restrictByYear} onChange={(_, val) => setRestrictByYear(val)} size="small" />}
+          label={<Typography variant="caption">Restrict pheno to genomic year range</Typography>}
+          sx={{ marginLeft: '8px' }}
+        />
+        <Tooltip title="When on, phenotypic rows outside the dashboard's current year range are dropped before the latest-year row per country is chosen. When off, the chart falls back to the latest available pheno row per country, which may be from a very different period than the genomic data.">
+          <InfoOutlined fontSize="small" sx={{ cursor: 'pointer', color: 'rgba(0,0,0,0.5)' }} />
+        </Tooltip>
       </Box>
+
+      {/* Period summary — make the comparison's time alignment visible at a
+          glance. Without this it's not obvious what year the pheno value
+          comes from versus what years the geno %R was computed over. */}
+      {availableDrugs.length > 0 && (
+        <Typography variant="caption" sx={{ display: 'block', color: 'text.secondary', paddingTop: '2px', paddingBottom: '4px' }}>
+          <strong>Genomic period:</strong> {genoYearStart}–{genoYearEnd} (dashboard year filter) ·{' '}
+          <strong>Phenotypic:</strong>{' '}
+          {restrictByYear
+            ? `latest available row per country within ${genoYearStart}–${genoYearEnd}`
+            : 'latest available row per country (any year) — time mismatch possible'}
+          {stats?.phenoExcludedCount > 0 && (
+            <> · <em>{stats.phenoExcludedCount} pheno row(s) dropped as out-of-range</em></>
+          )}
+        </Typography>
+      )}
 
       {/* Decoli specimen caveat */}
       {organism === 'decoli' && (
@@ -711,7 +815,14 @@ export const GenomicVsPhenotypicGraph = ({ showFilter, setShowFilter }) => {
                 />
                 <Scatter data={scatterData}>
                   {scatterData.map((entry, i) => (
-                    <Cell key={`cell-${i}`} fill={entry.color} fillOpacity={0.8} />
+                    <Cell
+                      key={`cell-${i}`}
+                      fill={entry.color}
+                      fillOpacity={entry.timeMismatch ? 0.35 : 0.8}
+                      stroke={entry.timeMismatch ? '#d32f2f' : 'none'}
+                      strokeWidth={entry.timeMismatch ? 1.5 : 0}
+                      strokeDasharray={entry.timeMismatch ? '3 2' : undefined}
+                    />
                   ))}
                   {/* 95% CI error bars on genomic estimate (Y-axis) */}
                   <ErrorBar

--- a/client/src/components/Elements/Graphs/GenomicVsPhenotypicGraph/GenomicVsPhenotypicGraph.js
+++ b/client/src/components/Elements/Graphs/GenomicVsPhenotypicGraph/GenomicVsPhenotypicGraph.js
@@ -2,6 +2,7 @@ import { InfoOutlined, CheckCircleOutline, WarningAmber, FileDownload } from '@m
 import {
   Alert,
   Box,
+  Card,
   CardContent,
   Chip,
   CircularProgress,
@@ -46,6 +47,7 @@ import {
   getGLASSPhenotypicByOrganismDrug,
 } from '../../../../data/glass_data';
 import { atbToAmrnetMapping, getAmrnetDrugsForATBClass } from '../../../../util/atbDrugMapping';
+import { PlottingOptionsHeader } from '../../Shared/PlottingOptionsHeader';
 import { useStyles } from './GenomicVsPhenotypicGraphMUI';
 
 // Public-facing source landing pages used by the Data Sources panel.
@@ -889,91 +891,105 @@ export const GenomicVsPhenotypicGraph = ({ showFilter, setShowFilter }) => {
             </>
           )}
 
-          {/* Methodology */}
-          <Typography variant="body2" fontWeight={600} sx={{ marginTop: '4px' }}>{t('amrInsights.gvp.methodology')}</Typography>
-          <Box className={classes.tooltipWrapper}>
-            <Typography variant="caption" sx={{ lineHeight: 1.5 }}>
-              <strong>{t('amrInsights.gvp.matchingLabel')}</strong> {t('amrInsights.gvp.matching')}
-              <br /><br />
-              <strong>{t('amrInsights.gvp.concordanceLabel')}</strong> {t('amrInsights.gvp.concordanceText')}
-              <br /><br />
-              <strong>{t('amrInsights.gvp.errorBarsLabel')}</strong> {t('amrInsights.gvp.errorBars')}
-              <br /><br />
-              <strong>{t('amrInsights.gvp.correlationsLabel')}</strong> {t('amrInsights.gvp.correlations')}
-              <br /><br />
-              <strong>{t('amrInsights.gvp.drugMappingLabel')}</strong>{' '}
-              {phenoSource === 'typhi_literature'
-                ? t('amrInsights.gvp.drugMappingTyphiLiterature')
-                : phenoSource === 'literature' && organism === 'ecoli'
-                ? 'Phenotypic = 3GC non-susceptibility (ESBL proxy) from ECDC EARS-Net 2021 / national reports. Genomic = ESBL gene carriage (AMRnet).'
-                : phenoSource === 'literature' && organism === 'kpneumo'
-                ? 'Phenotypic = Carbapenem non-susceptibility from ECDC EARS-Net 2021 / national reports. Genomic = Carbapenemase gene carriage (AMRnet).'
-                : phenoSource === 'literature' && organism === 'saureus'
-                ? 'Phenotypic = MRSA (mecA/mecC or phenotypic oxacillin resistance) from ECDC EARS-Net 2021 / national reports. Genomic = mecA/mecC gene carriage (AMRnet Methicillin).'
-                : phenoSource === 'literature' && (organism === 'senterica' || organism === 'sentericaints')
-                ? 'Phenotypic = Salmonella ciprofloxacin non-susceptibility from WHO GLASS 2022 / ECDC EARS-Net 2021 / national reports. Genomic = Ciprofloxacin resistance markers (AMRnet).'
-                : phenoSource === 'literature' && organism === 'decoli'
-                ? 'Phenotypic = E. coli ciprofloxacin resistance from community/enteric studies (WHO GLASS, GEMS). Genomic = Ciprofloxacin resistance markers (AMRnet). Note: phenotypic data not specific to diarrheagenic pathotypes.'
-                : phenoSource === 'literature' && organism === 'shige'
-                ? 'Phenotypic = Shigella ciprofloxacin non-susceptibility from WHO GLASS 2022 / GEMS studies / CHINET. Genomic = Ciprofloxacin resistance markers (AMRnet).'
-                : phenoSource === 'literature' && organism === 'ngono'
-                ? 'Phenotypic = N. gonorrhoeae ciprofloxacin resistance (MIC ≥1 mg/L) from WHO GASP / ECDC GASP / CDC GISP. Genomic = Ciprofloxacin resistance markers — primarily GyrA/ParC QRDR mutations (AMRnet).'
-                : phenoSource === 'literature' && organism === 'strepneumo'
-                ? 'Phenotypic = S. pneumoniae co-trimoxazole (SXT) non-susceptibility from ECDC EARS-Net 2021 / WHO GLASS 2022 / national reports. Genomic = Co-Trimoxazole resistance markers — folP/folA variants (AMRnet).'
-                : `${glassIndicator?.label || '—'}. AMRnet = genome-derived (${glassIndicator?.drug || '—'}). Note: genotypic and phenotypic definitions may differ.`
-              }
-              <br /><br />
-              <strong>{t('amrInsights.gvp.caveatsLabel')}</strong>{' '}
-              {phenoSource === 'typhi_literature'
-                ? t('amrInsights.gvp.caveatsTyphiLiterature')
-                : phenoSource === 'literature'
-                ? t('amrInsights.gvp.caveatsLiterature')
-                : t('amrInsights.gvp.caveatsGlass')
-              }
-              <br /><br />
-              <strong>{t('amrInsights.gvp.bubbleSizeLabel')}</strong> ∝ {t('amrInsights.gvp.bubbleSize').replace(/^.*?∝\s*/, '')}
-            </Typography>
-          </Box>
-
-          {/* Data Sources panel — clickable citations for the current pheno source
-              and the AMRnet genomic side. Per-organism literature curators are
-              named where the JSON metadata supplies them. */}
-          <Typography variant="body2" fontWeight={600} sx={{ marginTop: '8px' }}>Data Sources</Typography>
-          <Box className={classes.tooltipWrapper}>
-            <Typography variant="caption" sx={{ lineHeight: 1.5 }} component="div">
-              <strong>Phenotypic (X):</strong>{' '}
-              {phenoSource === 'glass' || phenoSource === 'typhi_literature' && organism !== 'styphi' ? (
-                <>
-                  <a href={SOURCE_URLS.glass} target="_blank" rel="noopener noreferrer">
-                    WHO GLASS
-                  </a> — {glassIndicator?.label || 'Global Antimicrobial Resistance and Use Surveillance System'}.
-                </>
-              ) : (
-                <>
-                  Bundled surveillance literature (ECDC EARS-Net 2021 + national reports / WHO GASP / GEMS, depending on
-                  the organism). The JSON metadata files in {' '}
-                  <code>client/src/assets/</code> carry per-source citations (year ranges, breakpoints, specimen) and a{' '}
-                  <code>doi_or_url</code> field for each entry. The download button above exports the full JSON as a CSV.
-                  {' '}
-                  <a href={SOURCE_URLS.ecdc} target="_blank" rel="noopener noreferrer">
-                    See ECDC AMR data hub
-                  </a> for primary EARS-Net releases.
-                </>
-              )}
-              <br /><br />
-              <strong>Genomic (Y):</strong>{' '}
-              <a href={SOURCE_URLS.amrnet} target="_blank" rel="noopener noreferrer">AMRnet</a> genome-derived call
-              for <em>{glassIndicator?.drug || '—'}</em> using the standard AMRnet drug-rules engine. Per-country %R is
-              computed across genomes that pass the dashboard's current global filters; the matching N is reported in
-              each tooltip.
-              <br /><br />
-              <strong>Caveat:</strong> phenotypic and genotypic resistance definitions are not always identical (e.g.
-              EUCAST clinical breakpoints vs gene-presence calls), and time periods may not overlap perfectly. See the
-              year-overlap line in each tooltip.
-            </Typography>
-          </Box>
         </Box>
       </Box>
+
+      {/* Floating reference panel — Methodology + Data Sources. The inline
+          right-side block keeps the live stats (Correlation, Concordance,
+          Error Metrics) so they always show alongside the chart. The dense
+          reference text lives here, toggled by the showFilter prop the
+          parent AMRInsights wires in. */}
+      {showFilter && (
+        <Box className={classes.floatingFilter}>
+          <Card elevation={3}>
+            <CardContent>
+              <PlottingOptionsHeader onClose={() => setShowFilter(false)} className={classes.titleWrapper} />
+
+              {/* Methodology */}
+              <Typography variant="body2" fontWeight={600}>{t('amrInsights.gvp.methodology')}</Typography>
+              <Box className={classes.tooltipWrapper} sx={{ marginTop: '4px' }}>
+                <Typography variant="caption" sx={{ lineHeight: 1.5 }}>
+                  <strong>{t('amrInsights.gvp.matchingLabel')}</strong> {t('amrInsights.gvp.matching')}
+                  <br /><br />
+                  <strong>{t('amrInsights.gvp.concordanceLabel')}</strong> {t('amrInsights.gvp.concordanceText')}
+                  <br /><br />
+                  <strong>{t('amrInsights.gvp.errorBarsLabel')}</strong> {t('amrInsights.gvp.errorBars')}
+                  <br /><br />
+                  <strong>{t('amrInsights.gvp.correlationsLabel')}</strong> {t('amrInsights.gvp.correlations')}
+                  <br /><br />
+                  <strong>{t('amrInsights.gvp.drugMappingLabel')}</strong>{' '}
+                  {phenoSource === 'typhi_literature'
+                    ? t('amrInsights.gvp.drugMappingTyphiLiterature')
+                    : phenoSource === 'literature' && organism === 'ecoli'
+                    ? 'Phenotypic = 3GC non-susceptibility (ESBL proxy) from ECDC EARS-Net 2021 / national reports. Genomic = ESBL gene carriage (AMRnet).'
+                    : phenoSource === 'literature' && organism === 'kpneumo'
+                    ? 'Phenotypic = Carbapenem non-susceptibility from ECDC EARS-Net 2021 / national reports. Genomic = Carbapenemase gene carriage (AMRnet).'
+                    : phenoSource === 'literature' && organism === 'saureus'
+                    ? 'Phenotypic = MRSA (mecA/mecC or phenotypic oxacillin resistance) from ECDC EARS-Net 2021 / national reports. Genomic = mecA/mecC gene carriage (AMRnet Methicillin).'
+                    : phenoSource === 'literature' && (organism === 'senterica' || organism === 'sentericaints')
+                    ? 'Phenotypic = Salmonella ciprofloxacin non-susceptibility from WHO GLASS 2022 / ECDC EARS-Net 2021 / national reports. Genomic = Ciprofloxacin resistance markers (AMRnet).'
+                    : phenoSource === 'literature' && organism === 'decoli'
+                    ? 'Phenotypic = E. coli ciprofloxacin resistance from community/enteric studies (WHO GLASS, GEMS). Genomic = Ciprofloxacin resistance markers (AMRnet). Note: phenotypic data not specific to diarrheagenic pathotypes.'
+                    : phenoSource === 'literature' && organism === 'shige'
+                    ? 'Phenotypic = Shigella ciprofloxacin non-susceptibility from WHO GLASS 2022 / GEMS studies / CHINET. Genomic = Ciprofloxacin resistance markers (AMRnet).'
+                    : phenoSource === 'literature' && organism === 'ngono'
+                    ? 'Phenotypic = N. gonorrhoeae ciprofloxacin resistance (MIC ≥1 mg/L) from WHO GASP / ECDC GASP / CDC GISP. Genomic = Ciprofloxacin resistance markers — primarily GyrA/ParC QRDR mutations (AMRnet).'
+                    : phenoSource === 'literature' && organism === 'strepneumo'
+                    ? 'Phenotypic = S. pneumoniae co-trimoxazole (SXT) non-susceptibility from ECDC EARS-Net 2021 / WHO GLASS 2022 / national reports. Genomic = Co-Trimoxazole resistance markers — folP/folA variants (AMRnet).'
+                    : `${glassIndicator?.label || '—'}. AMRnet = genome-derived (${glassIndicator?.drug || '—'}). Note: genotypic and phenotypic definitions may differ.`
+                  }
+                  <br /><br />
+                  <strong>{t('amrInsights.gvp.caveatsLabel')}</strong>{' '}
+                  {phenoSource === 'typhi_literature'
+                    ? t('amrInsights.gvp.caveatsTyphiLiterature')
+                    : phenoSource === 'literature'
+                    ? t('amrInsights.gvp.caveatsLiterature')
+                    : t('amrInsights.gvp.caveatsGlass')
+                  }
+                  <br /><br />
+                  <strong>{t('amrInsights.gvp.bubbleSizeLabel')}</strong> ∝ {t('amrInsights.gvp.bubbleSize').replace(/^.*?∝\s*/, '')}
+                </Typography>
+              </Box>
+
+              {/* Data Sources */}
+              <Typography variant="body2" fontWeight={600} sx={{ marginTop: '12px' }}>Data Sources</Typography>
+              <Box className={classes.tooltipWrapper} sx={{ marginTop: '4px' }}>
+                <Typography variant="caption" sx={{ lineHeight: 1.5 }} component="div">
+                  <strong>Phenotypic (X):</strong>{' '}
+                  {phenoSource === 'glass' || phenoSource === 'typhi_literature' && organism !== 'styphi' ? (
+                    <>
+                      <a href={SOURCE_URLS.glass} target="_blank" rel="noopener noreferrer">
+                        WHO GLASS
+                      </a> — {glassIndicator?.label || 'Global Antimicrobial Resistance and Use Surveillance System'}.
+                    </>
+                  ) : (
+                    <>
+                      Bundled surveillance literature (ECDC EARS-Net 2021 + national reports / WHO GASP / GEMS, depending on
+                      the organism). The JSON metadata files in {' '}
+                      <code>client/src/assets/</code> carry per-source citations (year ranges, breakpoints, specimen) and a{' '}
+                      <code>doi_or_url</code> field for each entry. The download button above exports the full JSON as a CSV.
+                      {' '}
+                      <a href={SOURCE_URLS.ecdc} target="_blank" rel="noopener noreferrer">
+                        See ECDC AMR data hub
+                      </a> for primary EARS-Net releases.
+                    </>
+                  )}
+                  <br /><br />
+                  <strong>Genomic (Y):</strong>{' '}
+                  <a href={SOURCE_URLS.amrnet} target="_blank" rel="noopener noreferrer">AMRnet</a> genome-derived call
+                  for <em>{glassIndicator?.drug || '—'}</em> using the standard AMRnet drug-rules engine. Per-country %R is
+                  computed across genomes that pass the dashboard's current global filters; the matching N is reported in
+                  each tooltip.
+                  <br /><br />
+                  <strong>Caveat:</strong> phenotypic and genotypic resistance definitions are not always identical (e.g.
+                  EUCAST clinical breakpoints vs gene-presence calls), and time periods may not overlap perfectly. See the
+                  year-overlap line in each tooltip.
+                </Typography>
+              </Box>
+            </CardContent>
+          </Card>
+        </Box>
+      )}
     </CardContent>
   );
 };

--- a/client/src/components/Elements/Graphs/GenomicVsPhenotypicGraph/GenomicVsPhenotypicGraphMUI.js
+++ b/client/src/components/Elements/Graphs/GenomicVsPhenotypicGraph/GenomicVsPhenotypicGraphMUI.js
@@ -5,6 +5,7 @@ const useStyles = makeStyles((_theme) => ({
     display: 'flex',
     flexDirection: 'column',
     borderTop: '1px solid rgba(0, 0, 0, 0.12)',
+    position: 'relative',
   },
   controlsRow: {
     display: 'flex',
@@ -88,6 +89,30 @@ const useStyles = makeStyles((_theme) => ({
     gap: '8px',
     flexWrap: 'wrap',
     padding: '4px 0',
+  },
+  // Floating reference panel — Methodology + Data Sources content. Keeps
+  // the inline right panel focused on the live stats (Correlation,
+  // Concordance, Error metrics) so the dense explanatory text doesn't push
+  // them off-screen.
+  floatingFilter: {
+    position: 'absolute',
+    top: 16,
+    right: -(360 + 16),
+    width: '360px',
+    maxHeight: '70vh',
+    overflowY: 'auto',
+    zIndex: 1,
+
+    '@media (max-width: 1900px)': {
+      right: 16,
+    },
+  },
+  titleWrapper: {
+    paddingBottom: '8px',
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
   },
 }));
 

--- a/client/src/util/resistance.js
+++ b/client/src/util/resistance.js
@@ -1,0 +1,99 @@
+// Per-genome resistance helpers shared across Co-occurrence and ATB
+// Correlation plots. Both compute "%R per class/group" from raw genome data
+// using the same organism-specific resistance rules used elsewhere in
+// AMRnet, so the answer they give matches what the rest of the dashboard
+// sees.
+
+import {
+  drugRulesKP,
+  drugRulesNG,
+  drugRulesSA,
+  drugRulesSP,
+  drugRulesST,
+  statKeysECOLI,
+} from './drugClassesRules';
+
+// Categories that aren't real drugs but compound flags (MDR, XDR, Pansusceptible
+// etc.) — exclude them when reasoning about pairwise drug resistance.
+export const RESISTANCE_EXCLUSIONS = [
+  'MDR',
+  'XDR',
+  'Pansusceptible',
+  'Susceptible',
+  'Susceptible to cat I/II drugs',
+  'H58',
+  'Ciprofloxacin NS',
+  'Ciprofloxacin R',
+  'Trimethoprim-sulfamethoxazole',
+  'Trimethoprim-Sulfamethoxazole',
+];
+
+/**
+ * Determine which drugs a single genome is resistant to.
+ * Returns a Set of drug names matching the keys used in the organism's
+ * drug-rules mapping (drugRulesST/KP/NG/SA/SP or statKeysECOLI).
+ */
+export function getResistantDrugs(genome, organism) {
+  const resistant = new Set();
+
+  if (organism === 'styphi') {
+    drugRulesST.forEach(rule => {
+      if (RESISTANCE_EXCLUSIONS.includes(rule.key)) return;
+      if (rule.values.some(v => genome[rule.columnID]?.toString() === v.toString())) {
+        resistant.add(rule.key);
+      }
+    });
+  } else if (organism === 'kpneumo') {
+    drugRulesKP.forEach(rule => {
+      if (RESISTANCE_EXCLUSIONS.includes(rule.key)) return;
+      const hasResistance = rule.columnIDs.some(id => genome[id] && genome[id] !== '-' && genome[id] !== 'ND');
+      if ('every' in rule) {
+        const allPresent = rule.columnIDs.every(id => genome[id] && genome[id] !== '-' && genome[id] !== 'ND');
+        if (allPresent) resistant.add(rule.key);
+      } else if (hasResistance) {
+        resistant.add(rule.key);
+      }
+    });
+  } else if (organism === 'ngono') {
+    drugRulesNG.forEach(rule => {
+      if (RESISTANCE_EXCLUSIONS.includes(rule.key)) return;
+      if (Array.isArray(rule.columnID)) {
+        if (rule.values.some(v => rule.columnID.some(col => genome[col]?.toString() === v.toString()))) {
+          resistant.add(rule.key);
+        }
+      } else if (rule.values.some(v => genome[rule.columnID]?.toString() === v.toString())) {
+        resistant.add(rule.key);
+      }
+    });
+  } else if (['senterica', 'sentericaints', 'ecoli', 'decoli', 'shige'].includes(organism)) {
+    statKeysECOLI.forEach(drug => {
+      if (RESISTANCE_EXCLUSIONS.includes(drug.name) || !drug.resistanceView || drug.computed) return;
+      if (!drug.rules || drug.rules.length === 0) return;
+      const matchRule = rule => {
+        const raw = genome[rule.column];
+        const isEmpty = raw == null || raw === '' || raw === '-';
+        // equal: true → susceptible check (value IS empty/'-')
+        // equal: false → resistance check (value has actual gene content)
+        return rule.equal ? isEmpty : !isEmpty;
+      };
+      const isResistant = drug.every ? drug.rules.every(matchRule) : drug.rules.some(matchRule);
+      if (isResistant) resistant.add(drug.name);
+    });
+  } else if (organism === 'saureus') {
+    drugRulesSA.forEach(rule => {
+      if (RESISTANCE_EXCLUSIONS.includes(rule.key) || rule.pansusceptible) return;
+      if (rule.values.some(v => genome[rule.columnID]?.toString() === v.toString())) {
+        resistant.add(rule.key);
+      }
+    });
+  } else if (organism === 'strepneumo') {
+    drugRulesSP.forEach(rule => {
+      if (RESISTANCE_EXCLUSIONS.includes(rule.key) || rule.pansusceptible) return;
+      if (rule.values.some(v => genome[rule.columnID]?.toString() === v.toString())) {
+        resistant.add(rule.key);
+      }
+    });
+  }
+
+  return resistant;
+}


### PR DESCRIPTION
## Summary

Promotes PR #419 (merged into \`development\` as 738d9751) to \`main\` for production rollout.

Highlights:

- **ATB (AM Usage vs Resistance)**: Y axis now plots true AMRnet genomic %R per ATB class (union of drugs in the class), not WHO GLASS pheno mis-labelled as genomic. CSV exports gain audit columns + GLASS attribution header. Data Sources lives in a floating right-side panel.
- **GVP (Genomic vs Phenotypic)**: Explicit Drug selector populated from every (drug, pheno-source) pair with both AMRnet + phenotypic coverage. Time-alignment guard (default ON) drops pheno rows outside the dashboard's genomic year range before picking the latest per country. Period summary line under the selector. Out-of-range points get a dashed red border when toggle is OFF. CSV downloads gain source-attribution header. Methodology + Data Sources move into the floating panel.
- **AMRInsights**: FilterList / FilterListOff toggle in the card header so users can re-open the floating panel after closing it. Only shown on tabs that actually expose a panel (ATB, GVP).

See #419 for the full per-commit breakdown.

## Test plan

- [ ] Smoke-test on production immediately after \`./deploy/deploy-production.sh\`:
  - AMR Insights → ATB: Y values are now a real spread across countries (no longer all ≈0); filter icon toggles the floating Data Sources panel.
  - AMR Insights → GVP: Drug selector lists multiple drug + source pairs; time-alignment toggle changes the visible point set; mismatched points have dashed red borders when toggle is OFF.
  - AMR Insights header: filter icon appears between camera and expand-chevron on ATB and GVP tabs, hidden on COO.