### PR TITLE
feat(saureus): Global Filter ALL/MRSA (mecA gene)

### DIFF
--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -183,6 +183,7 @@ export const DashboardPage = () => {
   const organism = useAppSelector(state => state.dashboard.organism);
   const dataset = useAppSelector(state => state.map.dataset);
   const datasetKP = useAppSelector(state => state.map.datasetKP);
+  const datasetSA = useAppSelector(state => state.map.datasetSA);
   const actualTimeInitial = useAppSelector(state => state.dashboard.actualTimeInitial);
   const actualTimeFinal = useAppSelector(state => state.dashboard.actualTimeFinal);
   const actualCountry = useAppSelector(state => state.dashboard.actualCountry);
@@ -1690,6 +1691,7 @@ export const DashboardPage = () => {
         data: storeData,
         dataset,
         datasetKP,
+        datasetSA,
         actualTimeInitial,
         actualTimeFinal,
         organism,
@@ -1913,6 +1915,7 @@ export const DashboardPage = () => {
         actualTimeFinal,
         dataset,
         datasetKP,
+        datasetSA,
         effectiveLineages.join(','),
       ].join('|');
       if (currentGeoKey !== prevGeoFilterKey.current) {

--- a/client/src/components/Dashboard/filters.js
+++ b/client/src/components/Dashboard/filters.js
@@ -174,6 +174,7 @@ export function filterData({
   data,
   dataset,
   datasetKP,
+  datasetSA = 'All',
   actualTimeInitial,
   actualTimeFinal,
   organism,
@@ -189,6 +190,13 @@ export function filterData({
     const columnID = statKeysKP.find(x => x.name === datasetKP).column;
     if (Array.isArray(columnID)) return columnID.some(x => item[x] !== '-');
     return item[columnID] !== '-';
+  };
+  // S. aureus dataset filter: 'MRSA' keeps only genomes carrying the mecA gene
+  // (listed in the comma-separated `Acquired` field). Inert for other organisms.
+  const checkDatasetSA = item => {
+    if (datasetSA === 'All' || organism !== 'saureus') return true;
+    if (datasetSA === 'MRSA') return typeof item.Acquired === 'string' && /(^|,)\s*mecA\b/.test(item.Acquired);
+    return true;
   };
   const checkTime = item => {
     return item.DATE >= actualTimeInitial && item.DATE <= actualTimeFinal;
@@ -215,7 +223,9 @@ export function filterData({
   let listPMID = [];
 
   // Filter
-  const newData = data.filter(x => checkDataset(x) && checkDatasetKP(x) && checkTime(x) && checkLineages(x));
+  const newData = data.filter(
+    x => checkDataset(x) && checkDatasetKP(x) && checkDatasetSA(x) && checkTime(x) && checkLineages(x),
+  );
 
   // Set genotypes, genomes and PMID
   if (actualRegion !== 'All') {

--- a/client/src/components/Elements/Map/TopLeftControls/TopLeftControls.js
+++ b/client/src/components/Elements/Map/TopLeftControls/TopLeftControls.js
@@ -25,7 +25,7 @@ import {
   setCanFilterData,
   setSelectedLineages,
 } from '../../../../stores/slices/dashboardSlice';
-import { setDataset, setDatasetKP } from '../../../../stores/slices/mapSlice.ts';
+import { setDataset, setDatasetKP, setDatasetSA } from '../../../../stores/slices/mapSlice.ts';
 import { amrLikeOrganisms } from '../../../../util/organismsCards';
 import { useStyles } from './TopLeftControlsMUI';
 
@@ -40,6 +40,7 @@ export const TopLeftControls = ({ style, closeButton = null, title }) => {
   const dispatch = useAppDispatch();
   const dataset = useAppSelector(state => state.map.dataset);
   const datasetKP = useAppSelector(state => state.map.datasetKP);
+  const datasetSA = useAppSelector(state => state.map.datasetSA);
   const actualTimeInitial = useAppSelector(state => state.dashboard.actualTimeInitial);
   const actualTimeFinal = useAppSelector(state => state.dashboard.actualTimeFinal);
   const yearsCompleteListToShowInGlobalFilter = useAppSelector(
@@ -83,6 +84,14 @@ export const TopLeftControls = ({ style, closeButton = null, title }) => {
   function handleChangeKP(_event, newValue) {
     if (newValue !== null) {
       dispatch(setDatasetKP(newValue));
+      resetYearRangeToFull();
+      dispatch(setCanFilterData(true));
+    }
+  }
+
+  function handleChangeSA(_event, newValue) {
+    if (newValue !== null) {
+      dispatch(setDatasetSA(newValue));
       resetYearRangeToFull();
       dispatch(setCanFilterData(true));
     }
@@ -188,6 +197,18 @@ export const TopLeftControls = ({ style, closeButton = null, title }) => {
                 </ToggleButton>
                 <ToggleButton value="Carbapenems" color="primary">
                   CARB+
+                </ToggleButton>
+              </ToggleButtonGroup>
+            </div>
+          )}
+          {organism !== 'saureus' ? null : (
+            <div className={classes.datasetWrapper}>
+              <ToggleButtonGroup value={datasetSA} exclusive size="small" onChange={handleChangeSA}>
+                <ToggleButton value="All" color="primary">
+                  {t('common.datasetAll').toUpperCase()}
+                </ToggleButton>
+                <ToggleButton value="MRSA" color="primary">
+                  MRSA
                 </ToggleButton>
               </ToggleButtonGroup>
             </div>

--- a/client/src/components/Elements/ResetButton/ResetButton.js
+++ b/client/src/components/Elements/ResetButton/ResetButton.js
@@ -41,7 +41,7 @@ import {
   setTrendsGraphDrugClass,
   setTrendsGraphView,
 } from '../../../stores/slices/graphSlice';
-import { setDataset, setDatasetKP, setMapView, setPosition } from '../../../stores/slices/mapSlice';
+import { setDataset, setDatasetKP, setDatasetSA, setMapView, setPosition } from '../../../stores/slices/mapSlice';
 import {
   defaultDrugsForDrugResistanceGraphNG,
   defaultDrugsForDrugResistanceGraphSA,
@@ -81,6 +81,7 @@ export const ResetButton = () => {
 
     dispatch(setDataset('All'));
     dispatch(setDatasetKP('All'));
+    dispatch(setDatasetSA('All'));
     dispatch(setActualTimeInitial(yearsCompleteListToShowInGlobalFilter[0]));
     dispatch(
       setActualTimeFinal(yearsCompleteListToShowInGlobalFilter[yearsCompleteListToShowInGlobalFilter.length - 1]),

--- a/client/src/stores/slices/mapSlice.ts
+++ b/client/src/stores/slices/mapSlice.ts
@@ -49,6 +49,7 @@ interface MapState {
   tooltipContent: Object | null;
   dataset: string;
   datasetKP: string;
+  datasetSA: string;
   mapData: Array<MapDataModel>;
   mapRegionData: Array<MapDataModel>;
   mapColoredBy: string;
@@ -68,6 +69,7 @@ const initialState: MapState = {
   tooltipContent: null,
   dataset: '',
   datasetKP: 'All',
+  datasetSA: 'All',
   mapData: [],
   mapRegionData: [],
   mapColoredBy: 'country',
@@ -99,6 +101,9 @@ export const mapSlice = createSlice({
     setDatasetKP: (state, action: PayloadAction<string>) => {
       state.datasetKP = action.payload;
     },
+    setDatasetSA: (state, action: PayloadAction<string>) => {
+      state.datasetSA = action.payload;
+    },
     setMapData: (state, action: PayloadAction<Array<any>>) => {
       state.mapData = action.payload;
     },
@@ -129,6 +134,7 @@ export const {
   setTooltipContent,
   setDataset,
   setDatasetKP,
+  setDatasetSA,
   setLoadingMap,
   setMapData,
   setMapRegionData,


### PR DESCRIPTION
Adds a **Global Filters** dataset toggle for *S. aureus* — **ALL / MRSA** — under 'Applied to all plots', mirroring the kpneumo ESBL/CARB toggle. **MRSA** restricts the dashboard to genomes carrying the **mecA** gene (token match in the comma-separated `Acquired` field; ~21,118 of 35,977 included genomes in the current DB).

Wiring (5 files): `mapSlice` (new `datasetSA` + `setDatasetSA`), `filters.js` (`checkDatasetSA` in the filter chain, guarded to saureus, `datasetSA` defaults to 'All' so existing callers/tests are unaffected), `Dashboard.js` (reads + passes `datasetSA`, added to the geo cache key), `TopLeftControls` (ALL/MRSA toggle shown only for saureus), `ResetButton` (resets to 'All').

Note: filter is mecA specifically per the request; `Methicillin==1` (which also counts mecC) is ~21,302 — slightly broader. Part of the dashboard feature batch (item 6).