### PR TITLE
feat: transpose X/Y axes in 'AMR MARKER BY GENOTYPE' heatmap

### DIFF
--- a/client/src/components/Elements/Graphs/BubbleMarkersHeatmapGraph/BubbleMarkersHeatmapGraph.js
+++ b/client/src/components/Elements/Graphs/BubbleMarkersHeatmapGraph/BubbleMarkersHeatmapGraph.js
@@ -228,9 +228,11 @@ export const BubbleMarkersHeatmapGraph = ({ showFilter, setShowFilter }) => {
     setYAxisSelected(yAxisOptions?.slice(0, 10));
   }, [yAxisOptions]);
 
+  // Transposed layout: rows are markers (yAxisSelected), so the left-hand row
+  // label width is sized to the longest marker name.
   const yAxisWidth = useMemo(() => {
-    return longestVisualWidth(xAxisSelected ?? []);
-  }, [xAxisSelected]);
+    return longestVisualWidth(yAxisSelected ?? []);
+  }, [yAxisSelected]);
 
   const getOptionLabel = useCallback(
     item => {
@@ -329,28 +331,28 @@ export const BubbleMarkersHeatmapGraph = ({ showFilter, setShowFilter }) => {
       return [];
     }
 
-    // For kpneumo, use the original drugs-based structure
+    // For kpneumo, use the original drugs-based structure.
+    // Transposed: one row per marker (yAxisSelected); each row has one cell per
+    // genotype (xAxisSelected) along the X axis.
     if (['kpneumo'].includes(organism)) {
       const itemsData = selectedCRData?.stats[statColumn]?.items || [];
 
-      return xAxisSelected.map(xName => {
-        // Try to find the matching item by name
-        const item = itemsData.find(i => i.name === xName);
+      return yAxisSelected.map(marker => {
+        const itemData = { name: marker, items: [] };
 
-        const itemData = { name: xName, items: [] };
-
-        // Safely access nested drug items, or default to empty array
-        const drugs = item?.drugs?.[bubbleMarkersYAxisType]?.items || [];
-
-        yAxisSelected.forEach(option => {
-          const info = drugs.find(x => x.name === option) || { name: option, count: 0, percentage: 0 };
+        xAxisSelected.forEach(xName => {
+          // Try to find the matching genotype item by name
+          const item = itemsData.find(i => i.name === xName);
+          // Safely access nested drug items, or default to empty array
+          const drugs = item?.drugs?.[bubbleMarkersYAxisType]?.items || [];
+          const info = drugs.find(x => x.name === marker) || { name: marker, count: 0, percentage: 0 };
 
           itemData.items.push({
-            itemName: info.name,
+            itemName: xName,
             percentage: info.percentage,
             count: info.count,
             index: 1,
-            typeName: xName,
+            typeName: marker,
             total: info.count, // No item.totalCount exists here, so fallback to count
           });
         });
@@ -361,31 +363,33 @@ export const BubbleMarkersHeatmapGraph = ({ showFilter, setShowFilter }) => {
 
     // For all other organisms (ngono, styphi, shige, ecoli, decoli, sentrerica, etc.)
     // use genotypesDrugClassesData similar to DeterminantsGraph
+    // Transposed: one row per marker (yAxisSelected); each row has one cell per
+    // genotype (xAxisSelected) along the X axis.
     if (drugClassesData[bubbleMarkersYAxisType]) {
       const data = drugClassesData[bubbleMarkersYAxisType] || [];
 
-      return xAxisSelected.map(xName => {
-        const item = data.find(d => d.name === xName);
+      return yAxisSelected.map(marker => {
+        const itemData = { name: marker, items: [] };
 
-        const itemData = { name: xName, items: [] };
+        xAxisSelected.forEach(xName => {
+          const item = data.find(d => d.name === xName);
 
-        yAxisSelected.forEach(option => {
           let count = 0;
           let percentage = 0;
           let total = 0;
 
           if (item) {
-            count = item[option] || 0;
+            count = item[marker] || 0;
             total = item.totalCount || 0;
             percentage = total ? Number(((count / total) * 100).toFixed(2)) : 0;
           }
 
           itemData.items.push({
-            itemName: option,
+            itemName: xName,
             percentage,
             count,
             index: 1,
-            typeName: xName,
+            typeName: marker,
             total,
           });
         });
@@ -412,7 +416,7 @@ export const BubbleMarkersHeatmapGraph = ({ showFilter, setShowFilter }) => {
               return (
                 <ResponsiveContainer
                   key={`heatmap-graph-${index}`}
-                  width={yAxisWidth + 65 * yAxisSelected.length}
+                  width={yAxisWidth + 65 * xAxisSelected.length}
                   height={index === 0 ? 65 + FIRST_ROW_AXIS_HEIGHT : 65}
                 >
                   <ScatterChart cursor={isTouchDevice() ? 'default' : 'pointer'} margin={{ top: 0, bottom: 0 }}>


### PR DESCRIPTION
Transposes the **AMR Marker by Genotype** heatmap (`BubbleMarkersHeatmapGraph`): rows are now **markers** and the X-axis columns are now **genotypes** (previously the reverse).

- `configuredMapData` (both branches: kpneumo drugs-based and the generic `drugClassesData` one) now builds one row per marker with one cell per genotype; per-cell value lookups are preserved (same data, swapped loop order).
- `yAxisWidth` now sizes to the longest **marker** name (row labels), and chart width scales with the **genotype** count (columns).

⚠️ **Needs visual QA before merge** — this is a layout change to a custom multi-chart recharts heatmap and I couldn't render it in this environment. Please eyeball the heatmap (axes, labels, cell alignment, tooltip) for kpneumo + a non-kpneumo organism. Part of the dashboard feature batch (item 1).