### PR TITLE
fix(shige): Lincode prevalence map views read the LINcode field

### DIFF
--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -114,7 +114,7 @@ import {
   markersDrugsSH,
 } from '../../util/drugs';
 import { isProduction } from '../../util/env';
-import { deriveShigeLincode } from '../../util/shigeLincode';
+import { deriveShigeLincode, resolveShigeLincode } from '../../util/shigeLincode';
 import { getContinentGraphCard } from '../../util/graphCards';
 import { DEV_ONLY_ORGANISMS } from '../../util/organismsCards';
 import { AMRInsights } from '../Elements/AMRInsights';
@@ -314,7 +314,7 @@ export const DashboardPage = () => {
     // 'Lincode prevalence' map views can group/aggregate by them.
     if (organism === 'shige' && Array.isArray(responseData)) {
       responseData = responseData.map(item => {
-        const { numeric, alias } = deriveShigeLincode(item.LINcode, item.Pathovar);
+        const { numeric, alias } = deriveShigeLincode(resolveShigeLincode(item), item.Pathovar);
         // null (not '-') so unmatched genomes are skipped by the stats grouping
         // (which ignores falsy values) rather than forming a spurious '-' group.
         return { ...item, lincodeNumeric: numeric ?? null, lincodeAlias: alias ?? null };
@@ -1658,10 +1658,22 @@ export const DashboardPage = () => {
     isApplyingFilters.current = true;
     console.debug('[Dashboard] updateDataOnFilters: start');
     // Use in-memory cache when available — avoids reading all records from IndexedDB on every filter change.
-    const storeData =
+    let storeData =
       cachedOrganismData.current.key === organism && cachedOrganismData.current.data.length > 0
         ? cachedOrganismData.current.data
         : await getItems(organism);
+
+    // shige: the IndexedDB path returns the original records without the LINcode
+    // lineage fields derived in getInfoFromData, so the 'Lincode prevalence' map
+    // views and dropdowns would have nothing to group by. Derive them here too
+    // (idempotent — skips records that already carry the fields).
+    if (organism === 'shige') {
+      storeData = storeData.map(item => {
+        if (item.lincodeNumeric !== undefined) return item;
+        const { numeric, alias } = deriveShigeLincode(resolveShigeLincode(item), item.Pathovar);
+        return { ...item, lincodeNumeric: numeric ?? null, lincodeAlias: alias ?? null };
+      });
+    }
 
     if (organism === 'kpneumo' && convergenceGroupVariable !== currentConvergenceGroupVariable) {
       setCurrentConvergenceGroupVariable(convergenceGroupVariable);

--- a/client/src/components/Elements/Map/MapFilters/MapFilters.js
+++ b/client/src/components/Elements/Map/MapFilters/MapFilters.js
@@ -39,6 +39,8 @@ const excludedViews = [
   'ST prevalence',
   'NG-MAST prevalence',
   'Lineage prevalence (ST)',
+  'Lincode prevalence',
+  'Lincode alias prevalence',
   // 'Resistance prevalence',
 ];
 const mapViewsWithZeroPercentOption = [
@@ -57,6 +59,8 @@ const mapViewsWithZeroPercentOption = [
   'ST prevalence',
   'NG-MAST prevalence',
   'Lineage prevalence (ST)',
+  'Lincode prevalence',
+  'Lincode alias prevalence',
   'Resistance prevalence',
 ];
 
@@ -93,6 +97,9 @@ export const MapFilters = ({ showFilter, setShowFilter }) => {
   );
   const isOPrevalence = useMemo(() => mapView === 'O prevalence', [mapView]);
   const isOHPrevalence = useMemo(() => mapView === 'H prevalence', [mapView]);
+  // shige LINcode lineage views: numeric (all species) and named alias (S. sonnei only).
+  const isLincodePrevalence = useMemo(() => mapView === 'Lincode prevalence', [mapView]);
+  const isLincodeAliasPrevalence = useMemo(() => mapView === 'Lincode alias prevalence', [mapView]);
 
   const organismHasLotsOfGenotypes = useMemo(() => organismsWithLotsGenotypes.includes(organism), [organism]);
 
@@ -105,7 +112,11 @@ export const MapFilters = ({ showFilter, setShowFilter }) => {
           ? 'O_PREV'
           : isOHPrevalence
             ? 'OH_PREV'
-            : 'GENOTYPE';
+            : isLincodePrevalence
+              ? 'LINCODE_NUM'
+              : isLincodeAliasPrevalence
+                ? 'LINCODE_ALIAS'
+                : 'GENOTYPE';
     const items = {};
 
     mapData.forEach(obj => {
@@ -122,7 +133,15 @@ export const MapFilters = ({ showFilter, setShowFilter }) => {
     });
 
     return items;
-  }, [isNGMASTPrevalence, isPathSerPrevalence, isOPrevalence, isOHPrevalence, mapData]);
+  }, [
+    isNGMASTPrevalence,
+    isPathSerPrevalence,
+    isOPrevalence,
+    isOHPrevalence,
+    isLincodePrevalence,
+    isLincodeAliasPrevalence,
+    mapData,
+  ]);
 
   const optionsSelected = useMemo(() => {
     return isNGMASTPrevalence ? customDropdownMapViewNG : prevalenceMapViewOptionsSelected;
@@ -241,6 +260,8 @@ export const MapFilters = ({ showFilter, setShowFilter }) => {
       case 'Pathotype prevalence':
       case 'O prevalence':
       case 'Lineage prevalence (ST)':
+      case 'Lincode prevalence':
+      case 'Lincode alias prevalence':
         return gradientStyle;
       case '':
         return [];
@@ -288,6 +309,10 @@ export const MapFilters = ({ showFilter, setShowFilter }) => {
       return 'NGMAST';
     }
 
+    if (isLincodePrevalence || isLincodeAliasPrevalence) {
+      return 'lineages';
+    }
+
     if (['sentericaints', 'senterica'].includes(organism)) {
       return 'STs';
     }
@@ -296,7 +321,15 @@ export const MapFilters = ({ showFilter, setShowFilter }) => {
     }
 
     return 'genotypes';
-  }, [isOPrevalence, isOHPrevalence, isPathSerPrevalence, isNGMASTPrevalence, organism]);
+  }, [
+    isOPrevalence,
+    isOHPrevalence,
+    isPathSerPrevalence,
+    isNGMASTPrevalence,
+    isLincodePrevalence,
+    isLincodeAliasPrevalence,
+    organism,
+  ]);
 
   const nonResPrevalenceLabel = t(`dashboard.filters.plotOptions.labels.${nonResPrevalenceLabelKey}`);
 

--- a/client/src/util/shigeLincode.js
+++ b/client/src/util/shigeLincode.js
@@ -24,6 +24,26 @@ function hasPathovar(pathovar) {
 }
 
 /**
+ * Resolve the best available LINcode string from a genome record.
+ *
+ * The data does not carry a single `LINcode` field; it carries the LINcode
+ * truncated at fixed levels (`LINcode_11`, `LINcode_9`, ...). We prefer the
+ * finest (most segments) available so the most specific lineage entry can
+ * match, falling back to coarser levels when the finer ones are missing.
+ *
+ * @param {object} item - a genome record
+ * @returns {string|null} the dash-joined LINcode, or null if none present
+ */
+export function resolveShigeLincode(item) {
+  if (!item) return null;
+  const candidates = [item.LINcode_11, item.LINcode_9, item.LINcode_7, item.LINcode_5, item.LINcode_3, item.LINcode];
+  for (const c of candidates) {
+    if (c && c !== '-') return c;
+  }
+  return null;
+}
+
+/**
  * Derive the numeric LINcode lineage and the named alias for a genome.
  *
  * The named alias (e.g. "Global III", "CipR.SEA") is only assigned when the


### PR DESCRIPTION
## Problem
The `Lincode prevalence` and `Lincode alias prevalence` map views (shige) appeared in the menu but plotted nothing — they were reading the wrong field.

## Root cause
1. **Wrong source field.** The derivation read `item.LINcode`, but shige records don't carry a single LINcode field — they carry the LINcode truncated at fixed levels (`LINcode_11`, `LINcode_9`, …). So `lincodeNumeric`/`lincodeAlias` came out null everywhere.
2. **MapFilters not wired.** `GLNPSEntries` defaulted its source column to `GENOTYPE` for the new views, so the option list and the default selection were genotypes that don't exist in the `LINCODE_NUM`/`LINCODE_ALIAS` stats → empty map.

## Fix
- `shigeLincode.js`: add `resolveShigeLincode(item)` to pick the finest available LINcode level (`LINcode_11` → `_9` → …).
- `Dashboard.js`: derive from `resolveShigeLincode(item)` at both injection sites (getInfoFromData + IndexedDB filter path).
- `MapFilters.js`: add the two views to the column resolver (`LINCODE_NUM`/`LINCODE_ALIAS`), the `steps` gradient-legend switch, the excluded-view and zero-percent lists, and label them as lineages.

## Test
- `craco build` passes.
- Diff-aware lint clean on changed lines.
- Manual QA on dev: select shige → Lincode prevalence / Lincode alias prevalence; map now colours countries and the lineage selector populates.