### PR TITLE
Radar plot drug selector, AMR by Pathotype tab, and organism defaults

### DIFF
--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -84,6 +84,7 @@ import {
   setKOYearsData,
   setMaxSliderValueCM,
   setRawOrganismData,
+  setAllOrganismData,
   setRegionsYearData,
   setSublineagesYearData,
   setTrendsGraphDrugClass,
@@ -1908,6 +1909,7 @@ export const DashboardPage = () => {
       // Geographic Comparisons / Radar / ATB-correlation plots.
       dispatch(setDrugsCountriesData(drugsCountriesData.drugsData));
       dispatch(setDrugsRegionsData(drugsRegionsData.drugsData));
+      dispatch(setAllOrganismData(filters.data));
     }
 
     dispatch(setCanFilterData(false));

--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -103,6 +103,7 @@ import {
 import { generatePalleteForGenotypes } from '../../util/colorHelper';
 import {
   defaultDrugsForDrugResistanceGraphNG,
+  defaultDrugsForDrugResistanceGraphSA,
   defaultDrugsForDrugResistanceGraphST,
   drugClassesNG,
   drugsECOLI,
@@ -542,7 +543,7 @@ export const DashboardPage = () => {
       ecoli: drugsECOLI,
       decoli: drugsECOLI,
       shige: drugsECOLI,
-      saureus: drugsSA,
+      saureus: defaultDrugsForDrugResistanceGraphSA,
       strepneumo: drugsSP,
     };
 
@@ -1232,7 +1233,7 @@ export const DashboardPage = () => {
         }
         break;
       case 'saureus':
-        dispatch(setDrugResistanceGraphView(drugsSA));
+        dispatch(setDrugResistanceGraphView(defaultDrugsForDrugResistanceGraphSA));
         dispatch(setDeterminantsGraphDrugClass(getDrugClasses(organism)[0]));
         dispatch(setTrendsGraphDrugClass(getDrugClasses(organism)[0]));
         dispatch(setBubbleMarkersYAxisType(drugsSA.filter(x => x !== 'Pansusceptible')[0]));
@@ -1544,7 +1545,7 @@ export const DashboardPage = () => {
         ecoli: drugsECOLI,
         decoli: drugsECOLI,
         shige: drugsECOLI,
-        saureus: drugsSA,
+        saureus: defaultDrugsForDrugResistanceGraphSA,
         strepneumo: drugsSP,
       };
 

--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -75,6 +75,7 @@ import {
   setFrequenciesGraphView,
   setGenotypesAndDrugsYearData,
   setGenotypesDrugClassesData,
+  setPathotypesDrugClassesData,
   setGenotypesDrugsData,
   setGenotypesYearData,
   setKODiversityData,
@@ -577,7 +578,7 @@ export const DashboardPage = () => {
 
       // Get genotypes data
       // Use versioned key for organisms with marker-level genotype breakdown to bust stale cache
-      getStoreOrGenerateData(`${organism}_genotype_v4`, () => {
+      getStoreOrGenerateData(`${organism}_genotype_v5`, () => {
         const dt = getGenotypesData({
           data: responseData,
           genotypes,
@@ -595,6 +596,7 @@ export const DashboardPage = () => {
           dt.countriesDrugClassesData,
           dt.regionsDrugClassesData,
           dt.ngMastDrugClassesData,
+          dt.pathotypesDrugClassesData,
         ];
       }).then(
         ([
@@ -603,6 +605,7 @@ export const DashboardPage = () => {
           countriesDrugClassesData,
           regionsDrugClassesData,
           ngMastDrugClassesData,
+          pathotypesDrugClassesData,
         ]) => {
           const safeGenotypesDrugsData = Array.isArray(genotypesDrugsData) ? genotypesDrugsData : [];
           dispatch(setGenotypesDrugsData(safeGenotypesDrugsData));
@@ -611,6 +614,7 @@ export const DashboardPage = () => {
           dispatch(setCountriesYearData(countriesDrugClassesData));
           dispatch(setRegionsYearData(regionsDrugClassesData));
           dispatch(setNgMastDrugClassesData(ngMastDrugClassesData));
+          dispatch(setPathotypesDrugClassesData(pathotypesDrugClassesData ?? {}));
         },
       ),
 
@@ -1459,6 +1463,7 @@ export const DashboardPage = () => {
         // dispatch(setDrugsYearData([]));
         dispatch(setGenotypesDrugsData([]));
         dispatch(setGenotypesDrugClassesData([]));
+        dispatch(setPathotypesDrugClassesData({}));
         // dispatch(setGenotypesAndDrugsYearData({}));
         dispatch(setKODiversityData([]));
         dispatch(setConvergenceData([]));
@@ -1861,6 +1866,7 @@ export const DashboardPage = () => {
       dispatch(setCountriesYearData(genotypesData.countriesDrugClassesData));
       dispatch(setRegionsYearData(genotypesData.regionsDrugClassesData));
       dispatch(setNgMastDrugClassesData(genotypesData.ngMastDrugClassesData));
+      dispatch(setPathotypesDrugClassesData(genotypesData.pathotypesDrugClassesData ?? {}));
 
       // Dispatch yearly trends data (server preferred, client fallback)
       dispatch(setGenotypesYearData(finalGenotypesData));

--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -1234,9 +1234,9 @@ export const DashboardPage = () => {
         break;
       case 'saureus':
         dispatch(setDrugResistanceGraphView(defaultDrugsForDrugResistanceGraphSA));
-        dispatch(setDeterminantsGraphDrugClass(getDrugClasses(organism)[0]));
-        dispatch(setTrendsGraphDrugClass(getDrugClasses(organism)[0]));
-        dispatch(setBubbleMarkersYAxisType(drugsSA.filter(x => x !== 'Pansusceptible')[0]));
+        dispatch(setDeterminantsGraphDrugClass('Methicillin'));
+        dispatch(setTrendsGraphDrugClass('Methicillin'));
+        dispatch(setBubbleMarkersYAxisType('Methicillin'));
         break;
       case 'strepneumo':
         dispatch(setDrugResistanceGraphView(drugsSP));

--- a/client/src/components/Dashboard/filters.js
+++ b/client/src/components/Dashboard/filters.js
@@ -1945,6 +1945,48 @@ export function getGenotypesData({
     genotypesDrugClassesData[key].forEach(item => delete item['None']);
   });
 
+  // Pathotype-level marker data for ecoli-like organisms (shige, decoli, ecoli, senterica, sentericaints)
+  const pathotypesDrugClassesData = {};
+  const pathotypeOrganisms = ['shige', 'decoli', 'ecoli', 'senterica', 'sentericaints']; // senterica/sentericaints use seqsero2 (serotypes)
+  if (pathotypeOrganisms.includes(organism)) {
+    const pathotypeConfig = organismDrugMap[organism];
+    if (pathotypeConfig) {
+      pathotypeConfig.list.forEach(item => {
+        const key = pathotypeConfig.keyFn(item);
+        pathotypesDrugClassesData[key] = [];
+      });
+    }
+
+    const pathotypeCol = ['sentericaints', 'senterica'].includes(organism) ? 'seqsero2' : 'Pathovar';
+    const dataByPathotype = {};
+    data.forEach(x => {
+      const pKey = x[pathotypeCol]?.toString();
+      if (pKey && pKey !== 'NA' && pKey !== '-' && pKey !== '') {
+        if (!dataByPathotype[pKey]) dataByPathotype[pKey] = [];
+        dataByPathotype[pKey].push(x);
+      }
+    });
+
+    Object.keys(dataByPathotype).forEach(pathotype => {
+      const pathotypeData = dataByPathotype[pathotype];
+      const drugClassResponse = { name: pathotype, totalCount: pathotypeData.length, resistantCount: 0 };
+
+      statKeysECOLI.forEach(drug => {
+        if (!pathotypesDrugClassesData[drug.name]) return;
+        const drugClass = {
+          ...drugClassResponse,
+          ...getECOLIDrugClassData({ drugKey: drug.name, dataToFilter: pathotypeData }),
+        };
+        pathotypesDrugClassesData[drug.name].push(drugClass);
+      });
+    });
+
+    Object.keys(pathotypesDrugClassesData).forEach(key => {
+      pathotypesDrugClassesData[key].sort((a, b) => b.totalCount - a.totalCount);
+      pathotypesDrugClassesData[key].forEach(item => delete item['None']);
+    });
+  }
+
   // Years
   // years.forEach(year => {
   //   const yearData = (dataForGeographic || data).filter(x => x.DATE.toString() === year.toString());
@@ -2056,6 +2098,7 @@ export function getGenotypesData({
     countriesDrugClassesData,
     regionsDrugClassesData,
     ngMastDrugClassesData,
+    pathotypesDrugClassesData,
   };
 }
 

--- a/client/src/components/Elements/Graphs/BubbleMarkersPathotypeHeatmapGraph/BubbleMarkersPathotypeHeatmapGraph.js
+++ b/client/src/components/Elements/Graphs/BubbleMarkersPathotypeHeatmapGraph/BubbleMarkersPathotypeHeatmapGraph.js
@@ -1,0 +1,533 @@
+import { Clear, InfoOutlined } from '@mui/icons-material';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Checkbox,
+  Divider,
+  IconButton,
+  ListItemText,
+  MenuItem,
+  Select,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Cell,
+  Tooltip as ChartTooltip,
+  LabelList,
+  ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  XAxis,
+  YAxis,
+  ZAxis,
+} from 'recharts';
+import { useAppDispatch, useAppSelector } from '../../../../stores/hooks';
+import { setResetBool } from '../../../../stores/slices/graphSlice';
+import { darkGrey, hoverColor } from '../../../../util/colorHelper';
+import { drugAcronyms, drugAcronymsOpposite, getDrugClasses } from '../../../../util/drugs';
+import { longestVisualWidth, truncateWord } from '../../../../util/helpers';
+import { isTouchDevice } from '../../../../util/isTouchDevice';
+import { heatmapLegendGradient, heatmapTextColor, mixColorScale } from '../../Map/mapColorHelper';
+import { PlottingOptionsHeader } from '../../Shared/PlottingOptionsHeader';
+import { useStyles } from '../BubbleMarkersHeatmapGraph/BubbleMarkersHeatmapGraphMUI';
+import { useTranslation } from 'react-i18next';
+
+export const BubbleMarkersPathotypeHeatmapGraph = ({ showFilter, setShowFilter }) => {
+  const classes = useStyles();
+  const { t } = useTranslation();
+  const dispatch = useAppDispatch();
+
+  const [xAxisSelected, setXAxisSelected] = useState([]);
+  const [yAxisSelected, setYAxisSelected] = useState([]);
+  const [pathotypeSearch, setPathotypeSearch] = useState('');
+  const [markerSearch, setMarkerSearch] = useState('');
+  const [plotChart, setPlotChart] = useState(() => {});
+  const [regionSelected, setRegionSelected] = useState('All');
+  const [countrySelected, setCountrySelected] = useState('All');
+  const [yAxisType, setYAxisType] = useState('');
+
+  const organism = useAppSelector(state => state.dashboard.organism);
+  const canGetData = useAppSelector(state => state.dashboard.canGetData);
+  const canFilterData = useAppSelector(state => state.dashboard.canFilterData);
+  const loadingPDF = useAppSelector(state => state.dashboard.loadingPDF);
+  const mapData = useAppSelector(state => state.map.mapDataNoPathotype);
+  const mapRegionData = useAppSelector(state => state.map.mapRegionDataNoPathotype);
+  const economicRegions = useAppSelector(state => state.dashboard.economicRegions);
+  const countriesForFilter = useAppSelector(state => state.graph.countriesForFilter);
+  const pathotypesDrugClassesData = useAppSelector(state => state.graph.pathotypesDrugClassesData);
+  const resetBool = useAppSelector(state => state.graph.resetBool);
+
+  const selectedCRData = useMemo(() => {
+    return (countrySelected !== 'All' ? mapData : mapRegionData).find(
+      x => x.name === (countrySelected !== 'All' ? countrySelected : regionSelected),
+    );
+  }, [countrySelected, mapData, mapRegionData, regionSelected]);
+
+  const xAxisOptions = useMemo(() => {
+    return selectedCRData?.stats?.PATHOTYPE?.items?.map(x => x.name) ?? [];
+  }, [selectedCRData]);
+
+  const filteredXAxisOptions = useMemo(() => {
+    return xAxisOptions.filter(opt => opt.toLowerCase().includes(pathotypeSearch.toLowerCase()));
+  }, [xAxisOptions, pathotypeSearch]);
+
+  const drugClasses = useMemo(() => getDrugClasses(organism), [organism]);
+
+  const currentDrugClass = useMemo(() => {
+    if (yAxisType && drugClasses.includes(yAxisType)) return yAxisType;
+    return drugClasses[0] ?? '';
+  }, [yAxisType, drugClasses]);
+
+  const yAxisOptions = useMemo(() => {
+    if (!currentDrugClass || !pathotypesDrugClassesData[currentDrugClass]) return [];
+    const exclusions = ['name', 'totalCount', 'resistantCount', 'count', 'newTotalCount', 'Other', 'None'];
+    const totals = {};
+    pathotypesDrugClassesData[currentDrugClass].forEach(item => {
+      Object.keys(item).forEach(key => {
+        if (!exclusions.includes(key)) {
+          totals[key] = (totals[key] || 0) + (item[key] || 0);
+        }
+      });
+    });
+    return Object.entries(totals)
+      .sort((a, b) => b[1] - a[1])
+      .map(([k]) => k)
+      .filter(k => k !== '-');
+  }, [currentDrugClass, pathotypesDrugClassesData]);
+
+  const filteredYAxisOptions = useMemo(() => {
+    return yAxisOptions
+      .filter(opt => opt.toLowerCase().includes(markerSearch.toLowerCase()))
+      .slice(0, 20);
+  }, [yAxisOptions, markerSearch]);
+
+  const filteredRegions = useMemo(() => {
+    return mapRegionData
+      .filter(x => x.count >= 20 && x.name !== 'All')
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [mapRegionData]);
+
+  const filteredCountries = useMemo(() => {
+    const countries = regionSelected === 'All' ? countriesForFilter : economicRegions[regionSelected];
+    return mapData
+      .filter(x => countries?.includes(x.name))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [countriesForFilter, economicRegions, mapData, regionSelected]);
+
+  useEffect(() => {
+    setXAxisSelected(xAxisOptions.slice(0, 10));
+  }, [xAxisOptions]);
+
+  useEffect(() => {
+    setYAxisSelected(yAxisOptions.slice(0, 10));
+  }, [yAxisOptions]);
+
+  useEffect(() => {
+    if (!yAxisType && drugClasses.length > 0) setYAxisType(drugClasses[0]);
+  }, [drugClasses, yAxisType]);
+
+  useEffect(() => {
+    if (resetBool) {
+      setRegionSelected('All');
+      setCountrySelected('All');
+      setXAxisSelected(xAxisOptions.slice(0, 10));
+      setYAxisSelected(yAxisOptions.slice(0, 10));
+      dispatch(setResetBool(false));
+    }
+  }, [resetBool, xAxisOptions, yAxisOptions, dispatch]);
+
+  const yAxisWidth = useMemo(() => longestVisualWidth(xAxisSelected ?? []), [xAxisSelected]);
+
+  const getOptionLabel = useCallback(
+    item => {
+      const total = selectedCRData?.stats?.PATHOTYPE?.items?.find(x => x.name === item)?.count ?? 0;
+      return `${item} (total N=${total})`;
+    },
+    [selectedCRData],
+  );
+
+  const configuredMapData = useMemo(() => {
+    if (!currentDrugClass || yAxisSelected.length === 0 || !pathotypesDrugClassesData[currentDrugClass]) return [];
+    const data = pathotypesDrugClassesData[currentDrugClass];
+    return xAxisSelected.map(xName => {
+      const item = data.find(d => d.name === xName);
+      const itemData = { name: xName, items: [] };
+      yAxisSelected.forEach(option => {
+        const count = item ? item[option] || 0 : 0;
+        const total = item ? item.totalCount || 0 : 0;
+        const percentage = total ? Number(((count / total) * 100).toFixed(2)) : 0;
+        itemData.items.push({ itemName: option, percentage, count, index: 1, typeName: xName, total });
+      });
+      return itemData;
+    });
+  }, [currentDrugClass, pathotypesDrugClassesData, xAxisSelected, yAxisSelected]);
+
+  useEffect(() => {
+    if (!canGetData) return;
+    setPlotChart(() => (
+      <>
+        {configuredMapData.map((item, index) => (
+          <ResponsiveContainer
+            key={`pathotype-heatmap-${index}`}
+            width={yAxisWidth + 65 * yAxisSelected.length}
+            height={index === 0 ? 105 : 65}
+            style={{ paddingTop: index === 0 ? 70 : 0 }}
+          >
+            <ScatterChart cursor={isTouchDevice() ? 'default' : 'pointer'} margin={{ bottom: index === 0 ? -20 : 20 }}>
+              <XAxis
+                type="category"
+                dataKey="itemName"
+                interval={0}
+                tick={
+                  index === 0
+                    ? props => {
+                        const title = props.payload.value;
+                        return (
+                          <Tooltip title={title} placement="top">
+                            <text
+                              x={props.x}
+                              y={props.y}
+                              fontSize="14px"
+                              dy={-10}
+                              textAnchor="start"
+                              transform={`rotate(-45, ${props.x}, ${props.y})`}
+                              fill="rgb(128,128,128)"
+                            >
+                              {truncateWord(title)}
+                            </text>
+                          </Tooltip>
+                        );
+                      }
+                    : false
+                }
+                axisLine={false}
+                orientation="top"
+              />
+              <YAxis
+                type="number"
+                dataKey="index"
+                name={item.name.toLowerCase()}
+                tick={false}
+                tickLine={false}
+                axisLine={false}
+                domain={[1, 1]}
+                label={{ value: item.name, position: 'insideRight' }}
+                width={yAxisWidth}
+              />
+              <ZAxis type="number" dataKey="percentage" range={[3500, 3500]} />
+              <ChartTooltip
+                cursor={{ fill: hoverColor }}
+                wrapperStyle={{ zIndex: 100 }}
+                offset={40}
+                content={({ payload, active }) => {
+                  if (payload !== null && active) {
+                    const title = payload[0]?.payload.itemName;
+                    return (
+                      <div
+                        className={classes.chartTooltipLabel}
+                        style={{
+                          marginTop: index + 1 === configuredMapData.length ? -40 : index === 0 ? 40 : 0,
+                        }}
+                      >
+                        <Typography variant="body1" fontWeight="500">{payload[0]?.payload.typeName}</Typography>
+                        <Typography variant="caption" fontWeight="500">Total: {payload[0]?.payload.total}</Typography>
+                        <Typography variant="body2">{`${title}: ${payload[0]?.payload.count} (${payload[0]?.payload.percentage}%)`}</Typography>
+                      </div>
+                    );
+                  }
+                  return null;
+                }}
+              />
+              <Scatter data={item.items} shape="square">
+                {item.items.map((option, i) => (
+                  <Cell
+                    name={option.itemName}
+                    key={`pathotype-cell-${i}`}
+                    fill={option.percentage === 0 ? darkGrey : mixColorScale(option.percentage)}
+                  />
+                ))}
+                <LabelList
+                  dataKey="percentage"
+                  fontSize={12}
+                  content={({ x, y, value }) => (
+                    <text
+                      x={x + 33}
+                      y={y + 38}
+                      textAnchor="middle"
+                      fontSize={15}
+                      fontWeight={600}
+                      fill={heatmapTextColor(value)}
+                      pointerEvents="none"
+                    >
+                      {value}
+                    </text>
+                  )}
+                />
+              </Scatter>
+            </ScatterChart>
+          </ResponsiveContainer>
+        ))}
+      </>
+    ));
+  }, [configuredMapData, yAxisWidth, canGetData]);
+
+  function handleChangeRegion(event) {
+    setCountrySelected('All');
+    setRegionSelected(event.target.value);
+  }
+
+  function handleChangeCountry(event) {
+    const country = event.target.value;
+    if (!(regionSelected !== 'All' && country === 'All')) {
+      const region = Object.keys(economicRegions).find(k => economicRegions[k].includes(country)) ?? 'All';
+      setRegionSelected(region);
+    }
+    setCountrySelected(country);
+  }
+
+  function handleChangeXAxisSelected({ event = null, all = false }) {
+    const value = event?.target.value;
+    if (value?.length === 1 && value[0] === undefined) return;
+    if (!all) { setXAxisSelected(value); return; }
+    if (xAxisSelected.length === filteredXAxisOptions.length) { setXAxisSelected([]); return; }
+    setXAxisSelected(filteredXAxisOptions.slice());
+  }
+
+  function handleChangeYAxisSelected({ event = null, all = false }) {
+    const value = event?.target.value;
+    if (!all) { setYAxisSelected(value); return; }
+    if (yAxisSelected.length === filteredYAxisOptions.length) { setYAxisSelected([]); return; }
+    setYAxisSelected(filteredYAxisOptions.slice());
+  }
+
+  return (
+    <CardContent className={classes.bubbleMarkersHeatmapGraph}>
+      <div className={classes.graphWrapper}>
+        <div className={classes.graph} style={loadingPDF ? { overflow: 'visible' } : undefined} id="BAMRPH">
+          {plotChart}
+        </div>
+      </div>
+      {yAxisSelected.length === 0 && (
+        <Box className={classes.nothingSelected}>
+          <Typography fontWeight={600}>{t('common.noDataToShow')}</Typography>
+        </Box>
+      )}
+      <Divider className={classes.divider} />
+      <div className={classes.bottomLegend}>
+        <div className={classes.legend}>
+          <Typography fontSize="0.75rem">0%</Typography>
+          <Box className={classes.singleBox} sx={{ backgroundColor: darkGrey }} />
+        </div>
+        <div className={classes.legend}>
+          <Typography fontSize="0.75rem">1%</Typography>
+          <Box className={classes.gradientBox} style={{ backgroundImage: heatmapLegendGradient() }} />
+          <Typography fontSize="0.75rem">100%</Typography>
+        </div>
+      </div>
+      {showFilter && !canFilterData && (
+        <Box className={classes.floatingFilter}>
+          <Card elevation={3}>
+            <CardContent>
+              <PlottingOptionsHeader onClose={() => setShowFilter(false)} className={classes.titleWrapper} />
+              <div className={classes.selectsWrapper}>
+                <div className={classes.selectPreWrapper}>
+                  <div className={classes.selectWrapper}>
+                    <div className={classes.labelWrapper}>
+                      <Typography variant="caption">{t('common.selectRegion')}</Typography>
+                      <Tooltip title={t('common.n20RegionsTooltip')} placement="top">
+                        <InfoOutlined color="action" fontSize="small" className={classes.labelTooltipIcon} />
+                      </Tooltip>
+                    </div>
+                    <Select
+                      value={regionSelected}
+                      onChange={handleChangeRegion}
+                      inputProps={{ className: classes.selectInput }}
+                      MenuProps={{ classes: { paper: classes.menuPaper, list: classes.selectMenu } }}
+                      disabled={organism === 'none'}
+                      renderValue={selected => selected === 'All' ? t('common.allRegions') : selected}
+                    >
+                      <MenuItem value="All">{t('common.allRegions')}</MenuItem>
+                      {filteredRegions.map((region, i) => (
+                        <MenuItem key={i + 'reg'} value={region.name}>{region.name} (total N={region.count})</MenuItem>
+                      ))}
+                    </Select>
+                  </div>
+                  <div className={classes.selectWrapper}>
+                    <div className={classes.labelWrapper}>
+                      <Typography variant="caption">{t('common.selectCountry')}</Typography>
+                    </div>
+                    <Select
+                      value={countrySelected}
+                      onChange={handleChangeCountry}
+                      inputProps={{ className: classes.selectInput }}
+                      MenuProps={{ classes: { paper: classes.menuPaper, list: classes.selectMenu } }}
+                      disabled={organism === 'none'}
+                      renderValue={selected =>
+                        selected === 'All' ? (regionSelected !== 'All' ? 'All countries in region' : 'All countries') : selected
+                      }
+                    >
+                      <MenuItem value="All">
+                        {regionSelected !== 'All' ? 'All countries in region' : 'All countries'}
+                      </MenuItem>
+                      {filteredCountries.map((country, i) => (
+                        <MenuItem key={i + 'cty'} value={country.name}>{country.name} (total N={country.count})</MenuItem>
+                      ))}
+                    </Select>
+                  </div>
+                </div>
+                <div className={classes.selectPreWrapper}>
+                  <div className={classes.selectWrapper}>
+                    <div className={classes.labelWrapper}>
+                      <Typography variant="caption">Select pathotype</Typography>
+                      <Tooltip title="If there are too many pathotypes, only the first 20 are shown" placement="top">
+                        <InfoOutlined color="action" fontSize="small" className={classes.labelTooltipIcon} />
+                      </Tooltip>
+                    </div>
+                    <Select
+                      multiple
+                      value={xAxisSelected}
+                      onChange={event => handleChangeXAxisSelected({ event })}
+                      displayEmpty
+                      disabled={organism === 'none'}
+                      endAdornment={
+                        <Button
+                          variant="outlined"
+                          className={classes.selectButton}
+                          onClick={() => handleChangeXAxisSelected({ all: true })}
+                          disabled={organism === 'none'}
+                          color={xAxisSelected.length === filteredXAxisOptions.length ? 'error' : 'primary'}
+                        >
+                          {xAxisSelected.length === filteredXAxisOptions.length ? t('common.clearAll') : t('common.selectAll')}
+                        </Button>
+                      }
+                      inputProps={{ className: classes.multipleSelectInput }}
+                      MenuProps={{
+                        disableAutoFocusItem: true,
+                        classes: { paper: classes.menuPaper, list: classes.selectMenu },
+                      }}
+                      renderValue={selected => <div>{`${t('common.selectedOfTotal', { selected: selected?.length ?? 0, total: xAxisOptions?.length ?? 0 })}`}</div>}
+                      onClose={() => setPathotypeSearch('')}
+                    >
+                      <Box className={classes.selectSearch} onClick={e => e.stopPropagation()} onKeyDown={e => e.stopPropagation()}>
+                        <TextField
+                          variant="standard"
+                          placeholder="Search..."
+                          fullWidth
+                          value={pathotypeSearch}
+                          onChange={e => { e.stopPropagation(); setPathotypeSearch(e.target.value); }}
+                          InputProps={
+                            pathotypeSearch === ''
+                              ? undefined
+                              : { endAdornment: <IconButton size="small" onClick={e => { e.stopPropagation(); setPathotypeSearch(''); }}><Clear /></IconButton> }
+                          }
+                        />
+                      </Box>
+                      {filteredXAxisOptions.map((option, i) => (
+                        <MenuItem key={`pathotype-x-${i}`} value={option}>
+                          <Checkbox checked={xAxisSelected.indexOf(option) > -1} />
+                          <ListItemText primary={getOptionLabel(option)} />
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </div>
+                </div>
+                <div className={classes.selectPreWrapper}>
+                  <div className={classes.selectWrapper}>
+                    <div className={classes.labelWrapper}>
+                      <Typography variant="caption">{t('common.selectDrug')}</Typography>
+                    </div>
+                    <Select
+                      value={currentDrugClass}
+                      onChange={e => setYAxisType(e.target.value)}
+                      inputProps={{ className: classes.selectInput }}
+                      MenuProps={{ classes: { list: classes.selectMenu } }}
+                      disabled={organism === 'none'}
+                    >
+                      {drugClasses
+                        .filter(opt =>
+                          !['ecoli', 'decoli', 'shige', 'senterica', 'sentericaints'].includes(organism) ||
+                          (opt !== 'Ciprofloxacin NS' && opt !== 'Ciprofloxacin R'),
+                        )
+                        .map((option, i) => (
+                          <MenuItem key={`pathotype-drug-${i}`} value={option}>
+                            {drugAcronymsOpposite[drugAcronyms[option] ?? option] ?? option}
+                          </MenuItem>
+                        ))}
+                    </Select>
+                  </div>
+                  <div className={classes.selectWrapper}>
+                    <div className={classes.labelWrapper}>
+                      <Typography variant="caption">{t('common.selectMarkers')}</Typography>
+                      <Tooltip title="Only the first 20 options are shown at a time" placement="top">
+                        <InfoOutlined color="action" fontSize="small" className={classes.labelTooltipIcon} />
+                      </Tooltip>
+                    </div>
+                    <Select
+                      multiple
+                      value={yAxisSelected}
+                      onChange={event => handleChangeYAxisSelected({ event })}
+                      displayEmpty
+                      disabled={organism === 'none'}
+                      endAdornment={
+                        <Button
+                          variant="outlined"
+                          className={classes.selectButton}
+                          onClick={() => handleChangeYAxisSelected({ all: true })}
+                          disabled={organism === 'none'}
+                          color={
+                            yAxisSelected.length === filteredYAxisOptions.length ||
+                            yAxisSelected.some(x => !yAxisOptions.slice(0, 20).includes(x))
+                              ? 'error'
+                              : 'primary'
+                          }
+                        >
+                          {yAxisSelected.length === filteredYAxisOptions.length ||
+                          yAxisSelected.some(x => !yAxisOptions.slice(0, 20).includes(x))
+                            ? t('common.clearAll')
+                            : t('common.select20')}
+                        </Button>
+                      }
+                      inputProps={{ className: classes.multipleSelectInput }}
+                      MenuProps={{
+                        disableAutoFocusItem: true,
+                        classes: { paper: classes.menuPaper, list: classes.selectMenu },
+                      }}
+                      renderValue={selected => <div>{`${selected?.length} of ${yAxisOptions.length} selected`}</div>}
+                      onClose={() => setMarkerSearch('')}
+                    >
+                      <Box className={classes.selectSearch} onClick={e => e.stopPropagation()} onKeyDown={e => e.stopPropagation()}>
+                        <TextField
+                          variant="standard"
+                          placeholder="Search..."
+                          fullWidth
+                          value={markerSearch}
+                          onChange={e => { e.stopPropagation(); setMarkerSearch(e.target.value); }}
+                          InputProps={
+                            markerSearch === ''
+                              ? undefined
+                              : { endAdornment: <IconButton size="small" onClick={e => { e.stopPropagation(); setMarkerSearch(''); }}><Clear /></IconButton> }
+                          }
+                        />
+                      </Box>
+                      {filteredYAxisOptions.map((option, i) => (
+                        <MenuItem key={`pathotype-marker-${i}`} value={option}>
+                          <Checkbox checked={yAxisSelected.indexOf(option) > -1} />
+                          <ListItemText primary={option} />
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </Box>
+      )}
+    </CardContent>
+  );
+};

--- a/client/src/components/Elements/Graphs/BubbleMarkersPathotypeHeatmapGraph/index.js
+++ b/client/src/components/Elements/Graphs/BubbleMarkersPathotypeHeatmapGraph/index.js
@@ -1,0 +1,1 @@
+export * from './BubbleMarkersPathotypeHeatmapGraph';

--- a/client/src/components/Elements/Graphs/Graphs.js
+++ b/client/src/components/Elements/Graphs/Graphs.js
@@ -441,7 +441,7 @@ export const Graphs = () => {
       const originalOverflow = graph.style.overflow;
       const originalWidth = graph.style.width;
 
-      if (['HSG2', 'BKOH', 'BAMRH'].includes(currentCard.id)) {
+      if (['HSG2', 'BKOH', 'BAMRH', 'BAMRPH'].includes(currentCard.id)) {
         // Temporarily expand the graph to its full scrollable width
         graph.style.overflow = 'visible';
         graph.style.width = graph.scrollWidth + 'px';
@@ -456,7 +456,7 @@ export const Graphs = () => {
 
       await graphImgPromise;
 
-      if (['HSG2', 'BKOH', 'BAMRH'].includes(currentCard.id)) {
+      if (['HSG2', 'BKOH', 'BAMRH', 'BAMRPH'].includes(currentCard.id)) {
         // Restore original styles
         graph.style.overflow = originalOverflow;
         graph.style.width = originalWidth;
@@ -488,7 +488,7 @@ export const Graphs = () => {
         // BG is replaced from CVM for BubbleGeographicGraph
       }
       ///TODO: improve the code below as its hardcode
-      if (['HSG2', 'BKOH', 'BAMRH'].includes(currentCard.id))
+      if (['HSG2', 'BKOH', 'BAMRH', 'BAMRPH'].includes(currentCard.id))
         canvas.width = graphImg.width < 670 ? 922 : graphImg.width + 100;
       else canvas.width = 922;
       // console.log('canvas.width', canvas.width, graphImg.width);
@@ -507,9 +507,9 @@ export const Graphs = () => {
       legendImg.src = '/legends/HeatMapLegend.png';
       await legendPromise;
       ctx.drawImage(logo, 10, 10, 155, 80);
-      if (['HSG2', 'BKOH', 'BAMRH'].includes(currentCard.id)){
+      if (['HSG2', 'BKOH', 'BAMRH', 'BAMRPH'].includes(currentCard.id)){
         ctx.drawImage(graphImg, 40, 220);
-        ctx.drawImage(legendImg, canvas.width/1.5, 200);        
+        ctx.drawImage(legendImg, canvas.width/1.5, 200);
       }
       else ctx.drawImage(graphImg, canvas.width / 2 - graphImg.width / 2, 220);
 
@@ -792,7 +792,7 @@ export const Graphs = () => {
             {collapses['all'] && currentTab !== 'HSG' && (
               <>
                 <span>
-                  {currentTab !== 'RDWG' && currentTab !== 'BAMRH'  && currentTab !== 'BKOH' && currentTab !== 'HSG2' && (<SwitchColour />)}
+                  {currentTab !== 'RDWG' && currentTab !== 'BAMRH' && currentTab !== 'BAMRPH' && currentTab !== 'BKOH' && currentTab !== 'HSG2' && (<SwitchColour />)}
                 </span>
                 <Tooltip title={t('continentGraphs.tooltip.downloadData')} placement="top">
                   <IconButton

--- a/client/src/components/Elements/Graphs/RadarProfileGraph/RadarProfileGraph.js
+++ b/client/src/components/Elements/Graphs/RadarProfileGraph/RadarProfileGraph.js
@@ -24,7 +24,12 @@ import {
 } from 'recharts';
 import { useAppSelector } from '../../../../stores/hooks';
 import { drugRulesST } from '../../../../util/drugClassesRules';
-import { drugAcronyms, defaultDrugsForDrugResistanceGraphST } from '../../../../util/drugs';
+import {
+  drugAcronyms,
+  defaultDrugsForDrugResistanceGraphSA,
+  defaultDrugsForDrugResistanceGraphST,
+  drugsST,
+} from '../../../../util/drugs';
 import { getLocalizedCountryName } from '../../../../util/countryLocalization';
 import { PlottingOptionsHeader } from '../../Shared/PlottingOptionsHeader';
 import { useStyles } from './RadarProfileGraphMUI';
@@ -185,10 +190,13 @@ export const RadarProfileGraph = ({ showFilter, setShowFilter }) => {
     });
   }, [organism, drugsData, drugNames]);
 
-  // All selectable drug options
-  const allDrugOptions = useMemo(() => [...drugNames, ...extraDrugOptions], [drugNames, extraDrugOptions]);
+  // All selectable drug options — for styphi use the same list as the DRT plot (drugsST)
+  const allDrugOptions = useMemo(() => {
+    if (organism === 'styphi') return drugsST;
+    return [...drugNames, ...extraDrugOptions];
+  }, [drugNames, extraDrugOptions, organism]);
 
-  // Default selection: styphi matches AMR trends defaults; other organisms show all
+  // Default selection mirrors the DRT plot defaults per organism
   const defaultDrugs = useMemo(() => {
     if (organism === 'styphi') {
       const seen = new Set();
@@ -196,6 +204,10 @@ export const RadarProfileGraph = ({ showFilter, setShowFilter }) => {
         .map(d => (allDrugOptions.includes(d) ? d : (DEFAULT_DRUG_FALLBACKS[d] && allDrugOptions.includes(DEFAULT_DRUG_FALLBACKS[d]) ? DEFAULT_DRUG_FALLBACKS[d] : null)))
         .filter(d => d && !seen.has(d) && seen.add(d));
       return hits.length > 0 ? hits : allDrugOptions;
+    }
+    if (organism === 'saureus') {
+      const defaults = defaultDrugsForDrugResistanceGraphSA.filter(d => allDrugOptions.includes(d));
+      return defaults.length > 0 ? defaults : allDrugOptions;
     }
     return allDrugOptions;
   }, [organism, allDrugOptions]);

--- a/client/src/components/Elements/Graphs/RadarProfileGraph/RadarProfileGraph.js
+++ b/client/src/components/Elements/Graphs/RadarProfileGraph/RadarProfileGraph.js
@@ -28,11 +28,9 @@ import { getLocalizedCountryName } from '../../../../util/countryLocalization';
 import { PlottingOptionsHeader } from '../../Shared/PlottingOptionsHeader';
 import { useStyles } from './RadarProfileGraphMUI';
 
-// Direct column lookups for styphi — avoids the getDrugClassData resistantCount bug
+// Column lookups for all styphi drugs (including MDR/XDR/Pansusceptible)
 const STYPHI_DRUG_RULES = Object.fromEntries(
-  drugRulesST
-    .filter(r => !['MDR', 'XDR', 'Pansusceptible'].includes(r.key))
-    .map(r => [r.key, { columnID: r.columnID, values: r.values }]),
+  drugRulesST.map(r => [r.key, { columnID: r.columnID, values: r.values }]),
 );
 
 const RADAR_COLORS = ['#006cde', '#cd3cbe', '#00ac35', '#e65c00', '#785EF0'];
@@ -68,11 +66,13 @@ export const RadarProfileGraph = ({ showFilter, setShowFilter }) => {
   const { t, i18n } = useTranslation();
   const [selectedCountries, setSelectedCountries] = useState([]);
   const [xAxisType, setXAxisType] = useState(DEFAULT_X_AXIS_TYPE);
+  const [selectedDrugs, setSelectedDrugs] = useState(null); // null = default (all regular drugs)
 
   const organism = useAppSelector(state => state.dashboard.organism);
   const drugsCountriesData = useAppSelector(state => state.graph.drugsCountriesData);
   const drugsRegionsData = useAppSelector(state => state.graph.drugsRegionsData);
   const rawOrganismData = useAppSelector(state => state.graph.rawOrganismData);
+  const economicRegions = useAppSelector(state => state.dashboard.economicRegions);
   const canGetData = useAppSelector(state => state.dashboard.canGetData);
   const resetBool = useAppSelector(state => state.graph.resetBool);
 
@@ -99,6 +99,54 @@ export const RadarProfileGraph = ({ showFilter, setShowFilter }) => {
     return map;
   }, [organism, xAxisType, rawOrganismData]);
 
+  // For styphi, compute MDR/XDR/Pansusceptible per location (country or region) from raw data
+  const styphiExtraResistance = useMemo(() => {
+    if (organism !== 'styphi' || !rawOrganismData?.length) return null;
+
+    if (xAxisType === 'country') {
+      const map = {};
+      rawOrganismData.forEach(item => {
+        const country = item.COUNTRY_ONLY;
+        if (!country) return;
+        if (!map[country]) map[country] = {};
+        Object.entries(STYPHI_DRUG_RULES).forEach(([drugKey, rule]) => {
+          if (!map[country][drugKey]) map[country][drugKey] = { resistant: 0, total: 0 };
+          map[country][drugKey].total++;
+          if (rule.values.includes(String(item[rule.columnID]))) {
+            map[country][drugKey].resistant++;
+          }
+        });
+      });
+      return map;
+    }
+
+    // Region view: aggregate using economicRegions country→region mapping
+    if (!economicRegions) return null;
+    const countryToRegions = {};
+    Object.entries(economicRegions).forEach(([region, countries]) => {
+      countries.forEach(country => {
+        if (!countryToRegions[country]) countryToRegions[country] = [];
+        countryToRegions[country].push(region);
+      });
+    });
+    const map = {};
+    rawOrganismData.forEach(item => {
+      const country = item.COUNTRY_ONLY;
+      if (!country) return;
+      (countryToRegions[country] || []).forEach(region => {
+        if (!map[region]) map[region] = {};
+        Object.entries(STYPHI_DRUG_RULES).forEach(([drugKey, rule]) => {
+          if (!map[region][drugKey]) map[region][drugKey] = { resistant: 0, total: 0 };
+          map[region][drugKey].total++;
+          if (rule.values.includes(String(item[rule.columnID]))) {
+            map[region][drugKey].resistant++;
+          }
+        });
+      });
+    });
+    return map;
+  }, [organism, xAxisType, rawOrganismData, economicRegions]);
+
   // Get available countries/regions that have data
   const availableLocations = useMemo(() => {
     if (!drugsData || typeof drugsData !== 'object') return [];
@@ -116,7 +164,7 @@ export const RadarProfileGraph = ({ showFilter, setShowFilter }) => {
   // filters.js also emits alongside them.
   const drugNames = useMemo(() => {
     if (!drugsData || typeof drugsData !== 'object') return [];
-    const EXCLUDED = new Set(['MDR', 'XDR', 'Pansusceptible', 'Susceptible', 'Susceptible to cat I/II drugs']);
+    const EXCLUDED = new Set([]); // removed 'MDR', 'XDR', 'Pansusceptible', 'Susceptible', 'Susceptible to cat I/II drugs'
     if (['ecoli', 'decoli', 'shige', 'senterica', 'sentericaints'].includes(organism)) {
       EXCLUDED.add('Ciprofloxacin NS');
       EXCLUDED.add('Ciprofloxacin R');
@@ -124,49 +172,80 @@ export const RadarProfileGraph = ({ showFilter, setShowFilter }) => {
     return Object.keys(drugsData).filter(d => !EXCLUDED.has(d));
   }, [drugsData, organism]);
 
-  // Build radar chart data: one entry per drug, with values per country
-  const radarData = useMemo(() => {
-    if (!drugsData || selectedCountries.length === 0 || drugNames.length === 0) return [];
+  // Extra drug options: MDR, XDR, Pansusceptible — only those not already in drugNames
+  const extraDrugOptions = useMemo(() => {
+    const EXTRA_DRUGS = ['MDR', 'XDR', 'Pansusceptible'];
+    return EXTRA_DRUGS.filter(drug => {
+      if (drugNames.includes(drug)) return false; // already in the regular list
+      if (organism === 'styphi') return true;
+      return drugsData && drug in drugsData;
+    });
+  }, [organism, drugsData, drugNames]);
 
-    return drugNames.map(drug => {
+  // All selectable drug options
+  const allDrugOptions = useMemo(() => [...drugNames, ...extraDrugOptions], [drugNames, extraDrugOptions]);
+
+  // Effective drugs shown on the radar (selectedDrugs=null means all options including extras)
+  const displayedDrugs = useMemo(() => {
+    if (!selectedDrugs) return allDrugOptions;
+    const valid = selectedDrugs.filter(d => allDrugOptions.includes(d));
+    return valid.length > 0 ? valid : allDrugOptions;
+  }, [selectedDrugs, allDrugOptions]);
+
+  // Build radar chart data: one entry per drug, with values per location
+  const radarData = useMemo(() => {
+    if (!drugsData || selectedCountries.length === 0 || displayedDrugs.length === 0) return [];
+
+    return displayedDrugs.map(drug => {
       const entry = {
         drug,
       };
 
-      selectedCountries.forEach(country => {
-        // styphi: use raw per-genome counts via STYPHI_DRUG_RULES to avoid resistantCount bug
+      selectedCountries.forEach(location => {
+        // 1. MDR/XDR/Pansusceptible for styphi: use raw per-genome computation
+        if (styphiExtraResistance) {
+          const raw = styphiExtraResistance[location]?.[drug];
+          if (raw !== undefined) {
+            entry[location] = raw.total >= 20 ? Number(((raw.resistant / raw.total) * 100).toFixed(1)) : null;
+            return;
+          }
+        }
+
+        // 2. Regular drugs for styphi country view: use per-genome raw counts
         if (styphiRawResistance) {
-          const raw = styphiRawResistance[country]?.[drug];
+          const raw = styphiRawResistance[location]?.[drug];
           if (raw && raw.total >= 20) {
-            entry[country] = Number(((raw.resistant / raw.total) * 100).toFixed(1));
+            entry[location] = Number(((raw.resistant / raw.total) * 100).toFixed(1));
           } else {
-            entry[country] = null;
+            entry[location] = null;
           }
           return;
         }
 
+        // 3. All other organisms / styphi region regular drugs: use precomputed drugsData
         const drugEntries = drugsData[drug];
         if (!Array.isArray(drugEntries)) {
-          entry[country] = null;
+          entry[location] = null;
           return;
         }
-        const countryEntry = drugEntries.find(d => d.name === country);
-        if (countryEntry && countryEntry.count > 0) {
-          const resistant = countryEntry.resistantCount ?? 0;
-          entry[country] = Number(((resistant / countryEntry.count) * 100).toFixed(1));
+        const locEntry = drugEntries.find(d => d.name === location);
+        if (locEntry && locEntry.count > 0) {
+          const resistant = locEntry.resistantCount ?? 0;
+          entry[location] = Number(((resistant / locEntry.count) * 100).toFixed(1));
         } else {
-          entry[country] = null;
+          entry[location] = null;
         }
       });
 
       return entry;
     });
-  }, [drugsData, selectedCountries, drugNames, styphiRawResistance]);
+  }, [drugsData, selectedCountries, displayedDrugs, styphiRawResistance, styphiExtraResistance]);
 
   useEffect(() => {
     if (resetBool) {
       setXAxisType(DEFAULT_X_AXIS_TYPE);
       setSelectedCountries([]);
+      setSelectedDrugs(null);
     }
   }, [resetBool]);
 
@@ -199,7 +278,19 @@ export const RadarProfileGraph = ({ showFilter, setShowFilter }) => {
     setSelectedCountries([]);
   };
 
+  const handleDrugSelect = event => {
+    const value = event.target.value;
+    setSelectedDrugs(typeof value === 'string' ? value.split(',') : [...value]);
+  };
+
+  const handleRemoveDrug = drugToRemove => {
+    const current = selectedDrugs ?? allDrugOptions;
+    setSelectedDrugs(current.filter(d => d !== drugToRemove));
+  };
+
   if (!canGetData) return null;
+
+  const activeDrugsForSelector = selectedDrugs ?? allDrugOptions;
 
   return (
     <CardContent className={classes.radarProfileGraph}>
@@ -345,6 +436,52 @@ export const RadarProfileGraph = ({ showFilter, setShowFilter }) => {
                   ))}
                 </Select>
               </Box>
+              {/* Drug selector */}
+              {allDrugOptions.length > 0 && (
+                <Box className={classes.selectWrapper}>
+                  <Box className={classes.labelWrapper}>
+                    <Typography variant="body2" fontWeight={600}>
+                      Select drugs
+                    </Typography>
+                    <Tooltip title="Choose which drugs and resistance categories to display on the radar axes">
+                      <InfoOutlined fontSize="small" sx={{ cursor: 'pointer', color: 'rgba(0,0,0,0.5)' }} />
+                    </Tooltip>
+                  </Box>
+                  <Select
+                    multiple
+                    value={activeDrugsForSelector}
+                    onChange={handleDrugSelect}
+                    renderValue={selected => (
+                      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                        {selected.map(drug => (
+                          <Chip
+                            key={drug}
+                            label={drug}
+                            size="small"
+                            onDelete={() => handleRemoveDrug(drug)}
+                            onMouseDown={e => e.stopPropagation()}
+                            sx={{
+                              backgroundColor: extraDrugOptions.includes(drug) ? '#5c5c8a' : '#607d8b',
+                              color: '#fff',
+                              '& .MuiChip-deleteIcon': { color: 'rgba(255,255,255,0.7)' },
+                            }}
+                          />
+                        ))}
+                      </Box>
+                    )}
+                    size="small"
+                    MenuProps={{ PaperProps: { className: classes.menuPaper } }}
+                    className={classes.selectMenu}
+                  >
+                    {allDrugOptions.map(drug => (
+                      <MenuItem key={drug} value={drug}>
+                        <Checkbox checked={activeDrugsForSelector.includes(drug)} size="small" />
+                        <ListItemText primary={drug} />
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </Box>
+              )}
             </CardContent>
           </Card>
         </Box>

--- a/client/src/components/Elements/Graphs/RadarProfileGraph/RadarProfileGraph.js
+++ b/client/src/components/Elements/Graphs/RadarProfileGraph/RadarProfileGraph.js
@@ -74,7 +74,7 @@ export const RadarProfileGraph = ({ showFilter, setShowFilter }) => {
   const organism = useAppSelector(state => state.dashboard.organism);
   const drugsCountriesData = useAppSelector(state => state.graph.drugsCountriesData);
   const drugsRegionsData = useAppSelector(state => state.graph.drugsRegionsData);
-  const rawOrganismData = useAppSelector(state => state.graph.rawOrganismData);
+  const rawOrganismData = useAppSelector(state => state.graph.allOrganismData);
   const economicRegions = useAppSelector(state => state.dashboard.economicRegions);
   const canGetData = useAppSelector(state => state.dashboard.canGetData);
   const resetBool = useAppSelector(state => state.graph.resetBool);

--- a/client/src/components/Elements/Graphs/RadarProfileGraph/RadarProfileGraph.js
+++ b/client/src/components/Elements/Graphs/RadarProfileGraph/RadarProfileGraph.js
@@ -24,6 +24,7 @@ import {
 } from 'recharts';
 import { useAppSelector } from '../../../../stores/hooks';
 import { drugRulesST } from '../../../../util/drugClassesRules';
+import { drugAcronyms, defaultDrugsForDrugResistanceGraphST } from '../../../../util/drugs';
 import { getLocalizedCountryName } from '../../../../util/countryLocalization';
 import { PlottingOptionsHeader } from '../../Shared/PlottingOptionsHeader';
 import { useStyles } from './RadarProfileGraphMUI';
@@ -32,13 +33,15 @@ import { useStyles } from './RadarProfileGraphMUI';
 const STYPHI_DRUG_RULES = Object.fromEntries(
   drugRulesST.map(r => [r.key, { columnID: r.columnID, values: r.values }]),
 );
-
+// When 'Ciprofloxacin NS' is absent from drugsData, 'Ciprofloxacin' (NS+R combined) is the fallback
+const DEFAULT_DRUG_FALLBACKS = { 'Ciprofloxacin NS': 'Ciprofloxacin',};
 const RADAR_COLORS = ['#006cde', '#cd3cbe', '#00ac35', '#e65c00', '#785EF0'];
 
 const MAX_COUNTRIES = 5;
 
 const DEFAULT_X_AXIS_TYPE = 'region';
 const DEFAULT_REGIONS = ['Eastern Africa', 'Western Africa', 'Southern Asia', 'South-eastern Asia'];
+const DEFAULT_RADAR_DRUGS_ST = defaultDrugsForDrugResistanceGraphST;
 
 const CustomTooltip = ({ active, payload, label }) => {
   if (!active || !payload?.length) return null;
@@ -185,12 +188,24 @@ export const RadarProfileGraph = ({ showFilter, setShowFilter }) => {
   // All selectable drug options
   const allDrugOptions = useMemo(() => [...drugNames, ...extraDrugOptions], [drugNames, extraDrugOptions]);
 
-  // Effective drugs shown on the radar (selectedDrugs=null means all options including extras)
+  // Default selection: styphi matches AMR trends defaults; other organisms show all
+  const defaultDrugs = useMemo(() => {
+    if (organism === 'styphi') {
+      const seen = new Set();
+      const hits = DEFAULT_RADAR_DRUGS_ST
+        .map(d => (allDrugOptions.includes(d) ? d : (DEFAULT_DRUG_FALLBACKS[d] && allDrugOptions.includes(DEFAULT_DRUG_FALLBACKS[d]) ? DEFAULT_DRUG_FALLBACKS[d] : null)))
+        .filter(d => d && !seen.has(d) && seen.add(d));
+      return hits.length > 0 ? hits : allDrugOptions;
+    }
+    return allDrugOptions;
+  }, [organism, allDrugOptions]);
+
+  // Effective drugs shown on the radar (selectedDrugs=null means use defaultDrugs)
   const displayedDrugs = useMemo(() => {
-    if (!selectedDrugs) return allDrugOptions;
+    if (!selectedDrugs) return defaultDrugs;
     const valid = selectedDrugs.filter(d => allDrugOptions.includes(d));
-    return valid.length > 0 ? valid : allDrugOptions;
-  }, [selectedDrugs, allDrugOptions]);
+    return valid.length > 0 ? valid : defaultDrugs;
+  }, [selectedDrugs, defaultDrugs, allDrugOptions]);
 
   // Build radar chart data: one entry per drug, with values per location
   const radarData = useMemo(() => {
@@ -284,13 +299,13 @@ export const RadarProfileGraph = ({ showFilter, setShowFilter }) => {
   };
 
   const handleRemoveDrug = drugToRemove => {
-    const current = selectedDrugs ?? allDrugOptions;
+    const current = selectedDrugs ?? defaultDrugs;
     setSelectedDrugs(current.filter(d => d !== drugToRemove));
   };
 
   if (!canGetData) return null;
 
-  const activeDrugsForSelector = selectedDrugs ?? allDrugOptions;
+  const activeDrugsForSelector = selectedDrugs ?? defaultDrugs;
 
   return (
     <CardContent className={classes.radarProfileGraph}>

--- a/client/src/components/Elements/Graphs/graphColorHelper.js
+++ b/client/src/components/Elements/Graphs/graphColorHelper.js
@@ -22,12 +22,19 @@ const dynamicColors = [
   '#aa8a5b',
   '#DC227F',
   // Extended palette for saureus / strepneumo
-  '#1a6b8a', // 19 - Vancomycin / Teicoplanin (glycopeptides)
+  '#1a6b8a', // 19 - Vancomycin
   '#e65c00', // 20 - Fusidic Acid
   '#7b2fa0', // 21 - Mupirocin
   '#1abc9c', // 22 - Linezolid
   '#6d4c1f', // 23 - Daptomycin
   '#c0392b', // 24 - Rifampicin
+  '#FF6B6B', // 25 - Erythromycin (distinct from Clindamycin)
+  '#00CED1', // 26 - Moxifloxacin (distinct from Ciprofloxacin)
+  '#FF8C00', // 27 - Teicoplanin (distinct from Vancomycin)
+  '#708090', // 28 - slate gray
+  '#556B2F', // 29 - dark olive green
+  '#4169E1', // 30 - royal blue
+  '#BA55D3', // 31 - medium orchid
 ];
 
 // Safe colors for colorblind users - high contrast and distinguishable
@@ -51,14 +58,20 @@ const safeColors = [
   '#d788d5',
   '#a44739',
   '#c75a92',
-  '#9b3b5b',
   // Extended palette for saureus / strepneumo
-  '#1a6b8a', // 19 - Vancomycin / Teicoplanin
+  '#1a6b8a', // 19 - Vancomycin
   '#e65c00', // 20 - Fusidic Acid
   '#7b2fa0', // 21 - Mupirocin
   '#1abc9c', // 22 - Linezolid
   '#6d4c1f', // 23 - Daptomycin
   '#c0392b', // 24 - Rifampicin
+  '#009E73', // 25 - Erythromycin (CVD-safe green, distinct from Clindamycin)
+  '#D55E00', // 26 - Moxifloxacin (CVD-safe vermillion, distinct from Ciprofloxacin)
+  '#E69F00', // 27 - Teicoplanin (CVD-safe orange, distinct from Vancomycin)
+  '#56B4E9', // 28 - sky blue 
+  '#F0E442', // 29 - yellow 
+  '#0072B2', // 30 - blue 
+  '#CC79A7', // 31 - reddish purple 
 ];
 
 const drugColorMap = {
@@ -109,21 +122,21 @@ const drugColorMap = {
   Bleomycin: 15,
   // S. aureus drugs
   Amikacin: 1,       // aminoglycoside
-  Gentamicin: 1,     // aminoglycoside
-  Tobramycin: 1,     // aminoglycoside
-  Kanamycin: 1,      // aminoglycoside
+  Gentamicin: 28,     // aminoglycoside
+  Tobramycin: 29,     // aminoglycoside
+  Kanamycin: 30,      // aminoglycoside
   Methicillin: 0,    // beta-lactam
-  Penicillin: 0,     // beta-lactam
+  Penicillin: 31,     // beta-lactam
   'Fusidic Acid': 20,
   Vancomycin: 19,    // glycopeptide
-  Clindamycin: 13,   // lincosamide (grouped with macrolides)
-  Erythromycin: 13,  // macrolide
+  Clindamycin: 13,   // lincosamide
+  Erythromycin: 25,  // macrolide (distinct index from Clindamycin)
   Mupirocin: 21,
   Linezolid: 22,
   Daptomycin: 23,
   Rifampicin: 24,
-  Moxifloxacin: 8,   // fluoroquinolone
-  Teicoplanin: 19,   // glycopeptide
+  Moxifloxacin: 26,  // fluoroquinolone (distinct index from Ciprofloxacin)
+  Teicoplanin: 27,   // glycopeptide (distinct index from Vancomycin)
   // S. pneumoniae drugs
   Fluoroquinolone: 8,
   Fluoroquinolones: 8,

--- a/client/src/components/Elements/ResetButton/ResetButton.js
+++ b/client/src/components/Elements/ResetButton/ResetButton.js
@@ -155,6 +155,9 @@ export const ResetButton = () => {
     }
     if (organism === 'saureus') {
       dispatch(setDrugResistanceGraphView(defaultDrugsForDrugResistanceGraphSA));
+      dispatch(setDeterminantsGraphDrugClass('Methicillin'));
+      dispatch(setTrendsGraphDrugClass('Methicillin'));
+      dispatch(setBubbleMarkersYAxisType('Methicillin'));
     }
     if (organism === 'strepneumo') {
       dispatch(setDrugResistanceGraphView(drugsSP));

--- a/client/src/components/Elements/ResetButton/ResetButton.js
+++ b/client/src/components/Elements/ResetButton/ResetButton.js
@@ -44,6 +44,7 @@ import {
 import { setDataset, setDatasetKP, setMapView, setPosition } from '../../../stores/slices/mapSlice';
 import {
   defaultDrugsForDrugResistanceGraphNG,
+  defaultDrugsForDrugResistanceGraphSA,
   defaultDrugsForDrugResistanceGraphST,
   drugsECOLI,
   drugsKP,
@@ -153,7 +154,7 @@ export const ResetButton = () => {
       dispatch(setDeterminantsGraphDrugClass('Azithromycin'));
     }
     if (organism === 'saureus') {
-      dispatch(setDrugResistanceGraphView(drugsSA));
+      dispatch(setDrugResistanceGraphView(defaultDrugsForDrugResistanceGraphSA));
     }
     if (organism === 'strepneumo') {
       dispatch(setDrugResistanceGraphView(drugsSP));

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -226,6 +226,7 @@
     "serotypeComparisons": "Serotype Comparisons",
     "pathotypeComparisons": "Pathotype Comparisons",
     "amrbyserotype": "AMR by serotype",
+    "amrbypathotype": "AMR by Pathotype",
     "radarProfile": "AMR Radar Profile",
     "radarProfileDescription": "Compare multi-drug resistance profiles between countries/regions (N≥20)",
     "temporalHeatmap": "Temporal Emergence Heatmap",

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -227,6 +227,7 @@
     "pathotypeComparisons": "Pathotype Comparisons",
     "amrbyserotype": "AMR by serotype",
     "amrbypathotype": "AMR by Pathotype",
+    "amrMarkerByPathotype": "AMR Marker by Pathotype",
     "radarProfile": "AMR Radar Profile",
     "radarProfileDescription": "Compare multi-drug resistance profiles between countries/regions (N≥20)",
     "temporalHeatmap": "Temporal Emergence Heatmap",

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -226,6 +226,7 @@
     "serotypeComparisons": "Comparaciones por Serotipo",
     "pathotypeComparisons": "Comparaciones por Patotipo",
     "amrbyserotype": "RAM por serotipo",
+    "amrbypathotype": "RAM por Patotipo",
     "topGenotypesUpTo10": "Principales Genotipos (hasta 10)",
     "topGenotypesUpTo30": "Principales Genotipos (hasta 30)",
     "radarProfile": "Perfil Radar de RAM",

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -227,6 +227,7 @@
     "pathotypeComparisons": "Comparaciones por Patotipo",
     "amrbyserotype": "RAM por serotipo",
     "amrbypathotype": "RAM por Patotipo",
+    "amrMarkerByPathotype": "Marcador RAM por Patotipo",
     "topGenotypesUpTo10": "Principales Genotipos (hasta 10)",
     "topGenotypesUpTo30": "Principales Genotipos (hasta 30)",
     "radarProfile": "Perfil Radar de RAM",

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -226,6 +226,7 @@
     "serotypeComparisons": "Comparaisons par Sérotype",
     "pathotypeComparisons": "Comparaisons par Pathotype",
     "amrbyserotype": "RAM par sérotype",
+    "amrbypathotype": "RAM par Pathotype",
     "topGenotypesUpTo10": "Principaux Génotypes (jusqu'à 10)",
     "topGenotypesUpTo30": "Principaux Génotypes (jusqu'à 30)",
     "radarProfile": "Profil Radar RAM",

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -227,6 +227,7 @@
     "pathotypeComparisons": "Comparaisons par Pathotype",
     "amrbyserotype": "RAM par sérotype",
     "amrbypathotype": "RAM par Pathotype",
+    "amrMarkerByPathotype": "Marqueur RAM par Pathotype",
     "topGenotypesUpTo10": "Principaux Génotypes (jusqu'à 10)",
     "topGenotypesUpTo30": "Principaux Génotypes (jusqu'à 30)",
     "radarProfile": "Profil Radar RAM",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -227,6 +227,7 @@
     "pathotypeComparisons": "Comparações por Patótipo",
     "amrbyserotype": "RAM por sorotipo",
     "amrbypathotype": "RAM por Patótipo",
+    "amrMarkerByPathotype": "Marcador RAM por Patótipo",
     "topGenotypesUpTo10": "Principais Genótipos (até 10)",
     "topGenotypesUpTo30": "Principais Genótipos (até 30)",
     "radarProfile": "Perfil Radar de RAM",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -226,6 +226,7 @@
     "serotypeComparisons": "Comparações por Sorotipo",
     "pathotypeComparisons": "Comparações por Patótipo",
     "amrbyserotype": "RAM por sorotipo",
+    "amrbypathotype": "RAM por Patótipo",
     "topGenotypesUpTo10": "Principais Genótipos (até 10)",
     "topGenotypesUpTo30": "Principais Genótipos (até 30)",
     "radarProfile": "Perfil Radar de RAM",

--- a/client/src/stores/slices/graphSlice.ts
+++ b/client/src/stores/slices/graphSlice.ts
@@ -92,6 +92,7 @@ interface GraphState {
   drugGene: string;
   coloredOptions: Array<any>;
   bubbleMarkersHeatmapGraphData: Array<any>;
+  pathotypesDrugClassesData: Array<any>;
   rawOrganismData: Array<any>;
 }
 
@@ -180,6 +181,7 @@ const initialState: GraphState = {
   drugGene: '',
   coloredOptions: [],
   bubbleMarkersHeatmapGraphData: [],
+  pathotypesDrugClassesData: [],
   rawOrganismData: [],
 };
 
@@ -267,6 +269,9 @@ export const graphSlice = createSlice({
     },
     setNgMastDrugClassesData: (state, action: PayloadAction<Array<any>>) => {
       state.ngMastDrugClassesData = action.payload;
+    },
+    setPathotypesDrugClassesData: (state, action: PayloadAction<Array<any>>) => {
+      state.pathotypesDrugClassesData = action.payload;
     },
     setGenotypesAndDrugsYearData: (state, action: PayloadAction<any>) => {
       const payloadObj = action.payload && typeof action.payload === 'object' ? action.payload : ({} as any);
@@ -456,6 +461,7 @@ export const {
   setDeterminantsGraphDrugClass,
   setGenotypesDrugClassesData,
   setNgMastDrugClassesData,
+  setPathotypesDrugClassesData,
   setGenotypesAndDrugsYearData,
   setTrendsGraphDrugClass,
   setTrendsGraphView,

--- a/client/src/stores/slices/graphSlice.ts
+++ b/client/src/stores/slices/graphSlice.ts
@@ -94,6 +94,7 @@ interface GraphState {
   bubbleMarkersHeatmapGraphData: Array<any>;
   pathotypesDrugClassesData: Array<any>;
   rawOrganismData: Array<any>;
+  allOrganismData: Array<any>;
 }
 
 const initialState: GraphState = {
@@ -183,6 +184,7 @@ const initialState: GraphState = {
   bubbleMarkersHeatmapGraphData: [],
   pathotypesDrugClassesData: [],
   rawOrganismData: [],
+  allOrganismData: [],
 };
 
 export const graphSlice = createSlice({
@@ -440,6 +442,9 @@ export const graphSlice = createSlice({
     setRawOrganismData: (state, action: PayloadAction<Array<any>>) => {
       state.rawOrganismData = action.payload;
     },
+    setAllOrganismData: (state, action: PayloadAction<Array<any>>) => {
+      state.allOrganismData = action.payload;
+    },
   },
 });
 
@@ -525,6 +530,7 @@ export const {
   setColoredOptions,
   setBubbleMarkersHeatmapGraphData,
   setRawOrganismData,
+  setAllOrganismData,
 } = graphSlice.actions;
 
 export default graphSlice.reducer;

--- a/client/src/util/drugClassesRules.js
+++ b/client/src/util/drugClassesRules.js
@@ -4,7 +4,6 @@ export const drugRulesST = [
   { key: 'Ampicillin/Amoxicillin', columnID: 'blaTEM-1D', values: ['1'] },
   { key: 'Azithromycin', columnID: 'azith_pred_pheno', values: ['AzithR'] },
   { key: 'Chloramphenicol', columnID: 'chloramphenicol_category', values: ['ChlR'] },
-  { key: 'Trimethoprim-sulfamethoxazole', columnID: 'co_trim', values: ['1'] },
   { key: 'Ceftriaxone', columnID: 'ESBL_category', values: ['ESBL'] },
   {
     key: 'Ciprofloxacin NS',
@@ -22,6 +21,7 @@ export const drugRulesST = [
   { key: 'Sulfonamides', columnID: 'sul_any', values: ['1'] },
   { key: 'Tetracycline', columnID: 'tetracycline_category', values: ['TetR'] },
   { key: 'Trimethoprim', columnID: 'dfra_any', values: ['1'] },
+  { key: 'Trimethoprim-sulfamethoxazole', columnID: 'co_trim', values: ['1'] },
   { key: 'MDR', columnID: 'MDR', values: ['MDR'], legends: 'Multidrug resistant (MDR)' },
   { key: 'XDR', columnID: 'XDR', values: ['XDR'], legends: 'Extensively drug resistant (XDR)' },
   { key: 'Pansusceptible', columnID: 'amr_category', values: ['No AMR detected'] },

--- a/client/src/util/drugClassesRules.js
+++ b/client/src/util/drugClassesRules.js
@@ -1466,11 +1466,12 @@ export const drugRulesSA = [
   { key: 'Moxifloxacin', columnID: 'Moxifloxacin', values: ['1'] },
   { key: 'Mupirocin', columnID: 'Mupirocin', values: ['1'] },
   { key: 'Penicillin', columnID: 'Penicillin', values: ['1'] },
-  { key: 'Pansusceptible', columnID: null, values: [], pansusceptible: true },
   { key: 'Rifampicin', columnID: 'Rifampicin', values: ['1'] },
   { key: 'Tetracycline', columnID: 'Tetracycline', values: ['1'] },
   { key: 'Tobramycin', columnID: 'Tobramycin', values: ['1'] },
   { key: 'Vancomycin', columnID: 'Vancomycin', values: ['1'] },
+  { key: 'Pansusceptible', columnID: null, values: [], pansusceptible: true },
+
 ];
 
 // ---------------------------------------------------------------------------
@@ -1484,8 +1485,9 @@ export const drugRulesSP = [
   { key: 'Fluoroquinolones', columnID: 'Fluoroquinolones', values: ['1'] },
   { key: 'Kanamycin', columnID: 'Kanamycin', values: ['1'] },
   // { key: 'Linezolid', columnID: 'Linezolid', values: ['1'] },
-  { key: 'Pansusceptible', columnID: 'amr_gene_count', values: ['0'], pansusceptible: true },
   { key: 'Tetracycline', columnID: 'Tetracycline', values: ['1'] },
+  { key: 'Pansusceptible', columnID: 'amr_gene_count', values: ['0'], pansusceptible: true },
+
 ];
 
 // ---------------------------------------------------------------------------

--- a/client/src/util/drugs.js
+++ b/client/src/util/drugs.js
@@ -108,6 +108,17 @@ export const drugClassesNG = Object.keys(drugClassesRulesNG).sort();
 // S. aureus drug list
 export const drugsSA = drugRulesSA.map(x => x.key);
 
+export const defaultDrugsForDrugResistanceGraphSA = [
+  'Methicillin',
+  'Daptomycin',
+  'Fusidic Acid',
+  'Linezolid',
+  'Moxifloxacin',
+  'Mupirocin',
+  'Vancomycin',
+  'Pansusceptible',
+];
+
 // S. pneumoniae drug list
 export const drugsSP = drugRulesSP.map(x => x.key);
 

--- a/client/src/util/drugs.js
+++ b/client/src/util/drugs.js
@@ -109,10 +109,10 @@ export const drugClassesNG = Object.keys(drugClassesRulesNG).sort();
 export const drugsSA = drugRulesSA.map(x => x.key);
 
 export const defaultDrugsForDrugResistanceGraphSA = [
-  'Methicillin',
   'Daptomycin',
   'Fusidic Acid',
   'Linezolid',
+  'Methicillin',
   'Moxifloxacin',
   'Mupirocin',
   'Vancomycin',

--- a/client/src/util/graphCards.js
+++ b/client/src/util/graphCards.js
@@ -2,6 +2,7 @@ import { BubbleChart, GridOn, ShowChart, StackedBarChart, Timeline, ViewModule, 
 import { BubbleHeatmapGraph2 } from '../components/Elements/Graphs/BubbleHeatmapGraph2';
 import { BubbleKOHeatmapGraph } from '../components/Elements/Graphs/BubbleKOHeatmapGraph';
 import { BubbleMarkersHeatmapGraph } from '../components/Elements/Graphs/BubbleMarkersHeatmapGraph';
+import { BubbleMarkersPathotypeHeatmapGraph } from '../components/Elements/Graphs/BubbleMarkersPathotypeHeatmapGraph';
 import { ConvergenceGraph } from '../components/Elements/Graphs/ConvergenceGraph';
 import { ConvergenceMapGraph } from '../components/Elements/Graphs/ConvergenceMapGraph';
 import { DeterminantsGraph } from '../components/Elements/Graphs/DeterminantsGraph';
@@ -182,8 +183,16 @@ export function getGraphCards(t){
       description: [''],
       icon: <ViewModule color="primary" />,
       id: 'BHPS',
-      organisms: ['shige'],
+      organisms: ['shige', 'decoli', 'ecoli'],
       component: <BubbleHPGraph />,
+    },
+    {
+      title: t('graphs.amrMarkerByPathotype'),
+      description: [''],
+      icon: <ViewModule color="primary" />,
+      id: 'BAMRPH',
+      organisms: ['shige', 'decoli', 'ecoli'],
+      component: <BubbleMarkersPathotypeHeatmapGraph />,
     },
     {
       title: t('graphs.vaccineCoverage'),

--- a/client/src/util/graphCards.js
+++ b/client/src/util/graphCards.js
@@ -178,6 +178,14 @@ export function getGraphCards(t){
       component: <BubbleHPGraph />,
     },
     {
+      title: t('graphs.amrbypathotype'),
+      description: [''],
+      icon: <ViewModule color="primary" />,
+      id: 'BHPS',
+      organisms: ['shige'],
+      component: <BubbleHPGraph />,
+    },
+    {
       title: t('graphs.vaccineCoverage'),
       description: [''],
       icon: <Vaccines color="primary" />,


### PR DESCRIPTION
## Summary

- **Radar plot — drug selector**: Added a "Select drugs" multi-select dropdown in the Plotting Options panel. For S. Typhi the list and default selection now match the DRT plot (`drugsST` / `defaultDrugsForDrugResistanceGraphST`); includes Ciprofloxacin NS, Ciprofloxacin R, and Trimethoprim-sulfamethoxazole which were previously missing. MDR, XDR, and Pansusceptible are selectable as extra options. The combined "Ciprofloxacin" fallback entry is excluded from the dropdown.
- **Radar plot — default drugs per organism**: S. aureus radar defaults to `defaultDrugsForDrugResistanceGraphSA` (Methicillin, Daptomycin, Vancomycin, etc.) instead of showing all drugs selected. Pansusceptible is ordered last for SA and SP.
- **Radar plot — country filter fix**: The global country filter was incorrectly scoping the radar's available locations. Fixed to ignore the selected country filter (same behaviour as the Geo-Comparisons heatmap), since the point of the radar is cross-country/region comparison.
- **AMR by Pathotype tab**: New "AMR BY PATHOTYPE" tab added to AMR Insights, backed by a new `BubbleMarkersPathotypeHeatmapGraph` component showing AMR marker prevalence broken down by pathotype.
- **DRT legend fix**: `getDrugsForLegends` now filters against `chartData` (drugs with non-null values) rather than the raw `drugsYearData` key union, preventing ghost legend entries.
