### PR TITLE
fix(glass): resilient GHO proxy + non-erroring empty cache response

### DIFF
--- a/server.js
+++ b/server.js
@@ -74,7 +74,15 @@ app.get('/api/glass-mongodb', async (req, res) => {
     const col = client.db('amrnet_admin').collection('glass_data');
     const count = await col.estimatedDocumentCount();
     if (count === 0) {
-      return res.status(404).json({ error: 'No GLASS data in MongoDB. Run: node scripts/check-glass-data.js' });
+      // Not populated yet — return 200 with an empty payload (not 404) so the
+      // client cleanly falls through to the live GHO proxy without logging a
+      // console error. Populate with: node scripts/check-glass-data.js
+      return res.json({
+        consumption: [],
+        resistance: { ecoli_3gc: [], mrsa: [], ng_ciprofloxacin: [], ng_azithromycin: [], ng_ceftriaxone: [], ng_cefixime: [] },
+        phenotypic: [],
+        source: 'none',
+      });
     }
 
     const ghoRecords = await col.find({ source: 'GHO_API' }).toArray();
@@ -98,21 +106,58 @@ app.get('/api/glass-mongodb', async (req, res) => {
   }
 });
 
-// GHO OData API proxy (avoids CORS issues with WHO API)
-app.get('/api/gho/:indicator', async (req, res) => {
-  try {
-    const indicator = req.params.indicator;
-    // Whitelist allowed indicators to prevent abuse
-    const allowed = ['GLASSAMC_TC', 'GLASSAMC_AWARE', 'AMR_INFECT_ECOLI', 'AMR_INFECT_MRSA', 'GASPRSCIP', 'GASPRSAZM', 'GASPRSCRO', 'GASPRSCFM', 'GASPRSESC'];
-    if (!allowed.includes(indicator)) {
-      return res.status(400).json({ error: 'Invalid indicator' });
+// GHO OData API proxy (avoids CORS issues with WHO API).
+//
+// The WHO GHO OData endpoint (ghoapi.azureedge.net) is the documented source
+// and still active, but WHO has signalled a migration to a new OData
+// implementation and the endpoint occasionally returns transient 5xx. To keep
+// the dashboard resilient we (a) cache successful responses in memory for a day
+// and (b) retry once with a timeout before giving up. The durable fix is to
+// pre-load the data into MongoDB (scripts/check-glass-data.js) so this live
+// proxy is only a fallback. See also the new WHO GLASS dashboard, which offers
+// the underlying AMR/AMU data for direct download.
+const GHO_CACHE = new Map(); // indicator -> { ts, data }
+const GHO_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+async function fetchGhoIndicator(indicator, { timeoutMs = 15000, retries = 1 } = {}) {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const response = await fetch(`https://ghoapi.azureedge.net/api/${indicator}`, { signal: controller.signal });
+      if (!response.ok) throw new Error(`GHO API returned ${response.status}`);
+      return await response.json();
+    } catch (err) {
+      if (attempt === retries) throw err;
+    } finally {
+      clearTimeout(timer);
     }
-    const response = await fetch(`https://ghoapi.azureedge.net/api/${indicator}`);
-    if (!response.ok) throw new Error(`GHO API returned ${response.status}`);
-    const data = await response.json();
+  }
+}
+
+app.get('/api/gho/:indicator', async (req, res) => {
+  const indicator = req.params.indicator;
+  // Whitelist allowed indicators to prevent abuse
+  const allowed = ['GLASSAMC_TC', 'GLASSAMC_AWARE', 'AMR_INFECT_ECOLI', 'AMR_INFECT_MRSA', 'GASPRSCIP', 'GASPRSAZM', 'GASPRSCRO', 'GASPRSCFM', 'GASPRSESC'];
+  if (!allowed.includes(indicator)) {
+    return res.status(400).json({ error: 'Invalid indicator' });
+  }
+
+  const cached = GHO_CACHE.get(indicator);
+  if (cached && Date.now() - cached.ts < GHO_CACHE_TTL_MS) {
+    return res.json(cached.data);
+  }
+
+  try {
+    const data = await fetchGhoIndicator(indicator);
+    GHO_CACHE.set(indicator, { ts: Date.now(), data });
     res.json(data);
   } catch (error) {
-    console.error('[GHO Proxy]', error.message);
+    console.error('[GHO Proxy]', indicator, error.message);
+    // Serve stale cache if we have it, rather than failing the widget.
+    if (cached) {
+      return res.json(cached.data);
+    }
     res.status(502).json({ error: 'Failed to fetch from WHO GHO API' });
   }
 });


### PR DESCRIPTION
## Problem
Two console errors from the GLASS data path:
- `/api/glass-mongodb` **404** when the `glass_data` collection isn't populated
- `/api/gho/GLASSAMC_TC` **502** on transient WHO-side failures

## Findings
- The WHO GHO OData endpoint (`ghoapi.azureedge.net`) is **still active** — verified `GLASSAMC_TC` returns 200 with data. The 502 was transient (or an EC2 outbound hiccup), not a permanent shutdown.
- WHO has signalled a future migration to a new OData implementation (≈end-2025, per third-party reports; no formal notice on the WHO API page yet).
- The client (`fetchGLASSData`) already degrades gracefully: MongoDB cache → live GHO proxy → static fallback. The errors were console noise + a reliability gap, not a functional break.

## Fix (keeps the existing fallback chain)
- **glass-mongodb**: when unpopulated, return **200** with an empty payload (`source:'none'`) instead of 404 → client falls through with no console error.
- **gho proxy**: 15s timeout + one retry + 24h in-memory cache; serve **stale cache** on failure instead of 502.

## Durable source (separate, needs a decision — not in this PR)
1. Pre-load `glass_data` via `scripts/check-glass-data.js` so the live proxy is only a fallback.
2. Ingest the new **WHO GLASS dashboard** download (AMR/AMU 2016–2023, 141 countries) directly into MongoDB — fully decouples us from the GHO OData endpoint and aligns with 'GLASS direct from WHO only'.

## Test
- `node --check server.js` passes; server-only change, client fallback unchanged.