### PR TITLE
fix(shige): colour map countries for Lincode prevalence views

### DIFF
--- a/client/src/components/Elements/Map/Map.js
+++ b/client/src/components/Elements/Map/Map.js
@@ -466,6 +466,8 @@ export const Map = () => {
                           case 'Genotype prevalence':
                           case 'Lineage prevalence (ST)':
                           case 'ST prevalence':
+                          case 'Lincode prevalence':
+                          case 'Lincode alias prevalence':
                           case 'Serotype prevalence':
                           case 'Pathotype prevalence':
                           case 'O prevalence':


### PR DESCRIPTION
## Problem
After #439, the shige **Lincode prevalence** / **Lincode alias prevalence** map views populated the lineage selector and tooltip correctly, but the countries were not coloured.

## Root cause
Map.js has two switches: one builds the tooltip (already lists the Lincode views) and one computes `fillColor`. The fillColor switch did **not** list the two Lincode views, so they fell through to the default (no fill).

## Fix
Add `Lincode prevalence` and `Lincode alias prevalence` to the genotype-prevalence colouring branch, alongside `Genotype prevalence` / `ST prevalence` — same `LINCODE_NUM` / `LINCODE_ALIAS` stats column, same N≥20 rule and red gradient.

## Test
- `craco build` passes.
- Manual QA on dev: shige → Lincode prevalence now colours countries by selected lineage prevalence.