### PR TITLE
feat(kpneumo): hide 'Virulence × Resistance Convergence' map in production

### DIFF
--- a/client/src/util/graphCards.js
+++ b/client/src/util/graphCards.js
@@ -17,6 +17,7 @@ import { amrLikeOrganisms, organismsCards } from './organismsCards';
 import { BubbleHPGraph } from '../components/Elements/ContinentPathotypeGraphs/BubbleHPGraph/BubbleHPGraph';
 import { useTranslation } from 'react-i18next';
 import { t } from 'react-i18next';
+import { isProduction } from './env';
 
 function getHeatMapsTitle(organism, t) {
   switch (organism) {
@@ -119,7 +120,9 @@ export function getGraphCards(t){
       description: [''],
       icon: <Coronavirus color="primary" />,
       id: 'CVM',
-      organisms: ['kpneumo'],
+      // 'Virulence × Resistance Convergence' map: kept in dev, hidden in production
+      // (empty organisms in prod → no organism matches → card not rendered).
+      organisms: isProduction() ? [] : ['kpneumo'],
       component: <ConvergenceMapGraph />,
     },
     {


### PR DESCRIPTION
Hides the **CVM** card (ConvergenceMapGraph, title 'Virulence × Resistance Convergence') from kpneumo Summary Plots in **production**, keeping it in dev. Uses the existing `isProduction()` gate — in prod the card's `organisms` list is empty so it isn't rendered. Dev unchanged.

Part of the dashboard feature batch (item 3).