### PR TITLE
ci: GitHub Actions (client build + lint changed files) + husky pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,12 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# The repo's root .npmrc sets legacy-peer-deps=true, but npm run from client/
+# doesn't read the parent .npmrc, and this dependency tree has peer conflicts
+# (e.g. rodal vs react 18). Set it here so installs resolve like they do locally.
+env:
+  NPM_CONFIG_LEGACY_PEER_DEPS: 'true'
+
 jobs:
   build:
     name: Client build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,87 @@
+name: CI
+
+# Runs on every PR into development/main and on pushes to those branches.
+# Two gates:
+#   1. build         — compiles the client (catches missing deps, broken imports,
+#                      syntax/undefined errors — e.g. an undeclared dom-to-image).
+#   2. lint-changed  — runs ESLint ONLY on the source files changed in the PR, so
+#                      new problems (unused imports, etc.) fail the check without
+#                      drowning in the repo's pre-existing lint backlog.
+#
+# Note: no lockfile is committed (package-lock.json / yarn.lock are gitignored),
+# so we use `npm install` rather than `npm ci`.
+
+on:
+  pull_request:
+    branches: [development, main]
+  push:
+    branches: [development, main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Client build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: client
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+      - name: Install client dependencies
+        run: npm install --no-audit --no-fund
+      - name: Build client
+        # CI=false: don't treat (pre-existing) warnings as errors; we still fail
+        # on real build errors (missing modules, syntax, undefined references).
+        run: CI=false npm run build
+
+  lint-changed:
+    name: Lint changed files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+      - name: Install client dependencies
+        working-directory: client
+        run: npm install --no-audit --no-fund
+      - name: Determine changed client source files
+        id: changed
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+          fi
+          # First push to a branch has an all-zero "before" SHA — fall back to HEAD~1.
+          if [ -z "$BASE" ] || ! git cat-file -e "$BASE" 2>/dev/null; then
+            BASE=$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)
+          fi
+          FILES=$(git diff --name-only --diff-filter=ACMR "$BASE" HEAD -- client/src \
+            | grep -E '\.(js|jsx|ts|tsx)$' \
+            | sed 's#^client/##' || true)
+          {
+            echo "files<<EOF"
+            echo "$FILES"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: ESLint (changed files only, zero tolerance)
+        if: steps.changed.outputs.files != ''
+        working-directory: client
+        env:
+          ESLINT_USE_FLAT_CONFIG: 'false'
+        run: |
+          echo "Linting changed files:"
+          echo "${{ steps.changed.outputs.files }}"
+          npx eslint ${{ steps.changed.outputs.files }} --max-warnings 0
+      - name: No changed source files
+        if: steps.changed.outputs.files == ''
+        run: echo "No client source files changed — nothing to lint."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,20 +31,21 @@ jobs:
   build:
     name: Client build
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: client
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-      - name: Install client dependencies
+      - name: Install dependencies
+        # Install at the repo root. The root `install` script cascades into
+        # client/, and several client imports (compress-json, jspdf, papaparse,
+        # downloadjs, …) live in the ROOT package.json and resolve via Node's
+        # walk-up to root node_modules — same as local dev and Heroku.
         run: npm install --no-audit --no-fund
       - name: Build client
         # CI=false: don't treat (pre-existing) warnings as errors; we still fail
         # on real build errors (missing modules, syntax, undefined references).
-        run: CI=false npm run build
+        run: cd client && CI=false npm run build
 
   lint-changed:
     name: Lint changed files

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+# lint-staged config lives in client/package.json; run it from there so only
+# the staged client files are linted/formatted (eslint --fix + prettier).
+cd client && npx lint-staged

--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
     "ajv": "^8",
     "ajv-keywords": "5.1.0",
     "axios": "^1.6.2",
+    "buffer": "^6.0.3",
     "chroma-js": "3.1.2",
     "color-blind": "0.1.3",
     "color-blind-esm": "0.1.4",
@@ -47,6 +48,7 @@
     "react-tooltip": "^4.2.10",
     "recharts": "^2.12.7",
     "rodal": "^1.8.1",
+    "stream-browserify": "^3.0.0",
     "swiper": "^11.2.2",
     "web-vitals": "^3.5.2"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "db:indexes": "node scripts/create-indexes.js",
     "lint:check": "cd client && npm run lint:check",
     "lint": "cd client && npm run lint",
-    "lint:fix": "cd client && npm run lint:fix"
+    "lint:fix": "cd client && npm run lint:fix",
+    "prepare": "husky install || true"
   },
   "license": "GPL-3.0",
   "dependencies": {
@@ -107,6 +108,7 @@
     "browser-sync": "^3.0.4",
     "concurrently": "^9.2.0",
     "cz-conventional-changelog": "3.0.1",
+    "husky": "^8.0.3",
     "eslint": "^8.57.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^10.1.5",


### PR DESCRIPTION
## Summary

Adds automated checks so PRs are validated without relying on local runs, plus a local pre-commit hook.

### CI — `.github/workflows/ci.yml`
Runs on PRs into `development`/`main` and pushes to those branches:
- **build** — compiles the client (`CI=false npm run build`). Catches missing dependencies, broken imports, syntax and undefined-reference errors — the class of issue that slipped through before (e.g. an imported-but-undeclared `dom-to-image`).
- **lint-changed** — runs ESLint with `--max-warnings 0` **only on the source files changed in the PR**. New problems (unused imports, etc.) fail the check, while the repo's pre-existing lint backlog doesn't block every PR.

Uses `npm install` (no lockfile is committed) and reads the Node version from `.nvmrc`.

### Pre-commit hook — husky + lint-staged
Activates the husky/lint-staged setup that was declared but inactive. On commit, `lint-staged` runs `eslint --fix` + `prettier` on staged client files. The root `prepare` script installs husky on `npm install` (guarded with `|| true` so it never breaks installs/deploys).

## Follow-ups
- Once this is merged and the checks have run once, enable **branch protection** on `development`/`main` requiring `Client build` and `Lint changed files` to pass before merge — that's what actually prevents bad merges.
- Optional: commit a lockfile to enable `npm ci` + Dependabot; add CodeQL.
