### PR TITLE
fix(shige): plot AMR marker heatmap (BAMRH) by LINcode lineage

### DIFF
--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -76,6 +76,8 @@ import {
   setGenotypesAndDrugsYearData,
   setGenotypesDrugClassesData,
   setPathotypesDrugClassesData,
+  setLincodeDrugClassesData,
+  setLincodeAliasDrugClassesData,
   setGenotypesDrugsData,
   setGenotypesYearData,
   setKODiversityData,
@@ -623,6 +625,8 @@ export const DashboardPage = () => {
           dt.regionsDrugClassesData,
           dt.ngMastDrugClassesData,
           dt.pathotypesDrugClassesData,
+          dt.lincodeDrugClassesData,
+          dt.lincodeAliasDrugClassesData,
         ];
       }).then(
         ([
@@ -632,6 +636,8 @@ export const DashboardPage = () => {
           regionsDrugClassesData,
           ngMastDrugClassesData,
           pathotypesDrugClassesData,
+          lincodeDrugClassesData,
+          lincodeAliasDrugClassesData,
         ]) => {
           const safeGenotypesDrugsData = Array.isArray(genotypesDrugsData) ? genotypesDrugsData : [];
           dispatch(setGenotypesDrugsData(safeGenotypesDrugsData));
@@ -641,6 +647,8 @@ export const DashboardPage = () => {
           dispatch(setRegionsYearData(regionsDrugClassesData));
           dispatch(setNgMastDrugClassesData(ngMastDrugClassesData));
           dispatch(setPathotypesDrugClassesData(pathotypesDrugClassesData ?? {}));
+          dispatch(setLincodeDrugClassesData(lincodeDrugClassesData ?? {}));
+          dispatch(setLincodeAliasDrugClassesData(lincodeAliasDrugClassesData ?? {}));
         },
       ),
 
@@ -1499,6 +1507,8 @@ export const DashboardPage = () => {
         dispatch(setGenotypesDrugsData([]));
         dispatch(setGenotypesDrugClassesData([]));
         dispatch(setPathotypesDrugClassesData({}));
+        dispatch(setLincodeDrugClassesData({}));
+        dispatch(setLincodeAliasDrugClassesData({}));
         // dispatch(setGenotypesAndDrugsYearData({}));
         dispatch(setKODiversityData([]));
         dispatch(setConvergenceData([]));
@@ -1903,6 +1913,8 @@ export const DashboardPage = () => {
       dispatch(setRegionsYearData(genotypesData.regionsDrugClassesData));
       dispatch(setNgMastDrugClassesData(genotypesData.ngMastDrugClassesData));
       dispatch(setPathotypesDrugClassesData(genotypesData.pathotypesDrugClassesData ?? {}));
+      dispatch(setLincodeDrugClassesData(genotypesData.lincodeDrugClassesData ?? {}));
+      dispatch(setLincodeAliasDrugClassesData(genotypesData.lincodeAliasDrugClassesData ?? {}));
 
       // Dispatch yearly trends data (server preferred, client fallback)
       dispatch(setGenotypesYearData(finalGenotypesData));

--- a/client/src/components/Dashboard/filters.js
+++ b/client/src/components/Dashboard/filters.js
@@ -2030,6 +2030,48 @@ export function getGenotypesData({
     });
   }
 
+  // shige: LINcode lineage marker data for the BAMRH heatmap. Mirrors the
+  // pathotype block but groups by the two derived LINcode dimensions so the
+  // 'AMR marker by genotype' heatmap can plot markers per lineage.
+  const lincodeDrugClassesData = {};
+  const lincodeAliasDrugClassesData = {};
+  if (organism === 'shige') {
+    const buildLincodeDrugClasses = (groupField, target) => {
+      statKeysECOLI.forEach(drug => {
+        if (drug.name !== 'Pansusceptible') target[drug.name] = [];
+      });
+
+      const byGroup = {};
+      data.forEach(x => {
+        const k = x[groupField]?.toString();
+        if (k && k !== 'NA' && k !== '-' && k !== '') {
+          if (!byGroup[k]) byGroup[k] = [];
+          byGroup[k].push(x);
+        }
+      });
+
+      Object.keys(byGroup).forEach(name => {
+        const groupData = byGroup[name];
+        const drugClassResponse = { name, totalCount: groupData.length, resistantCount: 0 };
+        statKeysECOLI.forEach(drug => {
+          if (!target[drug.name]) return;
+          target[drug.name].push({
+            ...drugClassResponse,
+            ...getECOLIDrugClassData({ drugKey: drug.name, dataToFilter: groupData }),
+          });
+        });
+      });
+
+      Object.keys(target).forEach(key => {
+        target[key].sort((a, b) => b.totalCount - a.totalCount);
+        target[key].forEach(item => delete item['None']);
+      });
+    };
+
+    buildLincodeDrugClasses('lincodeNumeric', lincodeDrugClassesData);
+    buildLincodeDrugClasses('lincodeAlias', lincodeAliasDrugClassesData);
+  }
+
   // Years
   // years.forEach(year => {
   //   const yearData = (dataForGeographic || data).filter(x => x.DATE.toString() === year.toString());
@@ -2142,6 +2184,8 @@ export function getGenotypesData({
     regionsDrugClassesData,
     ngMastDrugClassesData,
     pathotypesDrugClassesData,
+    lincodeDrugClassesData,
+    lincodeAliasDrugClassesData,
   };
 }
 

--- a/client/src/components/Elements/Graphs/BubbleMarkersHeatmapGraph/BubbleMarkersHeatmapGraph.js
+++ b/client/src/components/Elements/Graphs/BubbleMarkersHeatmapGraph/BubbleMarkersHeatmapGraph.js
@@ -81,6 +81,8 @@ export const BubbleMarkersHeatmapGraph = ({ showFilter, setShowFilter }) => {
   const organismHasLotsOfGenotypes = useMemo(() => organismsWithLotsGenotypes.includes(organism), [organism]);
   const genotypesDrugClassesData = useAppSelector(state => state.graph.genotypesDrugClassesData);
   const ngMastDrugClassesData = useAppSelector(state => state.graph.ngMastDrugClassesData);
+  const lincodeDrugClassesData = useAppSelector(state => state.graph.lincodeDrugClassesData);
+  const lincodeAliasDrugClassesData = useAppSelector(state => state.graph.lincodeAliasDrugClassesData);
   const determinantsGraphDrugClass = useAppSelector(state => state.graph.determinantsGraphDrugClass);
 
   const selectedCRData = useMemo(() => {
@@ -93,8 +95,20 @@ export const BubbleMarkersHeatmapGraph = ({ showFilter, setShowFilter }) => {
     if (organism === 'ngono' && bubbleMarkersHeatmapGraphVariable === 'NG-MAST TYPE') {
       return ngMastDrugClassesData;
     }
+    // shige: marker breakdown grouped by the selected LINcode dimension.
+    if (organism === 'shige') {
+      if (bubbleMarkersHeatmapGraphVariable === 'lincodeNumeric') return lincodeDrugClassesData;
+      if (bubbleMarkersHeatmapGraphVariable === 'lincodeAlias') return lincodeAliasDrugClassesData;
+    }
     return genotypesDrugClassesData;
-  }, [bubbleMarkersHeatmapGraphVariable, genotypesDrugClassesData, ngMastDrugClassesData, organism]);
+  }, [
+    bubbleMarkersHeatmapGraphVariable,
+    genotypesDrugClassesData,
+    ngMastDrugClassesData,
+    lincodeDrugClassesData,
+    lincodeAliasDrugClassesData,
+    organism,
+  ]);
 
   const statColumn = useMemo(() => {
     // shige: ST (GENOTYPE) / Lincode (LINCODE_NUM) / Lincode alias (LINCODE_ALIAS)

--- a/client/src/stores/slices/graphSlice.ts
+++ b/client/src/stores/slices/graphSlice.ts
@@ -41,6 +41,8 @@ interface GraphState {
   genotypesDrugsData: Array<any>;
   genotypesDrugClassesData: Array<any>;
   ngMastDrugClassesData: Array<any>;
+  lincodeDrugClassesData: { [drugClass: string]: any };
+  lincodeAliasDrugClassesData: { [drugClass: string]: any };
   determinantsGraphView: string;
   determinantsGraphDrugClass: string;
   trendsGraphDrugClass: string;
@@ -114,6 +116,8 @@ const initialState: GraphState = {
   genotypesDrugsData: [],
   genotypesDrugClassesData: [],
   ngMastDrugClassesData: [],
+  lincodeDrugClassesData: {},
+  lincodeAliasDrugClassesData: {},
   genotypesAndDrugsYearData: [],
   countriesYearData: [],
   regionsYearData: [],
@@ -271,6 +275,12 @@ export const graphSlice = createSlice({
     },
     setNgMastDrugClassesData: (state, action: PayloadAction<Array<any>>) => {
       state.ngMastDrugClassesData = action.payload;
+    },
+    setLincodeDrugClassesData: (state, action: PayloadAction<{ [drugClass: string]: any }>) => {
+      state.lincodeDrugClassesData = action.payload ?? {};
+    },
+    setLincodeAliasDrugClassesData: (state, action: PayloadAction<{ [drugClass: string]: any }>) => {
+      state.lincodeAliasDrugClassesData = action.payload ?? {};
     },
     setPathotypesDrugClassesData: (state, action: PayloadAction<Array<any>>) => {
       state.pathotypesDrugClassesData = action.payload;
@@ -466,6 +476,8 @@ export const {
   setDeterminantsGraphDrugClass,
   setGenotypesDrugClassesData,
   setNgMastDrugClassesData,
+  setLincodeDrugClassesData,
+  setLincodeAliasDrugClassesData,
   setPathotypesDrugClassesData,
   setGenotypesAndDrugsYearData,
   setTrendsGraphDrugClass,


### PR DESCRIPTION
## Problem
On **AMR marker by genotype** (BAMRH), choosing **Lincode** or **Lincode alias** in 'Select genotype' plotted nothing.

## Cause
The heatmap matrix is built from `genotypesDrugClassesData`, which is keyed by GENOTYPE. With a LINcode variable selected, the x-axis carried LINcode names that matched no rows → empty plot. (#443 wired the dropdown + stats column but not this marker dataset.)

## Fix
- `getGenotypesData`: build `lincodeDrugClassesData` / `lincodeAliasDrugClassesData` — mirrors the existing pathotype / NG-MAST blocks: group records by `lincodeNumeric` / `lincodeAlias` and run the ECOLI drug-class rules (`getECOLIDrugClassData`).
- graphSlice: new slots + setters.
- Dashboard: dispatch them (cached + live paths; reset path too).
- BubbleMarkersHeatmapGraph: `drugClassesData` returns the LINcode set when shige + the matching variable is selected.

## Test
- `craco build` passes.