### PR TITLE
fix(shige): Lincode tooltip shows N and % instead of undefined

### DIFF
--- a/client/src/components/Elements/Map/Map.js
+++ b/client/src/components/Elements/Map/Map.js
@@ -280,6 +280,8 @@ export const Map = () => {
       'H prevalence',
       'Pathotype prevalence',
       'ST prevalence',
+      'Lincode prevalence',
+      'Lincode alias prevalence',
       'Resistance prevalence',
       'No. Samples',
       'NG-MAST prevalence',


### PR DESCRIPTION
## Problem
On the shige **Lincode prevalence** / **Lincode alias prevalence** map views, the country tooltip showed `undefined (undefined)` for each selected lineage instead of the N and %.

## Root cause
The genotype-prevalence tooltip branch stores each entry as a preformatted **string** (`"5 (50%)"`). The renderer chooses string-vs-object rendering via `showPercentage()`. The two Lincode views were missing from `showPercentage()`'s string-rendering list, so the renderer treated the string as an object and read `.count`/`.percentage` off it → `undefined`.

## Fix
Add `Lincode prevalence` and `Lincode alias prevalence` to the `showPercentage()` list, alongside `Genotype prevalence` / `ST prevalence` etc.

## Test
- `craco build` passes.
- Manual QA on dev: tooltip now shows `<lineage>: N (P%)`.