### PR TITLE
feat(shige): rename map view 'Genotype prevalence' → 'ST prevalence'

### DIFF
--- a/client/src/util/mapLegends.js
+++ b/client/src/util/mapLegends.js
@@ -46,13 +46,18 @@ export const mapLegends = [
     value: 'Genotype prevalence',
     label: 'Genotype prevalence',
     labelKey: 'dashboard.mapViews.genotypePrevalence',
-    organisms: organismsCards.map(x => x.value).filter(x => !['sentericaints', 'kpneumo', 'senterica'].includes(x)),
+    // shige uses 'ST prevalence' instead (its GENOTYPE field is the 7-locus ST).
+    organisms: organismsCards
+      .map(x => x.value)
+      .filter(x => !['sentericaints', 'kpneumo', 'senterica', 'shige'].includes(x)),
   },
   {
     value: 'ST prevalence',
     label: 'ST prevalence',
     labelKey: 'dashboard.mapViews.stPrevalence',
-    organisms: ['kpneumo'],
+    // shige's GENOTYPE is the 7-locus MLST ST, so it shows 'ST prevalence'
+    // (same GENOTYPE-column rendering as kpneumo).
+    organisms: ['kpneumo', 'shige'],
   },
   {
     value: 'Lineage prevalence (ST)',


### PR DESCRIPTION
shige's `GENOTYPE` field is the 7-locus MLST ST (e.g. "ST10"), so its map view is relabelled from **'Genotype prevalence'** to **'ST prevalence'**. Implemented in `mapLegends.js` by moving shige into the existing `'ST prevalence'` option (the same value kpneumo uses) and out of `'Genotype prevalence'`. Both render via the GENOTYPE column, and 'ST prevalence' already has full handling across Map/MapFilters/downloads (kpneumo uses it), so no switch-case changes are needed.

Part of the dashboard feature batch (item 4).