### PR TITLE
feat(shige): LINcode lineage lookup + derivation helper (F5 foundation)

### DIFF
--- a/client/src/data/lincode_shigella_lineages.json
+++ b/client/src/data/lincode_shigella_lineages.json
@@ -1,0 +1,653 @@
+[
+  {
+    "prefix": "0-6-0-1-0-1-2-0-1-2-0",
+    "level": 11,
+    "species": "S. boydii",
+    "numeric": "Sb20",
+    "alias": null
+  },
+  {
+    "prefix": "0-6-0-0-1-0-6-1-4-0-5",
+    "level": 11,
+    "species": "S. boydii",
+    "numeric": "Sb2",
+    "alias": null
+  },
+  {
+    "prefix": "0-36-0-0-0-6-0-0-0-0-0",
+    "level": 11,
+    "species": "S. dysenteriae",
+    "numeric": "linA",
+    "alias": null
+  },
+  {
+    "prefix": "0-6-1-0-3-0-2-0-2-0-0",
+    "level": 11,
+    "species": "S. dysenteriae",
+    "numeric": "Sd16",
+    "alias": null
+  },
+  {
+    "prefix": "0-2-0-0-0-0-0-1-0-150-1",
+    "level": 11,
+    "species": "Shigella sonnei",
+    "numeric": "3.6.1.1.1",
+    "alias": "CipR.SEA"
+  },
+  {
+    "prefix": "0-2-0-0-0-0-0-1-0-1-0",
+    "level": 11,
+    "species": "Shigella sonnei",
+    "numeric": "3.6.1.1.2",
+    "alias": "CipR.MSM5"
+  },
+  {
+    "prefix": "0-2-0-0-0-0-0-0-1-0-1",
+    "level": 11,
+    "species": "Shigella sonnei",
+    "numeric": null,
+    "alias": "OJC"
+  },
+  {
+    "prefix": "0-6-0-1-0-1-3-5-0",
+    "level": 9,
+    "species": "S. boydii",
+    "numeric": "Sb18",
+    "alias": null
+  },
+  {
+    "prefix": "0-6-0-1-0-1-4-0-2",
+    "level": 9,
+    "species": "S. boydii",
+    "numeric": "Sb1",
+    "alias": null
+  },
+  {
+    "prefix": "0-36-0-0-0-3-1-1-6",
+    "level": 9,
+    "species": "S. dysenteriae",
+    "numeric": "Sd1",
+    "alias": null
+  },
+  {
+    "prefix": "0-6-1-0-3-0-3-1-0",
+    "level": 9,
+    "species": "S. dysenteriae",
+    "numeric": "Sd12",
+    "alias": null
+  },
+  {
+    "prefix": "0-12-0-0-1-0-0-0-3",
+    "level": 9,
+    "species": "S. dysenteriae",
+    "numeric": "Sd prov. BEDP 02-5104",
+    "alias": null
+  },
+  {
+    "prefix": "0-6-1-0-2-0-0-0-0",
+    "level": 9,
+    "species": "S. dysenteriae",
+    "numeric": "Sd4",
+    "alias": null
+  },
+  {
+    "prefix": "0-12-0-0-1-0-1-0-1",
+    "level": 9,
+    "species": "S. dysenteriae",
+    "numeric": "Sd2",
+    "alias": null
+  },
+  {
+    "prefix": "0-6-1-0-3-0-0-0-0",
+    "level": 9,
+    "species": "S. dysenteriae",
+    "numeric": "Sd3",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-0-1-0-0-1-0",
+    "level": 9,
+    "species": "Shigella flexneri",
+    "numeric": "1.2.2.5",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-0-1-0-0-87-0",
+    "level": 9,
+    "species": "Shigella flexneri",
+    "numeric": "1.2.2.5.11",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-0-1-0-0-32-0",
+    "level": 9,
+    "species": "Shigella flexneri",
+    "numeric": "1.2.2.5.12",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-0-1-0-0-6-2",
+    "level": 9,
+    "species": "Shigella flexneri",
+    "numeric": "1.2.2.5.4",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-0-1-0-0-7-0",
+    "level": 9,
+    "species": "Shigella flexneri",
+    "numeric": "1.2.2.5.6",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-0-1-0-0-19-2",
+    "level": 9,
+    "species": "Shigella flexneri",
+    "numeric": "1.2.2.5.9",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-1-0-0-1-0-0",
+    "level": 9,
+    "species": "Shigella flexneri",
+    "numeric": "2.1.2.2",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-1-0-0-2-1-0",
+    "level": 9,
+    "species": "Shigella flexneri",
+    "numeric": "2.1.2.5",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-1-0-0-2-0-0",
+    "level": 9,
+    "species": "Shigella flexneri",
+    "numeric": "2.1.2.6",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-1-0-0-0-0-0",
+    "level": 9,
+    "species": "Shigella flexneri",
+    "numeric": "2.1.2.7",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-1-0-0-0-1-0",
+    "level": 9,
+    "species": "Shigella flexneri",
+    "numeric": "2.1.2.7.1",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-0-0-1-0-0-0",
+    "level": 9,
+    "species": "Shigella flexneri",
+    "numeric": "3.1.1.1",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-0-0-0-0-1-0",
+    "level": 9,
+    "species": "Shigella flexneri",
+    "numeric": "3.2.1",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-0-0-0-1-19-1",
+    "level": 9,
+    "species": "Shigella flexneri",
+    "numeric": "3.2.1.3",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-0-0-0-1-0-0",
+    "level": 9,
+    "species": "Shigella flexneri",
+    "numeric": "3.2.1.3.1",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-0-0-0-0-0-0",
+    "level": 9,
+    "species": "Shigella flexneri",
+    "numeric": "3.2.1.5",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-0-0-0-0-155-1",
+    "level": 9,
+    "species": "Shigella flexneri",
+    "numeric": "3.2.1.5.3",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-0-0-0-0-0-1",
+    "level": 9,
+    "species": "Shigella flexneri",
+    "numeric": "3.2.1.5.5",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-0-0-0-0-2-0",
+    "level": 9,
+    "species": "Shigella flexneri",
+    "numeric": "3.2.1.5.5.1",
+    "alias": null
+  },
+  {
+    "prefix": "0-2-0-0-0-0-0-1-5",
+    "level": 9,
+    "species": "Shigella sonnei",
+    "numeric": "3.6.1",
+    "alias": "CipR_parent"
+  },
+  {
+    "prefix": "0-2-0-0-0-0-0-1-2",
+    "level": 9,
+    "species": "Shigella sonnei",
+    "numeric": null,
+    "alias": "Central Asia III"
+  },
+  {
+    "prefix": "0-2-0-0-0-0-0-1-1",
+    "level": 9,
+    "species": "Shigella sonnei",
+    "numeric": "3.6.3",
+    "alias": "Central Asia III"
+  },
+  {
+    "prefix": "0-2-0-0-0-0-0-1-52",
+    "level": 9,
+    "species": "Shigella sonnei",
+    "numeric": null,
+    "alias": "Central Asia III"
+  },
+  {
+    "prefix": "0-2-0-0-0-0-0-0-120",
+    "level": 9,
+    "species": "Shigella sonnei",
+    "numeric": "3.7",
+    "alias": "Global III"
+  },
+  {
+    "prefix": "0-2-0-0-0-0-0-0-130",
+    "level": 9,
+    "species": "Shigella sonnei",
+    "numeric": "3.7.10",
+    "alias": "Global III"
+  },
+  {
+    "prefix": "0-2-0-0-0-0-0-0-14",
+    "level": 9,
+    "species": "Shigella sonnei",
+    "numeric": "3.7.11",
+    "alias": "Global III"
+  },
+  {
+    "prefix": "0-2-0-0-0-0-0-0-113",
+    "level": 9,
+    "species": "Shigella sonnei",
+    "numeric": "3.7.16",
+    "alias": "Global III"
+  },
+  {
+    "prefix": "0-2-0-0-0-0-0-0-21",
+    "level": 9,
+    "species": "Shigella sonnei",
+    "numeric": "3.7.21",
+    "alias": "Global III"
+  },
+  {
+    "prefix": "0-2-0-0-0-0-0-0-17",
+    "level": 9,
+    "species": "Shigella sonnei",
+    "numeric": "3.7.22",
+    "alias": "Global III"
+  },
+  {
+    "prefix": "0-2-0-0-0-0-0-0-5",
+    "level": 9,
+    "species": "Shigella sonnei",
+    "numeric": "3.7.23",
+    "alias": null
+  },
+  {
+    "prefix": "0-2-0-0-0-0-0-0-4",
+    "level": 9,
+    "species": "Shigella sonnei",
+    "numeric": "3.7.25",
+    "alias": "MSM4"
+  },
+  {
+    "prefix": "0-2-0-0-0-0-0-0-158",
+    "level": 9,
+    "species": "Shigella sonnei",
+    "numeric": null,
+    "alias": "VN2.KH1.Aus"
+  },
+  {
+    "prefix": "0-2-0-0-0-0-0-0-132",
+    "level": 9,
+    "species": "Shigella sonnei",
+    "numeric": "3.7.3",
+    "alias": "Global III"
+  },
+  {
+    "prefix": "0-2-0-0-0-0-0-0-138",
+    "level": 9,
+    "species": "Shigella sonnei",
+    "numeric": "3.7.30.1",
+    "alias": "Middle East III"
+  },
+  {
+    "prefix": "0-2-0-0-0-0-0-0-7",
+    "level": 9,
+    "species": "Shigella sonnei",
+    "numeric": "3.7.30.4",
+    "alias": "Israel III"
+  },
+  {
+    "prefix": "0-2-0-0-0-0-0-0-59",
+    "level": 9,
+    "species": "Shigella sonnei",
+    "numeric": "3.7.4",
+    "alias": "Global III"
+  },
+  {
+    "prefix": "0-2-0-0-0-0-0-0-3",
+    "level": 9,
+    "species": "Shigella sonnei",
+    "numeric": "3.7.18",
+    "alias": "Global III"
+  },
+  {
+    "prefix": "0-2-0-0-0-1-0-0",
+    "level": 8,
+    "species": "Shigella sonnei",
+    "numeric": null,
+    "alias": "Latin America IIa"
+  },
+  {
+    "prefix": "0-2-0-0-0-1-0-1",
+    "level": 8,
+    "species": "Shigella sonnei",
+    "numeric": null,
+    "alias": "Latin America IIb"
+  },
+  {
+    "prefix": "0-2-0-0-0-1-0-29",
+    "level": 8,
+    "species": "Shigella sonnei",
+    "numeric": "2.11.4",
+    "alias": null
+  },
+  {
+    "prefix": "0-2-0-0-0-1-0-2",
+    "level": 8,
+    "species": "Shigella sonnei",
+    "numeric": null,
+    "alias": "Latin America IIb"
+  },
+  {
+    "prefix": "0-2-0-0-0-1-0-30",
+    "level": 8,
+    "species": "Shigella sonnei",
+    "numeric": "2.7.1",
+    "alias": null
+  },
+  {
+    "prefix": "0-2-0-0-0-1-0-27",
+    "level": 8,
+    "species": "Shigella sonnei",
+    "numeric": "2.7.3",
+    "alias": null
+  },
+  {
+    "prefix": "0-2-0-0-0-1-0-26",
+    "level": 8,
+    "species": "Shigella sonnei",
+    "numeric": "2.7.4",
+    "alias": null
+  },
+  {
+    "prefix": "0-2-0-0-0-0-0-3",
+    "level": 8,
+    "species": "Shigella sonnei",
+    "numeric": "3.4.1",
+    "alias": "Latin America III"
+  },
+  {
+    "prefix": "0-2-0-0-0-0-0-10",
+    "level": 8,
+    "species": "Shigella sonnei",
+    "numeric": "3.7.28",
+    "alias": "Global III"
+  },
+  {
+    "prefix": "0-2-0-0-0-0-0-4",
+    "level": 8,
+    "species": "Shigella sonnei",
+    "numeric": "3.7.7",
+    "alias": null
+  },
+  {
+    "prefix": "0-2-0-0-0-1-0-3",
+    "level": 8,
+    "species": "Shigella sonnei",
+    "numeric": null,
+    "alias": "Latin America IIb"
+  },
+  {
+    "prefix": "0-3-0-6-0-0-0",
+    "level": 7,
+    "species": "S. boydii",
+    "numeric": "Sb22",
+    "alias": null
+  },
+  {
+    "prefix": "0-6-1-0-0-0-1",
+    "level": 7,
+    "species": "S. dysenteriae",
+    "numeric": "Sd13",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-0-2-2-0",
+    "level": 7,
+    "species": "Shigella flexneri",
+    "numeric": "1.1.5.1",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-0-1-0-5",
+    "level": 7,
+    "species": "Shigella flexneri",
+    "numeric": "1.2.2.2",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-1-0-0-4",
+    "level": 7,
+    "species": "Shigella flexneri",
+    "numeric": "2.1.2",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-1-0-0-3",
+    "level": 7,
+    "species": "Shigella flexneri",
+    "numeric": "2.1.2.4",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-1-1-4-0",
+    "level": 7,
+    "species": "Shigella flexneri",
+    "numeric": "2.3.3.3",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-1-1-0-0",
+    "level": 7,
+    "species": "Shigella flexneri",
+    "numeric": "2.3.5",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-1-1-2-0",
+    "level": 7,
+    "species": "Shigella flexneri",
+    "numeric": "2.3.6.2",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-0-0-1-2",
+    "level": 7,
+    "species": "Shigella flexneri",
+    "numeric": "3.1.1.3",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-0-0-0-26",
+    "level": 7,
+    "species": "Shigella flexneri",
+    "numeric": "3.2.1.1",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-0-0-0-6",
+    "level": 7,
+    "species": "Shigella flexneri",
+    "numeric": "3.2.1.4",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-4-0-0-0",
+    "level": 7,
+    "species": "Shigella flexneri",
+    "numeric": "6.3.1",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-2-1-0-0",
+    "level": 7,
+    "species": "Shigella flexneri",
+    "numeric": "7.3.1",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-2-1-1-0",
+    "level": 7,
+    "species": "Shigella flexneri",
+    "numeric": "7.3.2",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-1-1-1-0",
+    "level": 7,
+    "species": "Shigella flexneri",
+    "numeric": "2.3.8.3",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-0-1-0-2",
+    "level": 7,
+    "species": "Shigella flexneri",
+    "numeric": "1.2.2.4",
+    "alias": null
+  },
+  {
+    "prefix": "0-2-0-0-0-1-2",
+    "level": 7,
+    "species": "Shigella sonnei",
+    "numeric": null,
+    "alias": "Korea II"
+  },
+  {
+    "prefix": "0-2-0-0-0-6-0",
+    "level": 7,
+    "species": "Shigella sonnei",
+    "numeric": "3",
+    "alias": "Lineage III"
+  },
+  {
+    "prefix": "0-2-0-0-0-0-2",
+    "level": 7,
+    "species": "Shigella sonnei",
+    "numeric": "3.1",
+    "alias": null
+  },
+  {
+    "prefix": "0-12-0-1-0",
+    "level": 5,
+    "species": "S. boydii",
+    "numeric": "Sb9",
+    "alias": null
+  },
+  {
+    "prefix": "0-6-0-1-3",
+    "level": 5,
+    "species": "S. boydii",
+    "numeric": "Sb3",
+    "alias": null
+  },
+  {
+    "prefix": "0-12-0-0-2",
+    "level": 5,
+    "species": "S. boydii",
+    "numeric": "Sb15",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-3-1",
+    "level": 5,
+    "species": "Shigella flexneri",
+    "numeric": "4.2",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-3-0",
+    "level": 5,
+    "species": "Shigella flexneri",
+    "numeric": "4.4",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-5-0",
+    "level": 5,
+    "species": "Shigella flexneri",
+    "numeric": "5.2",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-2-0",
+    "level": 5,
+    "species": "Shigella flexneri",
+    "numeric": "7.1",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-2-2",
+    "level": 5,
+    "species": "Shigella flexneri",
+    "numeric": "7.2",
+    "alias": null
+  },
+  {
+    "prefix": "0-3-0-6-0",
+    "level": 5,
+    "species": "Shigella flexneri",
+    "numeric": "9",
+    "alias": null
+  },
+  {
+    "prefix": "0-0-4",
+    "level": 3,
+    "species": "S. dysenteriae",
+    "numeric": "8",
+    "alias": null
+  }
+]

--- a/client/src/data/lincode_shigella_lineages.tsv
+++ b/client/src/data/lincode_shigella_lineages.tsv
@@ -1,0 +1,116 @@
+species	lineage_label	serotype	prefix	level	n_correct	n_prefix_total	purity
+S. boydii	Sb20	Sb20	0-6-0-1-0-1-2-0-1-2-0	l11	8	8	1
+S. boydii	Sb2	Sb2	0-6-0-0-1-0-6-1-4-0-5	l11	7	7	1
+S. boydii	Sb9	Sb9	0-12-0-1-0	l5	5	5	1
+S. boydii	Sb3	Sb3	0-6-0-1-3	l5	12	13	0.923
+S. boydii	Sb15	Sb15	0-12-0-0-2	l5	11	12	0.917
+S. boydii	Sb22	Sb22	0-3-0-6-0-0-0	l7	37	41	0.902
+S. boydii	Sb18	Sb18	0-6-0-1-0-1-3-5-0	l9	9	9	1
+S. boydii	Sb1	Sb1	0-6-0-1-0-1-4-0-2	l9	6	6	1
+S. dysenteriae	linA	Sd_unknown	0-36-0-0-0-6-0-0-0-0-0	l11	5	5	1
+S. dysenteriae	Sd16	Sd16	0-6-1-0-3-0-2-0-2-0-0	l11	9	10	0.9
+S. dysenteriae	8	8	0-0-4	l3	10	10	1
+S. dysenteriae	Sd13	Sd13	0-6-1-0-0-0-1	l7	7	7	1
+S. dysenteriae	Sd1	Sd1	0-36-0-0-0-3-1-1-6	l9	29	29	1
+S. dysenteriae	Sd12	Sd12	0-6-1-0-3-0-3-1-0	l9	14	14	1
+S. dysenteriae	Sd prov. BEDP 02-5104	Sd prov. BEDP 02-5104	0-12-0-0-1-0-0-0-3	l9	7	7	1
+S. dysenteriae	Sd4	Sd4	0-6-1-0-2-0-0-0-0	l9	5	5	1
+S. dysenteriae	Sd2	Sd2	0-12-0-0-1-0-1-0-1	l9	17	18	0.944
+S. dysenteriae	Sd3	Sd3	0-6-1-0-3-0-0-0-0	l9	11	12	0.917
+Shigella flexneri	4.2	NA	0-3-0-3-1	l5	16	16	1
+Shigella flexneri	4.4	NA	0-3-0-3-0	l5	28	28	1
+Shigella flexneri	5.2	NA	0-3-0-5-0	l5	14	14	1
+Shigella flexneri	7.1	NA	0-3-0-2-0	l5	50	50	1
+Shigella flexneri	7.2	NA	0-3-0-2-2	l5	28	28	1
+Shigella flexneri	9	NA	0-3-0-6-0	l5	14	14	1
+Shigella flexneri	1.1.5.1	NA	0-3-0-0-2-2-0	l7	14	14	1
+Shigella flexneri	1.2.2.2	NA	0-3-0-0-1-0-5	l7	10	10	1
+Shigella flexneri	2.1.2	NA	0-3-0-1-0-0-4	l7	12	12	1
+Shigella flexneri	2.1.2.4	NA	0-3-0-1-0-0-3	l7	10	10	1
+Shigella flexneri	2.3.3.3	NA	0-3-0-1-1-4-0	l7	14	14	1
+Shigella flexneri	2.3.5	NA	0-3-0-1-1-0-0	l7	407	407	1
+Shigella flexneri	2.3.6.2	NA	0-3-0-1-1-2-0	l7	17	17	1
+Shigella flexneri	3.1.1.3	NA	0-3-0-0-0-1-2	l7	13	13	1
+Shigella flexneri	3.2.1.1	NA	0-3-0-0-0-0-26	l7	13	13	1
+Shigella flexneri	3.2.1.4	NA	0-3-0-0-0-0-6	l7	29	29	1
+Shigella flexneri	6.3.1	NA	0-3-0-4-0-0-0	l7	14	14	1
+Shigella flexneri	7.3.1	NA	0-3-0-2-1-0-0	l7	19	19	1
+Shigella flexneri	7.3.2	NA	0-3-0-2-1-1-0	l7	65	65	1
+Shigella flexneri	2.3.8.3	NA	0-3-0-1-1-1-0	l7	55	56	0.982
+Shigella flexneri	1.2.2.4	NA	0-3-0-0-1-0-2	l7	25	27	0.926
+Shigella flexneri	1.2.2.5	NA	0-3-0-0-1-0-0-1-0	l9	48	48	1
+Shigella flexneri	1.2.2.5.11	NA	0-3-0-0-1-0-0-87-0	l9	17	17	1
+Shigella flexneri	1.2.2.5.12	NA	0-3-0-0-1-0-0-32-0	l9	56	56	1
+Shigella flexneri	1.2.2.5.4	NA	0-3-0-0-1-0-0-6-2	l9	37	37	1
+Shigella flexneri	1.2.2.5.6	NA	0-3-0-0-1-0-0-7-0	l9	109	109	1
+Shigella flexneri	1.2.2.5.9	NA	0-3-0-0-1-0-0-19-2	l9	44	44	1
+Shigella flexneri	2.1.2.2	NA	0-3-0-1-0-0-1-0-0	l9	35	35	1
+Shigella flexneri	2.1.2.5	NA	0-3-0-1-0-0-2-1-0	l9	14	14	1
+Shigella flexneri	2.1.2.6	NA	0-3-0-1-0-0-2-0-0	l9	17	17	1
+Shigella flexneri	2.1.2.7	NA	0-3-0-1-0-0-0-0-0	l9	12	12	1
+Shigella flexneri	2.1.2.7.1	NA	0-3-0-1-0-0-0-1-0	l9	11	11	1
+Shigella flexneri	3.1.1.1	NA	0-3-0-0-0-1-0-0-0	l9	50	50	1
+Shigella flexneri	3.2.1	NA	0-3-0-0-0-0-0-1-0	l9	85	85	1
+Shigella flexneri	3.2.1.3	NA	0-3-0-0-0-0-1-19-1	l9	13	13	1
+Shigella flexneri	3.2.1.3.1	NA	0-3-0-0-0-0-1-0-0	l9	639	639	1
+Shigella flexneri	3.2.1.5	NA	0-3-0-0-0-0-0-0-0	l9	138	138	1
+Shigella flexneri	3.2.1.5.3	NA	0-3-0-0-0-0-0-155-1	l9	32	32	1
+Shigella flexneri	3.2.1.5.5	NA	0-3-0-0-0-0-0-0-1	l9	18	18	1
+Shigella flexneri	3.2.1.5.5.1	NA	0-3-0-0-0-0-0-2-0	l9	104	104	1
+Shigella sonnei	CipR.SEA	NA	0-2-0-0-0-0-0-1-0-150-1	l11	28	28	1
+Shigella sonnei	3.6.1.1.1	NA	0-2-0-0-0-0-0-1-0-150-1	l11	28	28	1
+Shigella sonnei	CipR.MSM5	NA	0-2-0-0-0-0-0-1-0-1-0	l11	690	690	1
+Shigella sonnei	3.6.1.1.2	NA	0-2-0-0-0-0-0-1-0-1-0	l11	690	690	1
+Shigella sonnei	OJC	NA	0-2-0-0-0-0-0-0-1-0-1	l11	66	66	1
+Shigella sonnei	Global III OJC	NA	0-2-0-0-0-0-0-0-1-0-1	l11	66	66	1
+Shigella sonnei	Korea II	NA	0-2-0-0-0-1-2	l7	10	10	1
+Shigella sonnei	3	NA	0-2-0-0-0-6-0	l7	10	10	1
+Shigella sonnei	Lineage III	NA	0-2-0-0-0-6-0	l7	10	10	1
+Shigella sonnei	3.1	NA	0-2-0-0-0-0-2	l7	16	16	1
+Shigella sonnei	3.1 (CipR clade)	NA	0-2-0-0-0-0-2	l7	16	16	1
+Shigella sonnei	Latin America IIa	NA	0-2-0-0-0-1-0-0	l8	60	60	1
+Shigella sonnei	Latin America IIb	NA	0-2-0-0-0-1-0-1	l8	26	26	1
+Shigella sonnei	2.11.4	NA	0-2-0-0-0-1-0-29	l8	15	15	1
+Shigella sonnei	Latin America IIb	NA	0-2-0-0-0-1-0-2	l8	20	20	1
+Shigella sonnei	2.7.1	NA	0-2-0-0-0-1-0-30	l8	10	10	1
+Shigella sonnei	2.7.3	NA	0-2-0-0-0-1-0-27	l8	16	16	1
+Shigella sonnei	2.7.4	NA	0-2-0-0-0-1-0-26	l8	12	12	1
+Shigella sonnei	Latin America III	NA	0-2-0-0-0-0-0-3	l8	126	126	1
+Shigella sonnei	3.4.1	NA	0-2-0-0-0-0-0-3	l8	126	126	1
+Shigella sonnei	3.7.28	NA	0-2-0-0-0-0-0-10	l8	11	11	1
+Shigella sonnei	Global III	NA	0-2-0-0-0-0-0-10	l8	11	11	1
+Shigella sonnei	3.7.7	NA	0-2-0-0-0-0-0-4	l8	27	27	1
+Shigella sonnei	Latin America IIb	NA	0-2-0-0-0-1-0-3	l8	21	23	0.913
+Shigella sonnei	CipR_parent	NA	0-2-0-0-0-0-0-1-5	l9	173	173	1
+Shigella sonnei	3.6.1	NA	0-2-0-0-0-0-0-1-5	l9	173	173	1
+Shigella sonnei	Central Asia III	NA	0-2-0-0-0-0-0-1-2	l9	127	127	1
+Shigella sonnei	Central Asia III	NA	0-2-0-0-0-0-0-1-1	l9	356	356	1
+Shigella sonnei	3.6.3	NA	0-2-0-0-0-0-0-1-1	l9	356	356	1
+Shigella sonnei	Central Asia III	NA	0-2-0-0-0-0-0-1-52	l9	54	54	1
+Shigella sonnei	Global III	NA	0-2-0-0-0-0-0-0-120	l9	11	11	1
+Shigella sonnei	3.7	NA	0-2-0-0-0-0-0-0-120	l9	11	11	1
+Shigella sonnei	3.7.10	NA	0-2-0-0-0-0-0-0-130	l9	41	41	1
+Shigella sonnei	Global III	NA	0-2-0-0-0-0-0-0-130	l9	41	41	1
+Shigella sonnei	3.7.11	NA	0-2-0-0-0-0-0-0-14	l9	21	21	1
+Shigella sonnei	Global III	NA	0-2-0-0-0-0-0-0-14	l9	21	21	1
+Shigella sonnei	3.7.16	NA	0-2-0-0-0-0-0-0-113	l9	38	38	1
+Shigella sonnei	Global III	NA	0-2-0-0-0-0-0-0-113	l9	38	38	1
+Shigella sonnei	3.7.21	NA	0-2-0-0-0-0-0-0-21	l9	45	45	1
+Shigella sonnei	Global III	NA	0-2-0-0-0-0-0-0-21	l9	45	45	1
+Shigella sonnei	3.7.22	NA	0-2-0-0-0-0-0-0-17	l9	10	10	1
+Shigella sonnei	Global III	NA	0-2-0-0-0-0-0-0-17	l9	10	10	1
+Shigella sonnei	3.7.23	NA	0-2-0-0-0-0-0-0-5	l9	33	33	1
+Shigella sonnei	3.7.25	NA	0-2-0-0-0-0-0-0-4	l9	277	277	1
+Shigella sonnei	3.7.25 (CipR clade)	NA	0-2-0-0-0-0-0-0-4	l9	277	277	1
+Shigella sonnei	MSM4	NA	0-2-0-0-0-0-0-0-4	l9	277	277	1
+Shigella sonnei	VN2.KH1.Aus	NA	0-2-0-0-0-0-0-0-158	l9	37	37	1
+Shigella sonnei	3.7.3	NA	0-2-0-0-0-0-0-0-132	l9	28	28	1
+Shigella sonnei	Global III	NA	0-2-0-0-0-0-0-0-132	l9	28	28	1
+Shigella sonnei	Middle East III	NA	0-2-0-0-0-0-0-0-138	l9	22	22	1
+Shigella sonnei	3.7.30.1	NA	0-2-0-0-0-0-0-0-138	l9	22	22	1
+Shigella sonnei	Israel III	NA	0-2-0-0-0-0-0-0-7	l9	145	145	1
+Shigella sonnei	3.7.30.4	NA	0-2-0-0-0-0-0-0-7	l9	145	145	1
+Shigella sonnei	3.7.4	NA	0-2-0-0-0-0-0-0-59	l9	15	15	1
+Shigella sonnei	Global III	NA	0-2-0-0-0-0-0-0-59	l9	15	15	1
+Shigella sonnei	3.7.18	NA	0-2-0-0-0-0-0-0-3	l9	238	239	0.996
+Shigella sonnei	Global III	NA	0-2-0-0-0-0-0-0-3	l9	238	239	0.996

--- a/client/src/util/shigeLincode.js
+++ b/client/src/util/shigeLincode.js
@@ -1,0 +1,35 @@
+// Shigella LINcode → lineage derivation.
+//
+// Each shige genome carries a 13-segment `LINcode` (e.g. "0-2-0-0-0-0-0-1-0-1-0").
+// The lookup table (lincode_shigella_lineages.json, generated from the .tsv by
+// scripts/build-shige-lincode-lookup.mjs) maps LINcode prefixes — at a given
+// level (number of segments) — to two lineage dimensions:
+//   - numeric : hierarchical LINcode lineage label (all Shigella species)
+//   - alias   : named lineage alias (S. sonnei only; e.g. "CipR.SEA")
+//
+// A genome matches an entry when its LINcode truncated to `level` segments
+// equals the entry `prefix`. Entries are pre-sorted longest-level-first so the
+// most specific match wins.
+
+import LINEAGES from '../data/lincode_shigella_lineages.json';
+
+function truncateLincode(lincode, level) {
+  if (!lincode || lincode === '-') return null;
+  const segments = lincode.split('-');
+  return segments.length >= level ? segments.slice(0, level).join('-') : null;
+}
+
+/**
+ * Derive the numeric LINcode lineage and the named alias for a genome's LINcode.
+ * @param {string} lincode - the genome's full LINcode (LINcode field)
+ * @returns {{ numeric: string|null, alias: string|null, species: string|null }}
+ */
+export function deriveShigeLincode(lincode) {
+  if (!lincode || lincode === '-') return { numeric: null, alias: null, species: null };
+  for (const entry of LINEAGES) {
+    if (truncateLincode(lincode, entry.level) === entry.prefix) {
+      return { numeric: entry.numeric, alias: entry.alias, species: entry.species };
+    }
+  }
+  return { numeric: null, alias: null, species: null };
+}

--- a/client/src/util/shigeLincode.js
+++ b/client/src/util/shigeLincode.js
@@ -19,16 +19,31 @@ function truncateLincode(lincode, level) {
   return segments.length >= level ? segments.slice(0, level).join('-') : null;
 }
 
+function hasPathovar(pathovar) {
+  return pathovar != null && pathovar !== '' && pathovar !== '-';
+}
+
 /**
- * Derive the numeric LINcode lineage and the named alias for a genome's LINcode.
+ * Derive the numeric LINcode lineage and the named alias for a genome.
+ *
+ * The named alias (e.g. "Global III", "CipR.SEA") is only assigned when the
+ * genome has a pathotype (Pathovar) on record — per the rule that every lincode
+ * alias must carry pathotype information. The numeric LINcode lineage is not
+ * gated on pathovar.
+ *
  * @param {string} lincode - the genome's full LINcode (LINcode field)
+ * @param {string} [pathovar] - the genome's Pathovar (pathotype)
  * @returns {{ numeric: string|null, alias: string|null, species: string|null }}
  */
-export function deriveShigeLincode(lincode) {
+export function deriveShigeLincode(lincode, pathovar) {
   if (!lincode || lincode === '-') return { numeric: null, alias: null, species: null };
   for (const entry of LINEAGES) {
     if (truncateLincode(lincode, entry.level) === entry.prefix) {
-      return { numeric: entry.numeric, alias: entry.alias, species: entry.species };
+      return {
+        numeric: entry.numeric,
+        alias: hasPathovar(pathovar) ? entry.alias : null,
+        species: entry.species,
+      };
     }
   }
   return { numeric: null, alias: null, species: null };

--- a/scripts/build-shige-lincode-lookup.mjs
+++ b/scripts/build-shige-lincode-lookup.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/*
+ * Build the Shigella LINcode → lineage lookup JSON from the source TSV.
+ *
+ *   node scripts/build-shige-lincode-lookup.mjs
+ *
+ * Input : client/src/data/lincode_shigella_lineages.tsv  (source of truth)
+ * Output: client/src/data/lincode_shigella_lineages.json
+ *
+ * Matching rule (see deriveShigeLincode in util/shigeLincode.js): a genome's
+ * 13-segment LINcode is truncated to `level` segments and compared to `prefix`.
+ *
+ * Two "lincode" dimensions are produced per prefix:
+ *   - numeric : the hierarchical LINcode lineage label (e.g. "3.6.1.1.1",
+ *               "2.3.5", "Sb20") — available for all Shigella species.
+ *   - alias   : the named lineage alias (e.g. "CipR.SEA", "Central Asia III")
+ *               — only S. sonnei rows carry these.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const TSV = join(here, '../client/src/data/lincode_shigella_lineages.tsv');
+const OUT = join(here, '../client/src/data/lincode_shigella_lineages.json');
+
+const lines = readFileSync(TSV, 'utf8').trim().split('\n');
+const header = lines[0].split('\t');
+const col = name => header.indexOf(name);
+
+const byPrefix = new Map();
+for (const line of lines.slice(1)) {
+  const f = line.split('\t');
+  const species = f[col('species')];
+  const label = f[col('lineage_label')];
+  const prefix = f[col('prefix')];
+  const level = parseInt(f[col('level')].replace(/^l/, ''), 10);
+  if (!prefix || Number.isNaN(level)) continue;
+
+  let e = byPrefix.get(prefix);
+  if (!e) {
+    e = { prefix, level, species, numeric: null, alias: null };
+    byPrefix.set(prefix, e);
+  }
+
+  const isSonnei = species === 'Shigella sonnei';
+  const startsWithDigit = /^\d/.test(label);
+  if (!isSonnei) {
+    // Non-sonnei: the lineage label IS the lincode (numeric slot), no alias.
+    if (!e.numeric) e.numeric = label;
+  } else if (startsWithDigit) {
+    if (!e.numeric) e.numeric = label;
+  } else if (!e.alias) {
+    e.alias = label;
+  }
+}
+
+// Most-specific (longest level) first, so derivation prefers finer matches.
+const entries = [...byPrefix.values()].sort((a, b) => b.level - a.level);
+
+writeFileSync(OUT, JSON.stringify(entries, null, 2) + '\n');
+console.log(
+  `Wrote ${entries.length} prefixes to ${OUT} ` +
+    `(${entries.filter(e => e.numeric).length} with numeric, ${entries.filter(e => e.alias).length} with alias).`,
+);


### PR DESCRIPTION
**Sub-PR (a) of Feature 5.** Foundation for the shige Lincode feature — the lookup data + derivation, not yet wired into UI.

Per genome, derives two dimensions from the 13-segment `LINcode`:
- **numeric** — hierarchical LINcode lineage label (all Shigella species, e.g. `3.6.1.1.1`, `2.3.5`, `Sb20`)
- **alias** — named lineage alias (**S. sonnei only**, e.g. `CipR.SEA`, `Central Asia III`)

Matching: genome LINcode truncated to an entry's `level` == entry `prefix` (longest-level-first).

Files:
- `client/src/data/lincode_shigella_lineages.tsv` — source of truth (editable)
- `scripts/build-shige-lincode-lookup.mjs` — TSV → JSON converter
- `client/src/data/lincode_shigella_lineages.json` — generated (93 prefixes; 84 numeric, 28 alias)
- `client/src/util/shigeLincode.js` — `deriveShigeLincode(lincode)`

**Coverage** of the current curated table vs the live DB: ~36.5% of shige genomes resolve a numeric lincode, ~23.1% an alias (sonnei). Uncovered genomes show no derived lineage — extend the `.tsv` and re-run the converter to grow it.

Next: **(b)** ST/Lincode/Alias dropdowns on BAMRH/HSG2/GD; **(c)** 'Lincode prevalence' (+ alias for sonnei) map views. Both consume this helper and need visual QA.