### PR TITLE
fix(ecoli,shige): exclude aac(6')-Ib-cr from CipNS/CipR

### DIFF
--- a/client/src/__tests__/utils/drugResistance.test.js
+++ b/client/src/__tests__/utils/drugResistance.test.js
@@ -33,7 +33,8 @@ function isResistant(record, column) {
  */
 function countMarkers(quinoloneField) {
   if (!quinoloneField || quinoloneField === '-' || quinoloneField === '') return 0;
-  const qrdrPattern = /gyr[AB]|par[CE]/i;
+  // Only gyrA/parC QRDR mutations count (not gyrB/parE), per reviewer logic.
+  const qrdrPattern = /gyrA|parC/i;
   const qnrPattern = /qnr[A-Z]/i;
   let n = 0;
   quinoloneField.split(';').map(e => e.trim()).forEach(entry => {
@@ -182,9 +183,10 @@ describe('countMarkers (generic Quinolone detection)', () => {
     expect(countMarkers("aac(6')-Ib-cr; gyrA_S83F")).toBe(1);
   });
 
-  test('counts parC and parE mutations', () => {
+  test('counts parC but not parE/gyrB (only gyrA/parC QRDR per reviewer logic)', () => {
     expect(countMarkers('parC_S80I')).toBe(1);
-    expect(countMarkers('parE_D420N')).toBe(1);
+    expect(countMarkers('parE_D420N')).toBe(0);
+    expect(countMarkers('gyrB_S464F')).toBe(0);
   });
 
   test('ignores unrelated genes', () => {

--- a/client/src/__tests__/utils/drugResistance.test.js
+++ b/client/src/__tests__/utils/drugResistance.test.js
@@ -26,15 +26,18 @@ function isResistant(record, column) {
   return !isEmpty(record[column]);
 }
 
-/** Count ciprofloxacin resistance markers in a Quinolone field. */
+/**
+ * Count ciprofloxacin resistance determinants in a Quinolone field.
+ * aac(6')-Ib-cr is excluded — on its own it does not meet the CipNS threshold
+ * (wildtype + S, ECO1001), so it counts toward neither CipNS nor CipR.
+ */
 function countMarkers(quinoloneField) {
   if (!quinoloneField || quinoloneField === '-' || quinoloneField === '') return 0;
   const qrdrPattern = /gyr[AB]|par[CE]/i;
   const qnrPattern = /qnr[A-Z]/i;
-  const aacCrPattern = /aac.*Ib.*cr/i;
   let n = 0;
   quinoloneField.split(';').map(e => e.trim()).forEach(entry => {
-    if (qrdrPattern.test(entry) || qnrPattern.test(entry) || aacCrPattern.test(entry)) n++;
+    if (qrdrPattern.test(entry) || qnrPattern.test(entry)) n++;
   });
   return n;
 }
@@ -173,8 +176,10 @@ describe('countMarkers (generic Quinolone detection)', () => {
     expect(countMarkers('qnrB4; qnrS1')).toBe(2);
   });
 
-  test('counts aac(6\')-Ib-cr', () => {
-    expect(countMarkers("aac(6')-Ib-cr")).toBe(1);
+  test('excludes aac(6\')-Ib-cr (wildtype + S, not a CipNS/R determinant)', () => {
+    expect(countMarkers("aac(6')-Ib-cr")).toBe(0);
+    // aac(6')-Ib-cr alongside a real QRDR mutation: only the QRDR counts → CipNS, not CipR.
+    expect(countMarkers("aac(6')-Ib-cr; gyrA_S83F")).toBe(1);
   });
 
   test('counts parC and parE mutations', () => {

--- a/client/src/components/Dashboard/filters.js
+++ b/client/src/components/Dashboard/filters.js
@@ -47,15 +47,16 @@ import { amrLikeOrganisms } from '../../util/organismsCards';
 // Ciprofloxacin mechanism patterns (E. coli / Shigella / Salmonella), genotype
 // equivalent of the ECOFF NWT threshold — shared across year/genotype/country/
 // drug-class aggregations. Count how many ";"-separated quinolone-resistance
-// determinants a Quinolone cell carries: a QRDR mutation (gyrA/B, parC/E) or a
+// determinants a Quinolone cell carries: a gyrA or parC QRDR mutation, or a
 // qnr gene (qnrA/B/C/D/S, any variant). CipNS = ≥1 determinant, CipR = ≥2
 // determinants from different loci (two gyrA mutations at different codons
 // count as two).
 //
-// aac(6')-Ib-cr is deliberately EXCLUDED: on its own it does not meet the
-// non-susceptibility threshold (classified wildtype + S, ECO1001), so it must
-// not contribute to CipNS or CipR.
-const _QRDR_RE = /gyr[AB]|par[CE]/i;
+// Per the reviewer's genotype-only logic, only gyrA and parC QRDR mutations
+// count (not gyrB/parE), and aac(6')-Ib-cr is EXCLUDED: on its own it does not
+// meet the non-susceptibility threshold (wildtype + S, ECO1001), so it must not
+// contribute to CipNS or CipR.
+const _QRDR_RE = /gyrA|parC/i;
 const _QNR_RE = /qnr[A-Z]/i;
 function countQuinoloneMarkers(raw) {
   if (!raw || raw === '-' || raw === 'ND') return 0;

--- a/client/src/components/Dashboard/filters.js
+++ b/client/src/components/Dashboard/filters.js
@@ -44,20 +44,26 @@ import { amrLikeOrganisms } from '../../util/organismsCards';
  * @param {number} chunkSize - Size of each chunk (default 500)
  * @returns {Promise<Array>} - Results from all chunks
  */
-// Ciprofloxacin mechanism patterns — shared across year/genotype/country/
-// drug-class aggregations. Count how many ";"-separated markers in a
-// Quinolone cell look like a QRDR mutation (gyrA/B, parC/E), a qnr gene,
-// or aac(6')-Ib-cr. CipNS = ≥1 marker, CipR = ≥2 markers.
+// Ciprofloxacin mechanism patterns (E. coli / Shigella / Salmonella), genotype
+// equivalent of the ECOFF NWT threshold — shared across year/genotype/country/
+// drug-class aggregations. Count how many ";"-separated quinolone-resistance
+// determinants a Quinolone cell carries: a QRDR mutation (gyrA/B, parC/E) or a
+// qnr gene (qnrA/B/C/D/S, any variant). CipNS = ≥1 determinant, CipR = ≥2
+// determinants from different loci (two gyrA mutations at different codons
+// count as two).
+//
+// aac(6')-Ib-cr is deliberately EXCLUDED: on its own it does not meet the
+// non-susceptibility threshold (classified wildtype + S, ECO1001), so it must
+// not contribute to CipNS or CipR.
 const _QRDR_RE = /gyr[AB]|par[CE]/i;
 const _QNR_RE = /qnr[A-Z]/i;
-const _AAC_CR_RE = /aac.*Ib.*cr/i;
 function countQuinoloneMarkers(raw) {
   if (!raw || raw === '-' || raw === 'ND') return 0;
   let n = 0;
   String(raw).split(';').forEach(e => {
     const g = e.trim();
     if (!g) return;
-    if (_QRDR_RE.test(g) || _QNR_RE.test(g) || _AAC_CR_RE.test(g)) n++;
+    if (_QRDR_RE.test(g) || _QNR_RE.test(g)) n++;
   });
   return n;
 }
@@ -73,7 +79,8 @@ function extractQuinoloneMarkers(raw) {
   String(raw).split(';').forEach(e => {
     const g = e.trim();
     if (!g) return;
-    if (_QRDR_RE.test(g) || _QNR_RE.test(g) || _AAC_CR_RE.test(g)) out.push(g);
+    // aac(6')-Ib-cr excluded — not a Ciprofloxacin-NS/R determinant (see above).
+    if (_QRDR_RE.test(g) || _QNR_RE.test(g)) out.push(g);
   });
   return out;
 }
@@ -2582,9 +2589,10 @@ function getECOLIDrugClassData({ drugKey, dataToFilter }) {
   }
 
   // Handle computed combination drugs.
-  //   CipNS         = ≥1 qnr/QRDR/aac(6')-Ib-cr marker in Quinolone column
-  //   CipR          = ≥2 such markers
-  //   Ciprofloxacin = ≥1 marker (combined label, used by marker-oriented views)
+  //   CipNS         = ≥1 quinolone determinant (QRDR gyrA/B,parC/E mutation OR
+  //                   qnr gene) in the Quinolone column; aac(6')-Ib-cr excluded
+  //   CipR          = ≥2 such determinants (from different loci)
+  //   Ciprofloxacin = ≥1 determinant (combined label, used by marker-oriented views)
   if (drug.computed) {
     if (drugKey === 'Ciprofloxacin') {
       // Marker-oriented aggregate: populate per-gene breakdown so

--- a/client/src/components/Elements/Graphs/StratifiedResistanceGraph/StratifiedResistanceGraph.js
+++ b/client/src/components/Elements/Graphs/StratifiedResistanceGraph/StratifiedResistanceGraph.js
@@ -40,10 +40,10 @@ function translateShigeLINcode(rawValue) {
 }
 
 // Quinolone marker regexes (mirrors filters.js — kept local to avoid an
-// extra cross-component import dependency).
+// extra cross-component import dependency). aac(6')-Ib-cr is excluded: on its
+// own it does not meet the CipNS threshold (wildtype + S, ECO1001).
 const QRDR_RE = /gyr[AB]|par[CE]/i;
 const QNR_RE = /qnr[A-Z]/i;
-const AAC_CR_RE = /aac.*Ib.*cr/i;
 function countQuinoloneMarkers(raw) {
   if (!raw || raw === '-' || raw === 'ND') return 0;
   let n = 0;
@@ -52,7 +52,7 @@ function countQuinoloneMarkers(raw) {
     .forEach(e => {
       const g = e.trim();
       if (!g) return;
-      if (QRDR_RE.test(g) || QNR_RE.test(g) || AAC_CR_RE.test(g)) n++;
+      if (QRDR_RE.test(g) || QNR_RE.test(g)) n++;
     });
   return n;
 }

--- a/client/src/components/Elements/Graphs/StratifiedResistanceGraph/StratifiedResistanceGraph.js
+++ b/client/src/components/Elements/Graphs/StratifiedResistanceGraph/StratifiedResistanceGraph.js
@@ -40,9 +40,10 @@ function translateShigeLINcode(rawValue) {
 }
 
 // Quinolone marker regexes (mirrors filters.js — kept local to avoid an
-// extra cross-component import dependency). aac(6')-Ib-cr is excluded: on its
-// own it does not meet the CipNS threshold (wildtype + S, ECO1001).
-const QRDR_RE = /gyr[AB]|par[CE]/i;
+// extra cross-component import dependency). Only gyrA/parC QRDR mutations count
+// (not gyrB/parE); aac(6')-Ib-cr is excluded: on its own it does not meet the
+// CipNS threshold (wildtype + S, ECO1001).
+const QRDR_RE = /gyrA|parC/i;
 const QNR_RE = /qnr[A-Z]/i;
 function countQuinoloneMarkers(raw) {
   if (!raw || raw === '-' || raw === 'ND') return 0;

--- a/client/src/util/drugClassesRules.js
+++ b/client/src/util/drugClassesRules.js
@@ -1362,13 +1362,14 @@ const ECOLI_PAN_RULE = {
 // All ECOLI-family organisms (ecoli / decoli / shige / senterica /
 // sentericaints) share the same Ciprofloxacin definition — the Quinolone
 // column is parsed gene-by-gene via countQuinoloneMarkers:
-// - CipNS (non-susceptible) = ≥1 quinolone determinant: a QRDR (gyrA/B, parC/E)
+// - CipNS (non-susceptible) = ≥1 quinolone determinant: a gyrA or parC QRDR
 //   mutation OR any qnr gene (qnrA/B/C/D/S). Genotype equivalent of the ECOFF
 //   NWT threshold; a single determinant is enough.
 // - CipR  (resistant)       = ≥2 determinants from different loci (e.g. gyrA+parC,
 //   two gyrA mutations at different codons, gyrA+qnr).
-// aac(6')-Ib-cr is EXCLUDED — alone it does not meet the threshold (wildtype + S,
-// ECO1001), so it counts toward neither CipNS nor CipR.
+// Only gyrA/parC QRDR mutations count (not gyrB/parE), per the reviewer's
+// genotype-only logic. aac(6')-Ib-cr is EXCLUDED — alone it does not meet the
+// threshold (wildtype + S, ECO1001), so it counts toward neither CipNS nor CipR.
 // Both are computed per-record in getECOLIDrugClassData via that helper.
 export const statKeysSalmonella = [
   ...[

--- a/client/src/util/drugClassesRules.js
+++ b/client/src/util/drugClassesRules.js
@@ -1362,9 +1362,13 @@ const ECOLI_PAN_RULE = {
 // All ECOLI-family organisms (ecoli / decoli / shige / senterica /
 // sentericaints) share the same Ciprofloxacin definition — the Quinolone
 // column is parsed gene-by-gene via countQuinoloneMarkers:
-// - CipNS (non-susceptible) = ≥1 qnr gene OR ≥1 QRDR (gyrA/B/parC) mutation
-//   OR aac(6')-Ib-cr
-// - CipR  (resistant)       = ≥2 such markers (multiple mechanisms)
+// - CipNS (non-susceptible) = ≥1 quinolone determinant: a QRDR (gyrA/B, parC/E)
+//   mutation OR any qnr gene (qnrA/B/C/D/S). Genotype equivalent of the ECOFF
+//   NWT threshold; a single determinant is enough.
+// - CipR  (resistant)       = ≥2 determinants from different loci (e.g. gyrA+parC,
+//   two gyrA mutations at different codons, gyrA+qnr).
+// aac(6')-Ib-cr is EXCLUDED — alone it does not meet the threshold (wildtype + S,
+// ECO1001), so it counts toward neither CipNS nor CipR.
 // Both are computed per-record in getECOLIDrugClassData via that helper.
 export const statKeysSalmonella = [
   ...[


### PR DESCRIPTION
## Reviewer logic (E. coli / Shigella, genotype-only) — IMPLEMENTED
- **CipNS** = any single quinolone determinant: a **gyrA** mutation OR a **parC** mutation OR any qnr gene (qnrA/B/C/D/S). ECOFF NWT genotype-equivalent.
- **CipR** = ≥2 determinants from different loci (gyrA+parC; two gyrA codons; gyrA+qnrS1; gyrA+qnrB19).
- **aac(6')-Ib-cr** excluded (wildtype + S, ECO1001) — counts toward neither.
- **Only gyrA/parC** QRDR mutations count — **gyrB/parE no longer counted** (per reviewer confirmation).

## Changes
- `countQuinoloneMarkers` / matcher narrowed `/gyr[AB]|par[CE]/` → `/gyrA|parC/`, and aac(6')-Ib-cr dropped, in both filters.js and StratifiedResistanceGraph.js.
- Rule comments (drugClassesRules.js) + unit test updated.

## Verified
| Quinolone field | count | class |
|---|---|---|
| aac(6')-Ib-cr | 0 | CipS |
| aac(6')-Ib-cr; gyrA_S83F | 1 | CipNS |
| gyrA_S83F | 1 | CipNS |
| gyrA_S83F; gyrA_D87N | 2 | CipR |
| gyrA_S83L; parC_S80I | 2 | CipR |
| qnrS1 | 1 | CipNS |
| gyrA_S83F; qnrS1 | 2 | CipR |
| parE_D420N | 0 | CipS |
| gyrB_S464F | 0 | CipS |

`craco build` passes.