### PR TITLE
chore(data-governance): GLASS direct from WHO only; hold literature aggregation pending protocol

### DIFF
--- a/client/src/components/Elements/Graphs/ATBCorrelationGraph/ATBCorrelationGraph.js
+++ b/client/src/components/Elements/Graphs/ATBCorrelationGraph/ATBCorrelationGraph.js
@@ -37,6 +37,7 @@ import { useStyles } from './ATBCorrelationGraphMUI';
 
 // WHO GLASS public-facing landing pages — used for the Data Sources panel.
 const GLASS_AMU_URL = 'https://www.who.int/data/gho/data/themes/topics/global-antimicrobial-resistance-and-use-surveillance-system-glass-database';
+const WHO_TERMS_URL = 'https://www.who.int/about/policies/publishing/data-policy/terms-and-conditions';
 const AMRNET_DOCS_URL = 'https://amrnet.readthedocs.io';
 
 // Dynamic color palette for regions (AMRnet uses UN sub-regions from UNR data)
@@ -452,7 +453,8 @@ export const ATBCorrelationGraph = ({ showFilter, setShowFilter }) => {
                   <a href={GLASS_AMU_URL} target="_blank" rel="noopener noreferrer">WHO GLASS-AMC via GHO OData API</a>{' '}
                   ({dataSource === 'glass'
                     ? `${glassData?.consumption?.length || 0} country-year records, 2016–2023`
-                    : 'static fallback, 16 countries, 2020'}). Total antibiotic consumption in DDD/1000 inhabitants/day. GLASS publishes TOTAL consumption, not per-class — so the X value is the same for every ATB class for a given country.
+                    : 'static fallback, 16 countries, 2020'}). Total antibiotic consumption in DDD/1000 inhabitants/day. GLASS publishes TOTAL consumption, not per-class — so the X value is the same for every ATB class for a given country. Obtained directly from WHO and used under the{' '}
+                  <a href={WHO_TERMS_URL} target="_blank" rel="noopener noreferrer">WHO data terms and conditions</a>.
                   <br /><br />
                   <strong>Genomic Resistance (Y):</strong>{' '}
                   <a href={AMRNET_DOCS_URL} target="_blank" rel="noopener noreferrer">AMRnet</a> genome-derived call. Per country: count of genomes resistant to <em>any</em> AMRnet drug in the selected ATB class

--- a/client/src/components/Elements/Graphs/GenomicVsPhenotypicGraph/GenomicVsPhenotypicGraph.js
+++ b/client/src/components/Elements/Graphs/GenomicVsPhenotypicGraph/GenomicVsPhenotypicGraph.js
@@ -53,15 +53,26 @@ import { useStyles } from './GenomicVsPhenotypicGraphMUI';
 // Public-facing source landing pages used by the Data Sources panel.
 const SOURCE_URLS = {
   glass: 'https://www.who.int/data/gho/data/themes/topics/global-antimicrobial-resistance-and-use-surveillance-system-glass-database',
+  whoTerms: 'https://www.who.int/about/policies/publishing/data-policy/terms-and-conditions',
   ecdc: 'https://www.ecdc.europa.eu/en/antimicrobial-resistance/surveillance-and-disease-data/data-ecdc',
   amrnet: 'https://amrnet.readthedocs.io',
 };
 
+// Data-governance hold: the bundled "literature" phenotypic AMR datasets are
+// disabled in the dashboard until an agreed identification/aggregation protocol
+// exists (how each value was found, breakpoint harmonisation, per-value
+// provenance, and how a user can verify a number). Blindly combining phenotypic
+// AMR from heterogeneous literature is not yet methodologically signed off.
+// Flip to `true` to re-enable once that protocol is in place. The JSON files and
+// all rendering code are kept intact so this is a one-line reversal.
+const LITERATURE_ENABLED = false;
+
 // Organisms that have bundled literature surveillance data
-const LITERATURE_ORGANISMS = new Set([
-  'styphi', 'ecoli', 'kpneumo', 'saureus',
-  'senterica', 'sentericaints', 'decoli', 'shige', 'ngono', 'strepneumo',
-]);
+const LITERATURE_ORGANISMS = new Set(
+  LITERATURE_ENABLED
+    ? ['styphi', 'ecoli', 'kpneumo', 'saureus', 'senterica', 'sentericaints', 'decoli', 'shige', 'ngono', 'strepneumo']
+    : [],
+);
 
 // Lookup map: organism → raw JSON (null = handled separately for styphi)
 // senterica and sentericaints share the same Salmonella CIP dataset
@@ -79,6 +90,7 @@ const LITERATURE_RAW = {
 
 // Default phenoSource per organism
 function defaultPhenoSource(organism) {
+  if (!LITERATURE_ENABLED) return 'glass';
   if (organism === 'styphi') return 'typhi_literature';
   if (LITERATURE_ORGANISMS.has(organism)) return 'literature';
   return 'glass';
@@ -961,6 +973,10 @@ export const GenomicVsPhenotypicGraph = ({ showFilter, setShowFilter }) => {
                       <a href={SOURCE_URLS.glass} target="_blank" rel="noopener noreferrer">
                         WHO GLASS
                       </a> — {glassIndicator?.label || 'Global Antimicrobial Resistance and Use Surveillance System'}.
+                      {' '}Obtained directly from WHO (GHO OData API) and used under the{' '}
+                      <a href={SOURCE_URLS.whoTerms} target="_blank" rel="noopener noreferrer">
+                        WHO data terms and conditions
+                      </a>.
                     </>
                   ) : (
                     <>

--- a/client/src/data/glass_data.js
+++ b/client/src/data/glass_data.js
@@ -129,16 +129,11 @@ export async function fetchGLASSData() {
 
   lastFetchTime = now;
 
-  // Also fetch the compiled GLASS phenotypic CSV
-  try {
-    const phenoResponse = await fetch('/api/glass-phenotypic');
-    if (phenoResponse.ok) {
-      glassDataCache.phenotypic = await phenoResponse.json();
-    }
-  } catch (err) {
-    console.warn('[GLASS] Failed to fetch phenotypic CSV:', err.message);
-    glassDataCache.phenotypic = [];
-  }
+  // The compiled GLASS phenotypic CSV (scraped from the qleclerc/GLASS2022 repo)
+  // was removed on data-governance grounds. Phenotypic AMR now comes only from
+  // the WHO GHO OData indicators above (data.resistance). Kept as an empty array
+  // so downstream consumers (getGLASSPhenotypicByOrganismDrug) stay safe.
+  glassDataCache.phenotypic = [];
 
   return glassDataCache;
 }

--- a/scripts/check-glass-data.js
+++ b/scripts/check-glass-data.js
@@ -2,12 +2,18 @@
 /**
  * Check GLASS data availability and save a copy to MongoDB for offline use.
  * Run: node scripts/check-glass-data.js
+ *
+ * GLASS AMU/AMR is sourced ONLY from the WHO GHO OData API (direct from WHO).
+ * The previous compiled CSV (scraped from the qleclerc/GLASS2022 GitHub repo,
+ * itself extracted from the GLASS 2022 report PDF) was removed on data-governance
+ * grounds — its provenance/status is unclear and GLASS data must come directly
+ * from WHO under the WHO data terms:
+ * https://www.who.int/about/policies/publishing/data-policy/terms-and-conditions
  */
 
 import connectDB from '../config/db.js';
 
 const GHO_API = 'https://ghoapi.azureedge.net/api';
-const GLASS_CSV_URL = 'https://raw.githubusercontent.com/qleclerc/GLASS2022/master/compiled_WHO_GLASS_2022.csv';
 
 const ISO3_TO_COUNTRY = {
   AFG: 'Afghanistan', ALB: 'Albania', DZA: 'Algeria', AGO: 'Angola', ARG: 'Argentina',
@@ -43,28 +49,9 @@ const ISO3_TO_COUNTRY = {
   HKG: 'Hong Kong',
 };
 
-function normalizeCountry(name) {
-  if (!name) return '';
-  const map = {
-    'United Kingdom of Great Britain and Northern Ireland': 'United Kingdom',
-    'Iran (Islamic Republic of)': 'Iran',
-    'Republic of Korea': 'South Korea',
-    'Republic of Moldova': 'Moldova',
-    'Russian Federation': 'Russia',
-    'Viet Nam': 'Vietnam',
-    "Lao People's Democratic Republic": 'Laos',
-    'Türkiye': 'Turkey',
-    'Bolivia (Plurinational State of)': 'Bolivia',
-    'Venezuela (Bolivarian Republic of)': 'Venezuela',
-    'United Republic of Tanzania': 'Tanzania',
-    'Brunei Darussalam': 'Brunei',
-  };
-  return map[name] || name.trim();
-}
-
 // ─────────────────────────────────────────────────────────────
-// 1. Fetch GHO indicators
-// ────────────────────────────────────────────────────────────���
+// Fetch GHO indicators (direct from WHO)
+// ─────────────────────────────────────────────────────────────
 const GHO_INDICATORS = {
   GLASSAMC_TC: 'Total ATB consumption (DDD/1000/day)',
   AMR_INFECT_ECOLI: 'E. coli 3GC resistance (%)',
@@ -96,45 +83,7 @@ async function fetchGHOIndicator(code) {
 }
 
 // ─────────────────────────────────────────────────────────────
-// 2. Fetch GLASS CSV
-// ─────────────────────────────────────────────────────────────
-async function fetchGLASSCSV() {
-  console.log(`  Fetching GLASS CSV from GitHub...`);
-  const res = await fetch(GLASS_CSV_URL);
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  const text = await res.text();
-  const lines = text.split('\n').filter(l => l.trim());
-  const headers = lines[0].split(',').map(h => h.replace(/"/g, '').trim());
-  const data = [];
-
-  for (let i = 1; i < lines.length; i++) {
-    const values = lines[i].split(',').map(v => v.replace(/"/g, '').trim());
-    if (values.length < headers.length) continue;
-    const row = {};
-    headers.forEach((h, j) => { row[h] = values[j]; });
-
-    if (['BLOOD', 'STOOL', 'URINE', 'GENITAL'].includes(row.Specimen)) {
-      data.push({
-        source: 'GLASS_CSV',
-        country: normalizeCountry(row.CountryTerritoryArea),
-        iso3: row.Iso3,
-        region: row.WHORegionName,
-        year: parseInt(row.Year),
-        specimen: row.Specimen,
-        pathogen: row.PathogenName,
-        antibiotic: row.AbTargets,
-        tested: parseInt(row.InterpretableAST) || 0,
-        resistant: parseInt(row.Resistant) || 0,
-        percentResistant: parseFloat(row.PercentResistant) || 0,
-      });
-    }
-  }
-  console.log(`    → ${data.length} records`);
-  return data;
-}
-
-// ─────────────────────────────────────────────────────────────
-// 3. Main
+// Main
 // ─────────────────────────────────────────────────────────────
 async function main() {
   console.log('═══════════════════════════════════════');
@@ -142,9 +91,9 @@ async function main() {
   console.log('═══════════════════════════════════════\n');
 
   // ── Fetch all GHO indicators ──
-  console.log('[1/3] Fetching GHO API indicators...');
+  console.log('[1/2] Fetching GHO API indicators (direct from WHO)...');
   const ghoRecords = [];
-  for (const [code, label] of Object.entries(GHO_INDICATORS)) {
+  for (const [code] of Object.entries(GHO_INDICATORS)) {
     try {
       const records = await fetchGHOIndicator(code);
       ghoRecords.push(...records);
@@ -154,24 +103,12 @@ async function main() {
   }
   console.log(`  Total GHO records: ${ghoRecords.length}\n`);
 
-  // ── Fetch GLASS CSV ──
-  console.log('[2/3] Fetching GLASS CSV (compiled_WHO_GLASS_2022)...');
-  let csvRecords = [];
-  try {
-    csvRecords = await fetchGLASSCSV();
-  } catch (err) {
-    console.error(`  ✗ FAILED: ${err.message}`);
-  }
-
   // ── Summary ──
-  console.log('\n─── Summary ───');
-
-  // GHO consumption
+  console.log('─── Summary ───');
   const consumption = ghoRecords.filter(r => r.indicator === 'GLASSAMC_TC');
   const consumptionCountries = [...new Set(consumption.map(r => r.country))];
   console.log(`Consumption (GLASSAMC_TC): ${consumption.length} records, ${consumptionCountries.length} countries`);
 
-  // GHO resistance
   for (const [code, label] of Object.entries(GHO_INDICATORS)) {
     if (code === 'GLASSAMC_TC') continue;
     const recs = ghoRecords.filter(r => r.indicator === code);
@@ -179,56 +116,8 @@ async function main() {
     console.log(`${label} (${code}): ${recs.length} records, ${countries.length} countries`);
   }
 
-  // CSV pathogens
-  const pathogens = [...new Set(csvRecords.map(r => r.pathogen))].sort();
-  console.log(`\nGLASS CSV pathogens: ${pathogens.join(', ')}`);
-
-  // Per pathogen+antibiotic combos
-  const combos = {};
-  csvRecords.forEach(r => {
-    const key = `${r.pathogen} | ${r.antibiotic} | ${r.specimen}`;
-    if (!combos[key]) combos[key] = { count: 0, countries: new Set() };
-    combos[key].count++;
-    combos[key].countries.add(r.country);
-  });
-
-  console.log('\nGLASS CSV breakdown (pathogen | antibiotic | specimen):');
-  Object.entries(combos)
-    .sort(([, a], [, b]) => b.count - a.count)
-    .forEach(([key, { count, countries }]) => {
-      console.log(`  ${key}: ${count} records, ${countries.size} countries`);
-    });
-
-  // ── Check overlap: consumption + resistance ──
-  console.log('\n─── Consumption × Resistance overlap ───');
-  const consumptionSet = new Set(consumptionCountries);
-
-  const testCombos = [
-    { label: 'Salmonella + Ciprofloxacin (BLOOD)', pathogen: 'Salmonella', antibiotic: 'Ciprofloxacin', specimen: 'BLOOD' },
-    { label: 'Salmonella + Ciprofloxacin (all)', pathogen: 'Salmonella', antibiotic: 'Ciprofloxacin' },
-    { label: 'E. coli + Ciprofloxacin (all)', pathogen: 'Escherichia coli', antibiotic: 'Ciprofloxacin' },
-    { label: 'E. coli + Ceftriaxone (all)', pathogen: 'Escherichia coli', antibiotic: 'Ceftriaxone' },
-    { label: 'K. pneumoniae + Meropenem (BLOOD)', pathogen: 'Klebsiella pneumoniae', antibiotic: 'Meropenem', specimen: 'BLOOD' },
-    { label: 'Shigella + Ciprofloxacin (all)', pathogen: 'Shigella', antibiotic: 'Ciprofloxacin' },
-    { label: 'S. pneumoniae + SXT (all)', pathogen: 'Streptococcus pneumoniae', antibiotic: 'Trimethoprim/sulfamethoxazole' },
-    { label: 'Salmonella + Ampicillin (all)', pathogen: 'Salmonella', antibiotic: 'Ampicillin' },
-    { label: 'Salmonella + Gentamicin (all)', pathogen: 'Salmonella', antibiotic: 'Gentamicin' },
-    { label: 'Salmonella + Ceftriaxone (all)', pathogen: 'Salmonella', antibiotic: 'Ceftriaxone' },
-  ];
-
-  testCombos.forEach(({ label, pathogen, antibiotic, specimen }) => {
-    const resCountries = new Set(
-      csvRecords
-        .filter(r => r.pathogen === pathogen && r.antibiotic === antibiotic && r.tested >= 10 && (!specimen || r.specimen === specimen))
-        .map(r => r.country),
-    );
-    const overlap = [...resCountries].filter(c => consumptionSet.has(c));
-    console.log(`  ${label}: ${resCountries.size} res countries, ${overlap.length} with consumption data`);
-    if (overlap.length > 0 && overlap.length <= 5) console.log(`    → ${overlap.join(', ')}`);
-  });
-
   // ── Save to MongoDB ──
-  console.log('\n[3/3] Saving to MongoDB (amrnet_admin.glass_data)...');
+  console.log('\n[2/2] Saving to MongoDB (amrnet_admin.glass_data)...');
   try {
     const client = await connectDB();
     const db = client.db('amrnet_admin');
@@ -236,19 +125,15 @@ async function main() {
 
     await col.deleteMany({});
 
-    const allRecords = [
-      ...ghoRecords.map(r => ({ ...r, source: 'GHO_API' })),
-      ...csvRecords,
-    ];
+    const allRecords = ghoRecords.map(r => ({ ...r, source: 'GHO_API' }));
 
     if (allRecords.length > 0) {
       await col.insertMany(allRecords);
-      console.log(`  ✓ Saved ${allRecords.length} records (${ghoRecords.length} GHO + ${csvRecords.length} CSV)`);
+      console.log(`  ✓ Saved ${allRecords.length} GHO records`);
     }
 
     // Create indexes
     await col.createIndex({ source: 1, indicator: 1, country: 1 });
-    await col.createIndex({ source: 1, pathogen: 1, antibiotic: 1, country: 1 });
     console.log('  ✓ Indexes created');
   } catch (err) {
     console.error(`  ✗ MongoDB save failed: ${err.message}`);
@@ -256,7 +141,7 @@ async function main() {
 
   console.log('\n═══════════════════════════════════════');
   console.log('  Done!');
-  console.log('════════════════════════════════════��══');
+  console.log('═══════════════════════════════════════');
   process.exit(0);
 }
 

--- a/server.js
+++ b/server.js
@@ -60,92 +60,12 @@ app.use(function (req, res, next) {
   next();
 });
 
-// Normalize GLASS country names to match AMRnet's getCountryDisplayName format
-function normalizeGLASSCountry(name) {
-  if (!name) return '';
-  const map = {
-    'United Kingdom of Great Britain and Northern Ireland': 'United Kingdom',
-    'United States of America': 'United States of America',
-    'Iran (Islamic Republic of)': 'Iran',
-    'Republic of Korea': 'South Korea',
-    'Republic of Moldova': 'Moldova',
-    'Russian Federation': 'Russia',
-    'Viet Nam': 'Vietnam',
-    'Lao People\'s Democratic Republic': 'Laos',
-    'Syrian Arab Republic': 'Syria',
-    'United Republic of Tanzania': 'Tanzania',
-    'Türkiye': 'Turkey',
-    'Czechia': 'Czechia',
-    'Czech Republic': 'Czechia',
-    'Bolivia (Plurinational State of)': 'Bolivia',
-    'Venezuela (Bolivarian Republic of)': 'Venezuela',
-    'Democratic People\'s Republic of Korea': 'North Korea',
-    'Democratic Republic of the Congo': 'Dem. Rep. Congo',
-    'State of Palestine': 'Palestine',
-    'Congo': 'Congo',
-    'Eswatini': 'Eswatini',
-    'Côte d\'Ivoire': "Côte d'Ivoire",
-    'The Netherlands': 'Netherlands',
-    'The Gambia': 'Gambia',
-    'Dominican Republic': 'Dominican Rep.',
-    'Central African Republic': 'Central African Rep.',
-    'Brunei Darussalam': 'Brunei',
-    'Republic of North Macedonia': 'North Macedonia',
-    'Bosnia and Herzegovina': 'Bosnia and Herzegovina',
-    'United Arab Emirates': 'United Arab Emirates',
-    'Saudi Arabia': 'Saudi Arabia',
-  };
-  return map[name] || name.trim();
-}
-
-// GLASS compiled phenotypic data proxy (from qleclerc/GLASS2022 GitHub repo)
-let glassCSVCache = null;
-let glassCSVCacheTime = 0;
-const GLASS_CSV_CACHE_MS = 24 * 60 * 60 * 1000; // 24 hours
-
-app.get('/api/glass-phenotypic', async (req, res) => {
-  try {
-    const now = Date.now();
-    if (glassCSVCache && (now - glassCSVCacheTime) < GLASS_CSV_CACHE_MS) {
-      return res.json(glassCSVCache);
-    }
-    const csvUrl = 'https://raw.githubusercontent.com/qleclerc/GLASS2022/master/compiled_WHO_GLASS_2022.csv';
-    const response = await fetch(csvUrl);
-    if (!response.ok) throw new Error(`GitHub returned ${response.status}`);
-    const text = await response.text();
-    const lines = text.split('\n').filter(l => l.trim());
-    const headers = lines[0].split(',').map(h => h.replace(/"/g, '').trim());
-    const data = [];
-    for (let i = 1; i < lines.length; i++) {
-      const values = lines[i].split(',').map(v => v.replace(/"/g, '').trim());
-      if (values.length < headers.length) continue;
-      const row = {};
-      headers.forEach((h, j) => { row[h] = values[j]; });
-      // Include relevant specimen types for different organisms
-      if (['BLOOD', 'STOOL', 'URINE', 'GENITAL'].includes(row.Specimen)) {
-        data.push({
-          country: normalizeGLASSCountry(row.CountryTerritoryArea),
-          iso3: row.Iso3,
-          region: row.WHORegionName,
-          year: parseInt(row.Year),
-          specimen: row.Specimen,
-          pathogen: row.PathogenName,
-          antibiotic: row.AbTargets,
-          tested: parseInt(row.InterpretableAST) || 0,
-          resistant: parseInt(row.Resistant) || 0,
-          percentResistant: parseFloat(row.PercentResistant) || 0,
-        });
-      }
-    }
-    glassCSVCache = data;
-    glassCSVCacheTime = now;
-    console.log(`[GLASS Phenotypic] Parsed ${data.length} records from GLASS CSV`);
-    res.json(data);
-  } catch (error) {
-    console.error('[GLASS Phenotypic]', error.message);
-    res.status(502).json({ error: 'Failed to fetch GLASS phenotypic data' });
-  }
-});
+// NOTE: The /api/glass-phenotypic proxy (which scraped a third-party compiled
+// CSV of the WHO GLASS 2022 report from the qleclerc/GLASS2022 GitHub repo) was
+// removed on data-governance grounds: the provenance/status of PDF-scraped data
+// is unclear, and GLASS data must be obtained directly from WHO and used under
+// the WHO data terms (https://www.who.int/about/policies/publishing/data-policy/terms-and-conditions).
+// GLASS AMU/AMR is now sourced only from the WHO GHO OData API via /api/gho/:indicator.
 
 // GLASS data from MongoDB (populated by scripts/check-glass-data.js)
 app.get('/api/glass-mongodb', async (req, res) => {


### PR DESCRIPTION
## Summary

Implements the data-reuse / data-governance direction agreed with the PI for the AMR Insights AMU/AMR layer. The principle: only ingest, process, and redistribute data we actually need, sourced under terms we can meet.

## Changes

**1. GLASS sourced directly from WHO only**
- Removed the `/api/glass-phenotypic` proxy (server.js) that fetched a third-party compiled CSV scraped from the GLASS 2022 report PDF (`qleclerc/GLASS2022` GitHub repo) — provenance/status unclear.
- Rewrote `scripts/check-glass-data.js` to load only the WHO **GHO OData** indicators (direct from WHO); dropped the CSV merge.
- `client/src/data/glass_data.js` no longer fetches the compiled CSV; phenotypic AMR now comes only from the WHO GHO indicators already fetched.

**2. Literature aggregation held**
- The bundled per-organism "literature" phenotypic datasets are disabled behind `LITERATURE_ENABLED = false` in the GVP graph, pending an agreed identification/aggregation protocol (search/inclusion criteria, breakpoint harmonisation, per-value provenance, "what does this number mean / how to verify"). JSON files and rendering code are kept intact — re-enabling is one line.

**3. WHO data terms surfaced**
- Added the WHO data terms link (https://www.who.int/about/policies/publishing/data-policy/terms-and-conditions) to the GVP and ATB Data Sources panels.

## Effect on the dashboard

Genomic-vs-phenotypic now relies on WHO-direct GLASS only. Organisms with a direct WHO GHO indicator (E. coli 3GC, MRSA, N. gonorrhoeae) keep their phenotypic comparison; organisms that previously depended on the scraped CSV or literature (kpneumo, NTS, Shigella, dEcoli, S. pneumoniae, Typhi) show "no phenotypic data available" until a vetted source/protocol exists.

## Note / coordination

This overlaps with #425, which re-touches the GVP literature feature. That PR's literature work should be dropped/rebased on top of this, since the literature layer is being held pending protocol.

## Verification

- `node --check` passes on server.js, glass_data.js, check-glass-data.js.
- GVP and ATB JSX parse cleanly.
- No orphaned references to the removed proxy/helpers.
