### PR TITLE
feat(shige): ST/Lincode/alias dropdown on GENOTYPE TRENDS (GD)

### DIFF
--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -674,6 +674,8 @@ export const DashboardPage = () => {
           dt.uniqueSublineages,
           dt.uniqueNGMAST,
           dt.NGMASTData,
+          dt.lincodeNumericData,
+          dt.lincodeAliasData,
         ];
       }).then(
         ([
@@ -687,6 +689,8 @@ export const DashboardPage = () => {
           uniqueSublineages,
           uniqueNGMAST,
           NGMASTData,
+          lincodeNumericData,
+          lincodeAliasData,
         ]) => {
           const safeGenotypesData = Array.isArray(genotypesData) ? genotypesData : [];
           const safeDrugsData = Array.isArray(drugsData) ? drugsData : [];
@@ -716,6 +720,11 @@ export const DashboardPage = () => {
           } else if (organism === 'ngono') {
             dispatch(setCgSTYearData(NGMASTData));
             // dispatch(setColorPalleteCgST(generatePalleteForGenotypes(uniqueNGMAST)));
+          } else if (organism === 'shige') {
+            // Reuse the cgST/sublineage trend slots for the two LINcode
+            // lineage dimensions (DistributionGraph reads them for shige).
+            dispatch(setCgSTYearData(lincodeNumericData ?? []));
+            dispatch(setSublineagesYearData(lincodeAliasData ?? []));
           }
         },
       ),
@@ -1926,6 +1935,11 @@ export const DashboardPage = () => {
         }
       } else if (organism === 'ngono') {
         dispatch(setCgSTYearData(yearsData.NGMASTData));
+      } else if (organism === 'shige') {
+        // Reuse the cgST/sublineage trend slots for the two LINcode lineage
+        // dimensions (DistributionGraph reads them for shige).
+        dispatch(setCgSTYearData(yearsData.lincodeNumericData ?? []));
+        dispatch(setSublineagesYearData(yearsData.lincodeAliasData ?? []));
       }
 
       // Geographic Comparisons (BubbleGeographicGraph), RadarProfile, and the

--- a/client/src/components/Dashboard/filters.js
+++ b/client/src/components/Dashboard/filters.js
@@ -995,6 +995,9 @@ export function getYearsData({ data, years, organism, getUniqueGenotypes = false
   const NGMASTData = [];
   const cgSTData = [];
   const sublineageData = [];
+  // shige LINcode lineage trends (numeric = all species, alias = S. sonnei)
+  const lincodeNumericData = [];
+  const lincodeAliasData = [];
 
   // Initialize data structures based on organism type
   const initializeDataStructures = rules => {
@@ -1067,6 +1070,22 @@ export function getYearsData({ data, years, organism, getUniqueGenotypes = false
         return acc;
       }, {});
       NGMASTData.push({ ...response, ...NGMASTStats });
+    } else if (organism === 'shige') {
+      // Per-year counts for each LINcode lineage dimension. Falsy values
+      // (unmatched genomes) are skipped so they don't form a spurious group.
+      const lincodeNumericStats = yearData.reduce((acc, x) => {
+        const lin = x.lincodeNumeric;
+        if (lin) acc[lin] = (acc[lin] || 0) + 1;
+        return acc;
+      }, {});
+      lincodeNumericData.push({ ...response, ...lincodeNumericStats });
+
+      const lincodeAliasStats = yearData.reduce((acc, x) => {
+        const alias = x.lincodeAlias;
+        if (alias) acc[alias] = (acc[alias] || 0) + 1;
+        return acc;
+      }, {});
+      lincodeAliasData.push({ ...response, ...lincodeAliasStats });
     }
 
     // Initialize drugStats
@@ -1405,6 +1424,8 @@ export function getYearsData({ data, years, organism, getUniqueGenotypes = false
     genotypesAndDrugsData,
     cgSTData,
     sublineageData,
+    lincodeNumericData: lincodeNumericData.filter(x => x.count > 0),
+    lincodeAliasData: lincodeAliasData.filter(x => x.count > 0),
     uniqueCgST,
     uniqueSublineages,
     uniqueNGMAST,

--- a/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
+++ b/client/src/components/Elements/Graphs/DistributionGraph/DistributionGraph.js
@@ -42,7 +42,11 @@ import {
   setTopXGenotype,
 } from '../../../../stores/slices/graphSlice.ts';
 import { generatePalleteForGenotypes, hoverColor, lightGrey } from '../../../../util/colorHelper';
-import { variableGraphOptions, variableGraphOptionsNG } from '../../../../util/convergenceVariablesOptions';
+import {
+  variableGraphOptions,
+  variableGraphOptionsNG,
+  variableGraphOptionsShige,
+} from '../../../../util/convergenceVariablesOptions';
 import { getRange } from '../../../../util/helpers';
 import { isTouchDevice } from '../../../../util/isTouchDevice';
 import { SelectCountry } from '../../SelectCountry';
@@ -83,6 +87,15 @@ export const DistributionGraph = ({ showFilter, setShowFilter }) => {
 
   const currentData = useMemo(() => {
     const base = (() => {
+      if (organism === 'shige') {
+        // ST (GENOTYPE) trends, or the LINcode dimensions stored in the
+        // cgST/sublineage trend slots (numeric → cgST, alias → sublineage).
+        return distributionGraphVariable === 'lincodeNumeric'
+          ? cgSTYearData
+          : distributionGraphVariable === 'lincodeAlias'
+            ? sublineagesYearData
+            : genotypesYearData;
+      }
       if (organism !== 'kpneumo' && organism !== 'ngono') {
         return genotypesYearData;
       }
@@ -706,7 +719,7 @@ export const DistributionGraph = ({ showFilter, setShowFilter }) => {
                   })}
                 </Select>
               </div>
-              {(organism === 'kpneumo' || organism === 'ngono') && (
+              {(organism === 'kpneumo' || organism === 'ngono' || organism === 'shige') && (
                 <div className={classes.selectWrapper}>
                   <div className={classes.labelWrapper}>
                     <Typography variant="caption">Select variable</Typography>
@@ -718,21 +731,18 @@ export const DistributionGraph = ({ showFilter, setShowFilter }) => {
                     MenuProps={{ classes: { list: classes.selectMenu } }}
                     disabled={organism === 'none'}
                   >
-                    {organism === 'ngono'
-                      ? variableGraphOptionsNG.map((option, index) => {
-                          return (
-                            <MenuItem key={index + 'distribution-variable'} value={option.value}>
-                              {option.label}
-                            </MenuItem>
-                          );
-                        })
-                      : variableGraphOptions.map((option, index) => {
-                          return (
-                            <MenuItem key={index + 'distribution-variable'} value={option.value}>
-                              {option.label}
-                            </MenuItem>
-                          );
-                        })}
+                    {(organism === 'ngono'
+                      ? variableGraphOptionsNG
+                      : organism === 'shige'
+                        ? variableGraphOptionsShige
+                        : variableGraphOptions
+                    ).map((option, index) => {
+                      return (
+                        <MenuItem key={index + 'distribution-variable'} value={option.value}>
+                          {option.label}
+                        </MenuItem>
+                      );
+                    })}
                   </Select>
                 </div>
               )}


### PR DESCRIPTION
## What
Adds the ST / Lincode / Lincode alias variable selector to **DistributionGraph** (GENOTYPE TRENDS) for shige — the third and final plot of F5(b) (HSG2 #438, BAMRH #443).

## How
- `getYearsData` builds per-year LINcode lineage series (`lincodeNumericData`, `lincodeAliasData`) from the injected `lincodeNumeric`/`lincodeAlias` fields.
- Dashboard dispatches them into the cgST / sublineage trend slots for shige — the same slot-reuse pattern ngono already uses for NG-MAST — at both the cached and live `getYearsData` paths.
- DistributionGraph selects the right series by variable for shige and renders the dropdown. `computedTopXGenotype` and the colour palette already derive from `currentData`, so colours follow automatically.

## Notes
- Variable resets to GENOTYPE on organism change (existing behaviour), so no stale kpneumo/ngono value leaks into shige.
- Independent of #443 (different files).

## Test
- `craco build` passes.