### PR TITLE
chore(husky): pre-commit prettier-only (stop blocking on lint backlog)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -174,11 +174,7 @@
     }
   },
   "lint-staged": {
-    "src/**/*.{js,jsx,ts,tsx}": [
-      "eslint --fix",
-      "prettier --write"
-    ],
-    "src/**/*.{json,css,md}": [
+    "src/**/*.{js,jsx,ts,tsx,json,css,md}": [
       "prettier --write"
     ]
   }


### PR DESCRIPTION
The husky pre-commit hook (added in #428) ran `eslint --fix` via lint-staged. ESLint exits non-zero on any non-fixable error in a staged file, so commits that merely *touch* a file carrying the repo's pre-existing lint backlog get blocked — which would frustrate the whole team. 

This switches lint-staged to **prettier formatting only** on pre-commit. Error-catching stays with the **diff-aware CI lint** job, which fails only on problems introduced on the PR's changed lines (the right place for it given the backlog).