### PR TITLE
fix(api): remove S. Typhi patient-level fields from API, public API and S3 export

### DIFF
--- a/config/db.js
+++ b/config/db.js
@@ -104,7 +104,7 @@ const getValidatedTimeoutMs = (envValue, defaultMs = 60000) => {
 };
 
 // Helper function to get data with timeout protection
-const getDataWithTimeout = async (dbName, collectionName, query) => {
+const getDataWithTimeout = async (dbName, collectionName, query, projection) => {
   try {
     // Ensure client is connected
     const connectedClient = await Promise.race([
@@ -112,9 +112,14 @@ const getDataWithTimeout = async (dbName, collectionName, query) => {
       new Promise((_, reject) => setTimeout(() => reject(new Error('Database connection timeout')), 10000)),
     ]);
 
+    // Optional field projection (e.g. to exclude personal/quasi-identifier
+    // fields from the payload). Backward-compatible: callers that omit it
+    // get the full document as before.
+    const findOptions = projection ? { projection } : {};
+
     // Execute query with timeout
     const result = await Promise.race([
-      connectedClient.db(dbName).collection(collectionName).find(query).toArray(),
+      connectedClient.db(dbName).collection(collectionName).find(query, findOptions).toArray(),
       new Promise((_, reject) => setTimeout(() => reject(new Error('Query timeout')), 100000)),
     ]);
 

--- a/config/personalFields.js
+++ b/config/personalFields.js
@@ -1,0 +1,41 @@
+/**
+ * Patient-level / quasi-identifier fields that are stored on styphi records but
+ * are NOT used by any dashboard graph or filter. They must never be shipped to
+ * the browser, the public REST API, or the S3 / file exports.
+ *
+ * A DB scan (scripts/gdpr-field-check.mjs) confirmed styphi is the only
+ * collection where these fields are populated; the other organisms carry none,
+ * so excluding these names on those collections is a harmless no-op.
+ *
+ * NOTE: `TRAVEL` (the local/travel/community category) is intentionally NOT
+ * here — it drives the dashboard dataset filter and is not free-text/personal.
+ */
+export const STYPHI_PERSONAL_FIELDS = [
+  'AGE',
+  'CONTACT',
+  'LAB',
+  'SYMPTOM STATUS',
+  'TRAVEL COUNTRY',
+  'TRAVEL ASSOCIATED',
+  'TRAVEL_LOCATION',
+  'LOCATION',
+  'REGION_IN_COUNTRY',
+  'COUNTRY OF ORIGIN',
+  'LATITUDE',
+  'LONGITUDE',
+];
+
+// MongoDB exclusion projection, e.g. find(query, { projection: STYPHI_PERSONAL_FIELDS_EXCLUSION })
+export const STYPHI_PERSONAL_FIELDS_EXCLUSION = Object.fromEntries(
+  STYPHI_PERSONAL_FIELDS.map(field => [field, 0]),
+);
+
+// Remove the personal fields from a plain object (e.g. a row parsed from a
+// CSV/TSV fallback that bypasses the DB projection). Mutates and returns it.
+export function stripPersonalFields(row) {
+  if (!row || typeof row !== 'object') return row;
+  for (const field of STYPHI_PERSONAL_FIELDS) {
+    delete row[field];
+  }
+  return row;
+}

--- a/routes/api/api.js
+++ b/routes/api/api.js
@@ -3,6 +3,7 @@ import express from 'express';
 import rateLimit from 'express-rate-limit';
 import fs from 'fs';
 import connectDB, { getCollectionCountWithTimeout, getDataWithTimeout } from '../../config/db.js';
+import { STYPHI_PERSONAL_FIELDS_EXCLUSION, stripPersonalFields } from '../../config/personalFields.js';
 
 const router = express.Router();
 
@@ -59,30 +60,10 @@ const readCsvFallback = (filePath, res) => {
       return res.json([]);
     })
     .pipe(csv())
-    .on('data', data => results.push(data))
+    .on('data', data => results.push(stripPersonalFields(data)))
     .on('end', () => {
       return res.json(results);
     });
-};
-
-// Personal / quasi-identifier fields stored on styphi records that are NOT used
-// by any dashboard graph or filter. Excluded from the API payload so they are
-// never shipped to the browser, the public REST API, or the S3 export.
-// NOTE: keep `TRAVEL` (the local/travel/community category) — it drives the
-// dataset filter. These are the patient-level free-text / metadata fields only.
-const STYPHI_PERSONAL_FIELDS_EXCLUSION = {
-  AGE: 0,
-  CONTACT: 0,
-  LAB: 0,
-  'SYMPTOM STATUS': 0,
-  'TRAVEL COUNTRY': 0,
-  'TRAVEL ASSOCIATED': 0,
-  TRAVEL_LOCATION: 0,
-  LOCATION: 0,
-  REGION_IN_COUNTRY: 0,
-  'COUNTRY OF ORIGIN': 0,
-  LATITUDE: 0,
-  LONGITUDE: 0,
 };
 
 // Main organism data endpoints

--- a/routes/api/api.js
+++ b/routes/api/api.js
@@ -65,13 +65,38 @@ const readCsvFallback = (filePath, res) => {
     });
 };
 
+// Personal / quasi-identifier fields stored on styphi records that are NOT used
+// by any dashboard graph or filter. Excluded from the API payload so they are
+// never shipped to the browser, the public REST API, or the S3 export.
+// NOTE: keep `TRAVEL` (the local/travel/community category) — it drives the
+// dataset filter. These are the patient-level free-text / metadata fields only.
+const STYPHI_PERSONAL_FIELDS_EXCLUSION = {
+  AGE: 0,
+  CONTACT: 0,
+  LAB: 0,
+  'SYMPTOM STATUS': 0,
+  'TRAVEL COUNTRY': 0,
+  'TRAVEL ASSOCIATED': 0,
+  TRAVEL_LOCATION: 0,
+  LOCATION: 0,
+  REGION_IN_COUNTRY: 0,
+  'COUNTRY OF ORIGIN': 0,
+  LATITUDE: 0,
+  LONGITUDE: 0,
+};
+
 // Main organism data endpoints
 router.get('/getDataForSTyphi', async function (_req, res) {
   const dbAndCollection = dbAndCollectionNames['styphi'];
   try {
-    const result = await getDataWithTimeout(dbAndCollection.dbName, dbAndCollection.collectionName, {
-      'dashboard view': { $regex: /^include$/, $options: 'i' },
-    });
+    const result = await getDataWithTimeout(
+      dbAndCollection.dbName,
+      dbAndCollection.collectionName,
+      {
+        'dashboard view': { $regex: /^include$/, $options: 'i' },
+      },
+      STYPHI_PERSONAL_FIELDS_EXCLUSION,
+    );
 
     console.log(`[STyphi API] Found ${result.length} documents for STyphi.`);
 

--- a/routes/api/generateDataAPIsFile.js
+++ b/routes/api/generateDataAPIsFile.js
@@ -5,6 +5,7 @@ import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
 import zlib from 'zlib';
 import { client } from '../../config/db.js';
+import { STYPHI_PERSONAL_FIELDS_EXCLUSION } from '../../config/personalFields.js';
 import * as Tools from '../../services/services.js';
 
 const { createObjectCsvWriter: createCsvWriter } = pkg;
@@ -44,7 +45,10 @@ router.post('/download', async function (req, res, next) {
   }
   let data;
   try {
-    data = await collection.find({}).toArray();
+    // Exclude styphi patient-level fields from the export (no-op for other
+    // organisms, which do not carry these fields).
+    const findOptions = organism === 'styphi' ? { projection: STYPHI_PERSONAL_FIELDS_EXCLUSION } : {};
+    data = await collection.find({}, findOptions).toArray();
     console.log('2', data.length, 'documents found');
   } catch (err) {
     console.error('Error querying MongoDB:', err);
@@ -170,7 +174,9 @@ router.get('/generate/:organism', async function (req, res, next) {
   }
 
   try {
-    const queryResult = await collection.find().toArray();
+    // Exclude styphi patient-level fields (no-op for other organisms).
+    const findOptions = organism === 'styphi' ? { projection: STYPHI_PERSONAL_FIELDS_EXCLUSION } : {};
+    const queryResult = await collection.find({}, findOptions).toArray();
     if (queryResult.length > 0) {
       // Remove the '_id' field from each document
       const sanitizedData = queryResult.map(doc => {
@@ -244,10 +250,12 @@ router.get('/clean/:organism', async function (req, res, next) {
   }
 
   try {
+    // Exclude styphi patient-level fields (no-op for other organisms).
+    const findOptions = organism === 'styphi' ? { projection: STYPHI_PERSONAL_FIELDS_EXCLUSION } : {};
     const queryResult = await client
       .db(`${database}`)
       .collection(`merge_rawdata_${collection_ext}`)
-      .find({ 'dashboard view': 'Include' })
+      .find({ 'dashboard view': 'Include' }, findOptions)
       .toArray();
     console.log('queryResult', queryResult.length);
     if (queryResult.length > 0) {

--- a/routes/api/publicApi.js
+++ b/routes/api/publicApi.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import connectDB from '../../config/db.js';
+import { STYPHI_PERSONAL_FIELDS_EXCLUSION } from '../../config/personalFields.js';
 
 const router = express.Router();
 
@@ -188,7 +189,12 @@ router.get('/organisms/:organism/genomes', async (req, res) => {
     const col = client.db(db).collection(collection);
     const [total, data] = await Promise.all([
       col.countDocuments(match),
-      col.find(match).project({ _id: 0, 'dashboard view': 0 }).skip(skip).limit(limit).toArray(),
+      col
+        .find(match)
+        .project({ _id: 0, 'dashboard view': 0, ...STYPHI_PERSONAL_FIELDS_EXCLUSION })
+        .skip(skip)
+        .limit(limit)
+        .toArray(),
     ]);
 
     res.json({
@@ -273,7 +279,10 @@ router.get('/organisms/:organism/download', async (req, res) => {
   try {
     const client = await connectDB();
     const col = client.db(db).collection(collection);
-    const data = await col.find(match).project({ _id: 0, 'dashboard view': 0 }).toArray();
+    const data = await col
+      .find(match)
+      .project({ _id: 0, 'dashboard view': 0, ...STYPHI_PERSONAL_FIELDS_EXCLUSION })
+      .toArray();
 
     if (format === 'csv') {
       if (data.length === 0) return res.status(204).send();

--- a/scripts/gdpr-field-check.mjs
+++ b/scripts/gdpr-field-check.mjs
@@ -1,0 +1,199 @@
+/**
+ * GDPR field-population check for AMRnet.
+ *
+ * For each organism collection, reports:
+ *   - total documents
+ *   - how many docs have a NON-EMPTY value for each potentially-personal field
+ *     (AGE, LATITUDE, LONGITUDE, CONTACT, TRAVEL COUNTRY, etc.)
+ *   - LATITUDE/LONGITUDE granularity: distinct coordinate pairs vs distinct
+ *     countries, plus sample values, to tell country-centroids (safe) apart
+ *     from sub-national point coordinates (re-identification risk).
+ *
+ * Read-only. Makes no writes. Run against the production/staging Atlas:
+ *
+ *   MONGODB_URI="mongodb+srv://..." node scripts/gdpr-field-check.mjs
+ *
+ * (or rely on .env / your existing environment if MONGODB_URI is already set)
+ */
+
+import { MongoClient } from 'mongodb';
+
+const URI = process.env.MONGODB_URI;
+if (!URI) {
+  console.error('ERROR: set MONGODB_URI before running.');
+  process.exit(1);
+}
+
+// Same map the API uses (routes/api/api.js)
+const COLLECTIONS = {
+  styphi: { dbName: 'styphi', collectionName: 'amrnetdb_styphi' },
+  kpneumo: { dbName: 'kpneumo', collectionName: 'amrnetdb_kpneumo' },
+  ngono: { dbName: 'ngono', collectionName: 'amrnetdb_ngono' },
+  ecoli: { dbName: 'ecoli', collectionName: 'amrnetdb_ecoli' },
+  decoli: { dbName: 'decoli', collectionName: 'amrnetdb_decoli' },
+  shige: { dbName: 'shige', collectionName: 'amrnetdb_shige' },
+  senterica: { dbName: 'senterica', collectionName: 'amrnetdb_senterica' },
+  sentericaints: { dbName: 'sentericaints', collectionName: 'amrnetdb_ints' },
+  saureus: { dbName: 'saureus', collectionName: 'amrnetdb_saureus' },
+  strepneumo: { dbName: 'strepneumo', collectionName: 'amrnetdb_spneumo' },
+};
+
+// Potentially-personal / quasi-identifier fields to probe (exact DB names).
+const FIELDS = [
+  'AGE',
+  'LATITUDE',
+  'LONGITUDE',
+  'CONTACT',
+  'LAB',
+  'SYMPTOM STATUS',
+  'TRAVEL',
+  'TRAVEL COUNTRY',
+  'TRAVEL ASSOCIATED',
+  'TRAVEL_LOCATION',
+  'LOCATION',
+  'REGION_IN_COUNTRY',
+  'COUNTRY OF ORIGIN',
+];
+
+// Values that count as "empty" / placeholder (case-insensitive for strings).
+const PLACEHOLDERS = ['', '-', 'na', 'n/a', 'unknown', 'not provided', 'null', 'none', 'not available'];
+
+// Build a $group spec: one counter per field = docs where field is non-empty.
+// A missing field compares equal to null in aggregation, so it is counted as empty.
+function presenceCounters() {
+  const spec = { _id: null, __total: { $sum: 1 } };
+  for (const f of FIELDS) {
+    const ref = '$' + f;
+    spec['f_' + f] = {
+      $sum: {
+        $cond: [
+          {
+            $and: [
+              // field must actually exist (missing fields must NOT count as present)
+              { $ne: [{ $type: ref }, 'missing'] },
+              { $ne: [ref, null] },
+              // normalise strings: trim + lowercase, then check against placeholders
+              {
+                $not: [
+                  {
+                    $in: [
+                      {
+                        $cond: [
+                          { $eq: [{ $type: ref }, 'string'] },
+                          { $toLower: { $trim: { input: ref } } },
+                          ref, // non-strings (e.g. numeric AGE/LAT) are "present" unless null
+                        ],
+                      },
+                      PLACEHOLDERS,
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          1,
+          0,
+        ],
+      },
+    };
+  }
+  return spec;
+}
+
+function pct(n, total) {
+  if (!total) return '0%';
+  return ((100 * n) / total).toFixed(1) + '%';
+}
+
+async function checkGranularity(coll) {
+  // Distinct coordinate pairs vs distinct countries → centroid vs point.
+  const countryField = ['COUNTRY_ONLY', 'COUNTRY OF ORIGIN', 'COUNTRY ISOLATED', 'COUNTRY'];
+  let distinctCountries = null;
+  for (const cf of countryField) {
+    try {
+      const vals = await coll.distinct(cf);
+      if (vals.length) {
+        distinctCountries = { field: cf, n: vals.length };
+        break;
+      }
+    } catch {
+      /* field absent */
+    }
+  }
+
+  const pairs = await coll
+    .aggregate([
+      { $match: { LATITUDE: { $nin: [null, ''] }, LONGITUDE: { $nin: [null, ''] } } },
+      { $group: { _id: { lat: '$LATITUDE', lon: '$LONGITUDE' } } },
+      { $count: 'n' },
+    ])
+    .toArray();
+  const distinctPairs = pairs[0]?.n ?? 0;
+
+  const samples = await coll
+    .find({ LATITUDE: { $nin: [null, ''] } }, { projection: { _id: 0, LATITUDE: 1, LONGITUDE: 1 } })
+    .limit(5)
+    .toArray();
+
+  return { distinctCountries, distinctPairs, samples };
+}
+
+async function main() {
+  const client = new MongoClient(URI);
+  await client.connect();
+  console.log('Connected. Running GDPR field-population check (read-only)…\n');
+
+  for (const [org, { dbName, collectionName }] of Object.entries(COLLECTIONS)) {
+    const coll = client.db(dbName).collection(collectionName);
+    let agg;
+    try {
+      agg = await coll.aggregate([{ $group: presenceCounters() }]).toArray();
+    } catch (e) {
+      console.log(`\n=== ${org} (${dbName}.${collectionName}) — ERROR: ${e.message} ===`);
+      continue;
+    }
+    const r = agg[0];
+    if (!r) {
+      console.log(`\n=== ${org} (${dbName}.${collectionName}) — 0 documents ===`);
+      continue;
+    }
+    const total = r.__total;
+    console.log(`\n=== ${org}  (${dbName}.${collectionName})  —  ${total} docs ===`);
+    for (const f of FIELDS) {
+      const n = r['f_' + f] ?? 0;
+      if (n > 0) {
+        const flag = n > 0 ? '  ⚠️ POPULATED' : '';
+        console.log(`   ${f.padEnd(20)} ${String(n).padStart(7)} non-empty  (${pct(n, total)})${flag}`);
+      } else {
+        console.log(`   ${f.padEnd(20)} ${String(0).padStart(7)} non-empty  (empty / unused)`);
+      }
+    }
+
+    // Geo granularity only if any LAT present
+    if ((r['f_LATITUDE'] ?? 0) > 0) {
+      const g = await checkGranularity(coll);
+      console.log(`   --- geo granularity ---`);
+      if (g.distinctCountries) {
+        console.log(`   distinct countries (${g.distinctCountries.field}): ${g.distinctCountries.n}`);
+      }
+      console.log(`   distinct LAT/LONG pairs: ${g.distinctPairs}`);
+      const ratio =
+        g.distinctCountries && g.distinctCountries.n
+          ? (g.distinctPairs / g.distinctCountries.n).toFixed(1)
+          : 'n/a';
+      console.log(
+        `   pairs-per-country ratio: ${ratio}  ` +
+          `(≈1 → country/region centroids = low risk; ≫1 → sub-national points = re-id risk)`,
+      );
+      console.log(`   sample coords: ${JSON.stringify(g.samples)}`);
+    }
+  }
+
+  await client.close();
+  console.log('\nDone.');
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Removes patient-level / quasi-identifier fields from every API path that serves **S. Typhi** data. A database scan (dev + prod, identical) confirmed styphi is the **only** organism where these fields are populated — the other 9 carry none.

Previously `/getDataForSTyphi` returned full documents with **no projection**, shipping patient metadata to the browser, the public REST API, and the S3 export. The client-side `columnsToRemove` only filtered the CSV download **after** the data had already left the server.

### Fields excluded
`AGE`, `CONTACT`, `LAB`, `SYMPTOM STATUS`, `TRAVEL COUNTRY`, `TRAVEL ASSOCIATED`, `TRAVEL_LOCATION`, `LOCATION`, `REGION_IN_COUNTRY`, `COUNTRY OF ORIGIN`, `LATITUDE`, `LONGITUDE`.

`TRAVEL` (the local/travel/community **category**) is intentionally kept — it drives the dashboard dataset filter and is not free-text/personal. All genomic/AMR columns are preserved.

## Changes

| Path | File |
|---|---|
| New single source of truth (field list, exclusion projection, `stripPersonalFields()`) | `config/personalFields.js` |
| Optional `projection` arg (backward-compatible) | `config/db.js` |
| Dashboard `/getDataForSTyphi` + TSV fallback | `routes/api/api.js` |
| Public API `/v1/.../genomes` and `/download` | `routes/api/publicApi.js` |
| S3 export `/download`, `/generate`, `/clean` | `routes/api/generateDataAPIsFile.js` |

Out of scope (intentionally): `generateDataClean.js` is an ETL job that writes to collections (source of truth, not an exposure endpoint); `optimized.js` has no styphi route; `aggregations.js` only does `$group` (no row-level data).

## Verification

- DB scan tool added at `scripts/gdpr-field-check.mjs` (read-only). Confirmed only styphi has these fields populated (AGE 34%, CONTACT 77%, SYMPTOM STATUS 47%, sub-national LOCATION/REGION 31%, etc.); no `LATITUDE`/`LONGITUDE` stored anywhere.
- Projection tested against a real styphi doc (dev + prod): personal fields removed (e.g. `AGE`, `CONTACT`, `TRAVEL COUNTRY`), all functional fields preserved (`GENOTYPE`, `COUNTRY_ONLY`, `DATE`, `TRAVEL`, `PMID`, AMR columns, `MDR`/`XDR`). 0 personal leaked, 0 functional dropped.
- `node --check` passes on all changed files; `personalFields.js` imports and `stripPersonalFields()` behaves correctly.

## Notes / follow-ups (not in this PR)

- Endpoints remain unauthenticated with open CORS — access control is a separate task.
- Privacy notice + DPIA (scoped to styphi) still recommended.
- Licensing confirmations with Warwick (EnteroBase) and CGPS (Pathogenwatch) are tracked separately.
