### PR TITLE
feat(shige): include Lincode map views in PNG/CSV/PDF downloads

### DIFF
--- a/client/src/components/Elements/DownloadData/PDFPreviewModal.js
+++ b/client/src/components/Elements/DownloadData/PDFPreviewModal.js
@@ -19,7 +19,7 @@ const PDF_MARGIN      = 24;
 const GRADIENT_MAP_VIEWS = [
   'Genotype prevalence', 'Serotype prevalence', 'Pathotype prevalence',
   'O prevalence', 'H prevalence', 'ST prevalence', 'NG-MAST prevalence',
-  'Lineage prevalence (ST)',
+  'Lineage prevalence (ST)', 'Lincode prevalence', 'Lincode alias prevalence',
 ];
 
 // Heatmap graph IDs (BubbleHeatmapGraph2, BubbleMarkersHeatmapGraph, BubbleKOHeatmapGraph)

--- a/client/src/components/Elements/Map/MapActions/DownloadMapSS.js
+++ b/client/src/components/Elements/Map/MapActions/DownloadMapSS.js
@@ -105,6 +105,8 @@ export const DownloadMapSS = async ({
         'Genotype prevalence',
         'Lineage prevalence (ST)',
         'ST prevalence',
+        'Lincode prevalence',
+        'Lincode alias prevalence',
         'Sublineage prevalence',
         'Pathotype prevalence',
         'Serotype prevalence',
@@ -182,6 +184,8 @@ export const DownloadMapSS = async ({
         case 'Genotype prevalence':
         case 'Lineage prevalence (ST)':
         case 'ST prevalence':
+        case 'Lincode prevalence':
+        case 'Lincode alias prevalence':
         case 'Sublineage prevalence':
           legendImg.src = 'legends/MapView_prevalence.png';
           break;

--- a/client/src/components/Elements/Map/MapActions/DownloadMapViewData.js
+++ b/client/src/components/Elements/Map/MapActions/DownloadMapViewData.js
@@ -84,6 +84,8 @@ export const DownloadMapViewData = ({ value }) => {
     const isPathotypeLikeView = ['Serotype prevalence', 'Pathotype prevalence'].includes(mapView);
     const isOPrevLikeView = mapView === 'O prevalence';
     const isOHPrevLikeView = mapView === 'H prevalence';
+    const isLincodeView = mapView === 'Lincode prevalence';
+    const isLincodeAliasView = mapView === 'Lincode alias prevalence';
     // const isGenotypeLikeView = [
     //   'Genotype prevalence',
     //   'ST prevalence',
@@ -137,7 +139,11 @@ export const DownloadMapViewData = ({ value }) => {
                 ? stats.O_PREV
                 : isOHPrevLikeView
                   ? stats.OH_PREV
-                  : stats.GENOTYPE;
+                  : isLincodeView
+                    ? stats.LINCODE_NUM
+                    : isLincodeAliasView
+                      ? stats.LINCODE_ALIAS
+                      : stats.GENOTYPE;
         const items = data?.items || [];
         const sum = data?.sum || 0;
         const foundGenotypes = items.map(x => x.name);


### PR DESCRIPTION
## What
Wires the two shige LINcode map views (**Lincode prevalence**, **Lincode alias prevalence**) into the three map download paths — they previously fell back to genotype handling.

- **PNG** (DownloadMapSS): added to the prevalence-views list (so the selected-lineage caption is drawn) and the gradient legend image switch.
- **CSV** (DownloadMapViewData): the selected-lineage columns now read `LINCODE_NUM` / `LINCODE_ALIAS` instead of defaulting to `GENOTYPE` (which produced all-zero columns). The full per-lineage breakdown was already exported via the generic stats dump.
- **PDF** (PDFPreviewModal): added to `GRADIENT_MAP_VIEWS` so the report renders the orange→dark-red gradient legend.

Completes **F5(c)**. (Geographic Comparisons has its own independent selector and is out of F5 scope.)

## Test
- `craco build` passes.