### PR TITLE
fix(cip): scope strict CipNS/CipR rule to ecoli/shige/decoli only

### DIFF
--- a/client/src/__tests__/utils/drugResistance.test.js
+++ b/client/src/__tests__/utils/drugResistance.test.js
@@ -28,17 +28,23 @@ function isResistant(record, column) {
 
 /**
  * Count ciprofloxacin resistance determinants in a Quinolone field.
- * aac(6')-Ib-cr is excluded — on its own it does not meet the CipNS threshold
- * (wildtype + S, ECO1001), so it counts toward neither CipNS nor CipR.
+ * Organism-scoped, mirroring filters.js:
+ *  - ecoli/shige/decoli (reviewer strict): gyrA & parC QRDR + qnr; gyrB/parE and
+ *    aac(6')-Ib-cr excluded (aac alone is wildtype + S, ECO1001).
+ *  - salmonella (senterica/sentericaints): broader legacy matcher (gyrA/B +
+ *    parC/E + aac(6')-Ib-cr), unchanged.
  */
-function countMarkers(quinoloneField) {
+const STRICT_CIP_ORGANISMS = ['ecoli', 'shige', 'decoli'];
+function countMarkers(quinoloneField, organism) {
   if (!quinoloneField || quinoloneField === '-' || quinoloneField === '') return 0;
-  // Only gyrA/parC QRDR mutations count (not gyrB/parE), per reviewer logic.
-  const qrdrPattern = /gyrA|parC/i;
-  const qnrPattern = /qnr[A-Z]/i;
+  const strict = STRICT_CIP_ORGANISMS.includes(organism);
+  const qrdr = strict ? /gyrA|parC/i : /gyr[AB]|par[CE]/i;
+  const qnr = /qnr[A-Z]/i;
+  const aacCr = /aac.*Ib.*cr/i;
   let n = 0;
   quinoloneField.split(';').map(e => e.trim()).forEach(entry => {
-    if (qrdrPattern.test(entry) || qnrPattern.test(entry)) n++;
+    if (qnr.test(entry)) n++;
+    else if (strict ? qrdr.test(entry) : qrdr.test(entry) || aacCr.test(entry)) n++;
   });
   return n;
 }
@@ -159,39 +165,59 @@ describe('Gene list splitting', () => {
 // Tests: Ciprofloxacin marker counting
 // ─────────────────────────────────────────────────────────────
 
-describe('countMarkers (generic Quinolone detection)', () => {
+describe('countMarkers — E. coli / Shigella / decoli (reviewer strict rule)', () => {
+  const ORG = 'shige'; // any of ecoli/shige/decoli
   test('returns 0 for empty fields', () => {
-    expect(countMarkers('')).toBe(0);
-    expect(countMarkers('-')).toBe(0);
-    expect(countMarkers(null)).toBe(0);
-    expect(countMarkers(undefined)).toBe(0);
+    expect(countMarkers('', ORG)).toBe(0);
+    expect(countMarkers('-', ORG)).toBe(0);
+    expect(countMarkers(null, ORG)).toBe(0);
+    expect(countMarkers(undefined, ORG)).toBe(0);
   });
 
   test('counts gyrA mutations', () => {
-    expect(countMarkers('gyrA_S83F')).toBe(1);
-    expect(countMarkers('gyrA_S83F; gyrA_D87N')).toBe(2);
+    expect(countMarkers('gyrA_S83F', ORG)).toBe(1);
+    expect(countMarkers('gyrA_S83F; gyrA_D87N', ORG)).toBe(2);
   });
 
   test('counts qnr genes', () => {
-    expect(countMarkers('qnrS1')).toBe(1);
-    expect(countMarkers('qnrB4; qnrS1')).toBe(2);
+    expect(countMarkers('qnrS1', ORG)).toBe(1);
+    expect(countMarkers('qnrB4; qnrS1', ORG)).toBe(2);
   });
 
   test('excludes aac(6\')-Ib-cr (wildtype + S, not a CipNS/R determinant)', () => {
-    expect(countMarkers("aac(6')-Ib-cr")).toBe(0);
+    expect(countMarkers("aac(6')-Ib-cr", ORG)).toBe(0);
     // aac(6')-Ib-cr alongside a real QRDR mutation: only the QRDR counts → CipNS, not CipR.
-    expect(countMarkers("aac(6')-Ib-cr; gyrA_S83F")).toBe(1);
+    expect(countMarkers("aac(6')-Ib-cr; gyrA_S83F", ORG)).toBe(1);
   });
 
   test('counts parC but not parE/gyrB (only gyrA/parC QRDR per reviewer logic)', () => {
-    expect(countMarkers('parC_S80I')).toBe(1);
-    expect(countMarkers('parE_D420N')).toBe(0);
-    expect(countMarkers('gyrB_S464F')).toBe(0);
+    expect(countMarkers('parC_S80I', ORG)).toBe(1);
+    expect(countMarkers('parE_D420N', ORG)).toBe(0);
+    expect(countMarkers('gyrB_S464F', ORG)).toBe(0);
+  });
+
+  test('CipR combos count 2', () => {
+    expect(countMarkers('gyrA_S83L; parC_S80I', ORG)).toBe(2);
+    expect(countMarkers('gyrA_S83F; qnrB19', ORG)).toBe(2);
   });
 
   test('ignores unrelated genes', () => {
-    expect(countMarkers('aadA2')).toBe(0); // aminoglycoside, not quinolone
-    expect(countMarkers('blaTEM-1')).toBe(0); // beta-lactam
+    expect(countMarkers('aadA2', ORG)).toBe(0); // aminoglycoside, not quinolone
+    expect(countMarkers('blaTEM-1', ORG)).toBe(0); // beta-lactam
+  });
+});
+
+describe('countMarkers — Salmonella (legacy broader matcher, unchanged)', () => {
+  const ORG = 'senterica'; // also sentericaints
+  test('still counts gyrB / parE / aac(6\')-Ib-cr (not restricted like ecoli/shige)', () => {
+    expect(countMarkers('gyrB_S464F', ORG)).toBe(1);
+    expect(countMarkers('parE_D420N', ORG)).toBe(1);
+    expect(countMarkers("aac(6')-Ib-cr", ORG)).toBe(1);
+  });
+  test('counts gyrA/parC/qnr like before', () => {
+    expect(countMarkers('gyrA_S83F', ORG)).toBe(1);
+    expect(countMarkers('gyrA_S83L; parC_S80I', ORG)).toBe(2);
+    expect(countMarkers('qnrS1', ORG)).toBe(1);
   });
 });
 

--- a/client/src/components/Dashboard/filters.js
+++ b/client/src/components/Dashboard/filters.js
@@ -44,27 +44,40 @@ import { amrLikeOrganisms } from '../../util/organismsCards';
  * @param {number} chunkSize - Size of each chunk (default 500)
  * @returns {Promise<Array>} - Results from all chunks
  */
-// Ciprofloxacin mechanism patterns (E. coli / Shigella / Salmonella), genotype
-// equivalent of the ECOFF NWT threshold — shared across year/genotype/country/
-// drug-class aggregations. Count how many ";"-separated quinolone-resistance
-// determinants a Quinolone cell carries: a gyrA or parC QRDR mutation, or a
-// qnr gene (qnrA/B/C/D/S, any variant). CipNS = ≥1 determinant, CipR = ≥2
-// determinants from different loci (two gyrA mutations at different codons
-// count as two).
+// Ciprofloxacin mechanism patterns, genotype equivalent of the ECOFF NWT
+// threshold — shared across year/genotype/country/drug-class aggregations.
+// Count how many ";"-separated quinolone-resistance determinants a Quinolone
+// cell carries. CipNS = ≥1 determinant, CipR = ≥2 determinants from different
+// loci (two gyrA mutations at different codons count as two).
 //
-// Per the reviewer's genotype-only logic, only gyrA and parC QRDR mutations
-// count (not gyrB/parE), and aac(6')-Ib-cr is EXCLUDED: on its own it does not
-// meet the non-susceptibility threshold (wildtype + S, ECO1001), so it must not
-// contribute to CipNS or CipR.
-const _QRDR_RE = /gyrA|parC/i;
+// The reviewer's genotype-only logic applies to **E. coli / Shigella / decoli
+// only**: count gyrA and parC QRDR mutations (not gyrB/parE) and any qnr gene
+// (qnrA/B/C/D/S); aac(6')-Ib-cr is EXCLUDED — on its own it does not meet the
+// non-susceptibility threshold (wildtype + S, ECO1001).
+//
+// Other organisms sharing the ECOLI rule set (non-typhoidal Salmonella:
+// senterica / sentericaints) keep the prior broader matcher (gyrA/B + parC/E +
+// aac(6')-Ib-cr) until a Salmonella-specific spec is provided. The `organism`
+// argument selects which matcher applies.
+const _QRDR_STRICT_RE = /gyrA|parC/i; // ecoli/shige/decoli (reviewer)
+const _QRDR_LEGACY_RE = /gyr[AB]|par[CE]/i; // salmonella (unchanged)
+const _AAC_CR_RE = /aac.*Ib.*cr/i; // legacy matcher only
 const _QNR_RE = /qnr[A-Z]/i;
-function countQuinoloneMarkers(raw) {
+const _STRICT_CIP_ORGANISMS = ['ecoli', 'shige', 'decoli'];
+
+function _isQuinoloneMarker(gene, strict) {
+  if (_QNR_RE.test(gene)) return true;
+  if (strict) return _QRDR_STRICT_RE.test(gene);
+  return _QRDR_LEGACY_RE.test(gene) || _AAC_CR_RE.test(gene);
+}
+
+function countQuinoloneMarkers(raw, organism) {
   if (!raw || raw === '-' || raw === 'ND') return 0;
+  const strict = _STRICT_CIP_ORGANISMS.includes(organism);
   let n = 0;
   String(raw).split(';').forEach(e => {
     const g = e.trim();
-    if (!g) return;
-    if (_QRDR_RE.test(g) || _QNR_RE.test(g)) n++;
+    if (g && _isQuinoloneMarker(g, strict)) n++;
   });
   return n;
 }
@@ -74,14 +87,14 @@ function countQuinoloneMarkers(raw) {
 // instead of a count. Used by the marker-oriented Ciprofloxacin aggregate
 // so per-gene breakdowns work in MarkerTrendsGraph / BubbleMarkersHeatmapGraph
 // / BubbleGeographicGraph (determinant mode).
-function extractQuinoloneMarkers(raw) {
+function extractQuinoloneMarkers(raw, organism) {
   if (!raw || raw === '-' || raw === 'ND') return [];
+  const strict = _STRICT_CIP_ORGANISMS.includes(organism);
   const out = [];
   String(raw).split(';').forEach(e => {
     const g = e.trim();
-    if (!g) return;
-    // aac(6')-Ib-cr excluded — not a Ciprofloxacin-NS/R determinant (see above).
-    if (_QRDR_RE.test(g) || _QNR_RE.test(g)) out.push(g);
+    // For ecoli/shige/decoli aac(6')-Ib-cr and gyrB/parE are excluded (see above).
+    if (g && _isQuinoloneMarker(g, strict)) out.push(g);
   });
   return out;
 }
@@ -503,7 +516,7 @@ function getMapStatsData({
       // "marker" entry keyed by the drug name so the country-level count is
       // the number of records passing the threshold.
       if (drug.computed) {
-        const m = countQuinoloneMarkers(item['Quinolone']);
+        const m = countQuinoloneMarkers(item['Quinolone'], organism);
         const passes =
           (statsKey === 'Ciprofloxacin NS' && m >= 1) ||
           (statsKey === 'Ciprofloxacin R' && m >= 2);
@@ -1300,9 +1313,9 @@ export function getYearsData({ data, years, organism, getUniqueGenotypes = false
             // (≥1 marker, i.e. same threshold as NS but labelled without the
             // NS/R split) is also emitted for marker views.
             if (drug.name === 'Ciprofloxacin NS' || drug.name === 'Ciprofloxacin') {
-              drugStats[drug.name] = yearData.filter(x => countQuinoloneMarkers(x['Quinolone']) >= 1).length;
+              drugStats[drug.name] = yearData.filter(x => countQuinoloneMarkers(x['Quinolone'], organism) >= 1).length;
             } else if (drug.name === 'Ciprofloxacin R') {
-              drugStats[drug.name] = yearData.filter(x => countQuinoloneMarkers(x['Quinolone']) >= 2).length;
+              drugStats[drug.name] = yearData.filter(x => countQuinoloneMarkers(x['Quinolone'], organism) >= 2).length;
             }
             return;
           }
@@ -1318,7 +1331,7 @@ export function getYearsData({ data, years, organism, getUniqueGenotypes = false
         const isResCipEC = x => hasRes(x, 'Quinolone');
         const isResAzmEC = x => hasRes(x, 'Macrolide');
         const isResBetaLactamEC = x => hasRes(x, 'Beta-lactam');
-        const isCipREC = x => countQuinoloneMarkers(x['Quinolone']) >= 2;
+        const isCipREC = x => countQuinoloneMarkers(x['Quinolone'], organism) >= 2;
 
         // MDR: at least 2 of {ciprofloxacin, macrolide, beta-lactam}
         const isMDREC = x => {
@@ -1349,7 +1362,7 @@ export function getYearsData({ data, years, organism, getUniqueGenotypes = false
 
           genotypesAndDrugsDataUniqueGenotypes[key].push(...Object.keys(filteredGenotypes));
 
-          const drugClass = getECOLIDrugClassData({ drugKey: key, dataToFilter: yearData });
+          const drugClass = getECOLIDrugClassData({ drugKey: key, dataToFilter: yearData, organism });
           const item = { ...response, ...filteredGenotypes, ...drugClass, totalCount: count };
           delete item.count;
 
@@ -1596,7 +1609,7 @@ export function getDrugsCountriesData({ data, items, organism, type = 'country' 
             }),
           );
         } else if (['senterica', 'sentericaints'].includes(organism)) {
-          Object.assign(drugClassData, getECOLIDrugClassData({ drugKey: key, dataToFilter: itemData }));
+          Object.assign(drugClassData, getECOLIDrugClassData({ drugKey: key, dataToFilter: itemData, organism }));
         } else if (organism === 'saureus') {
           const rule = drugRulesSA.find(r => r.key === key);
           if (rule) {
@@ -1637,7 +1650,7 @@ export function getDrugsCountriesData({ data, items, organism, type = 'country' 
           }
         } else {
           // For ecoli, decoli, shige
-          Object.assign(drugClassData, getECOLIDrugClassData({ drugKey: key, dataToFilter: itemData }));
+          Object.assign(drugClassData, getECOLIDrugClassData({ drugKey: key, dataToFilter: itemData, organism }));
         }
 
         drugsData[key].push(drugClassData);
@@ -1918,16 +1931,16 @@ export function getGenotypesData({
         // Ciprofloxacin (≥1 marker) for marker-oriented views.
         if (drug.computed) {
           if (drug.name === 'Ciprofloxacin NS' || drug.name === 'Ciprofloxacin') {
-            response[drug.name] = genotypeData.filter(x => countQuinoloneMarkers(x['Quinolone']) >= 1).length;
+            response[drug.name] = genotypeData.filter(x => countQuinoloneMarkers(x['Quinolone'], organism) >= 1).length;
           } else if (drug.name === 'Ciprofloxacin R') {
-            response[drug.name] = genotypeData.filter(x => countQuinoloneMarkers(x['Quinolone']) >= 2).length;
+            response[drug.name] = genotypeData.filter(x => countQuinoloneMarkers(x['Quinolone'], organism) >= 2).length;
           } else {
             response[drug.name] = 0;
           }
           // Populate drill-down (gene breakdown) for the heatmap.
           const drugClass = {
             ...drugClassResponse,
-            ...getECOLIDrugClassData({ drugKey: drug.name, dataToFilter: genotypeData }),
+            ...getECOLIDrugClassData({ drugKey: drug.name, dataToFilter: genotypeData, organism }),
           };
           genotypesDrugClassesData[drug.name]?.push(drugClass);
           return;
@@ -1940,7 +1953,7 @@ export function getGenotypesData({
         if (drug.name !== 'Pansusceptible') {
           const drugClass = {
             ...drugClassResponse,
-            ...getECOLIDrugClassData({ drugKey: drug.name, dataToFilter: genotypeData }),
+            ...getECOLIDrugClassData({ drugKey: drug.name, dataToFilter: genotypeData, organism }),
           };
           genotypesDrugClassesData[drug.name].push(drugClass);
         }
@@ -2026,7 +2039,7 @@ export function getGenotypesData({
         if (!pathotypesDrugClassesData[drug.name]) return;
         const drugClass = {
           ...drugClassResponse,
-          ...getECOLIDrugClassData({ drugKey: drug.name, dataToFilter: pathotypeData }),
+          ...getECOLIDrugClassData({ drugKey: drug.name, dataToFilter: pathotypeData, organism }),
         };
         pathotypesDrugClassesData[drug.name].push(drugClass);
       });
@@ -2065,7 +2078,7 @@ export function getGenotypesData({
           if (!target[drug.name]) return;
           target[drug.name].push({
             ...drugClassResponse,
-            ...getECOLIDrugClassData({ drugKey: drug.name, dataToFilter: groupData }),
+            ...getECOLIDrugClassData({ drugKey: drug.name, dataToFilter: groupData, organism }),
           });
         });
       });
@@ -2578,7 +2591,7 @@ function getMarkerDrugClassData({ drugKey, dataToFilter, markerRules, fallbackDr
   return drugClass;
 }
 
-function getECOLIDrugClassData({ drugKey, dataToFilter }) {
+function getECOLIDrugClassData({ drugKey, dataToFilter, organism }) {
   const drugClass = {};
   const splitChar = ';'; // genes are separated by "; " (e.g. "aadA2; aph(3'')-Ib")
   const drug = statKeysECOLI.find(x => x.name === drugKey);
@@ -2589,9 +2602,10 @@ function getECOLIDrugClassData({ drugKey, dataToFilter }) {
     return {};
   }
 
-  // Handle computed combination drugs.
-  //   CipNS         = ≥1 quinolone determinant (QRDR gyrA/B,parC/E mutation OR
-  //                   qnr gene) in the Quinolone column; aac(6')-Ib-cr excluded
+  // Handle computed combination drugs (Ciprofloxacin). The matcher is
+  // organism-scoped: ecoli/shige/decoli use the reviewer's strict rule (gyrA/parC
+  // + qnr, no aac(6')-Ib-cr); Salmonella keeps the prior broader matcher.
+  //   CipNS         = ≥1 quinolone determinant
   //   CipR          = ≥2 such determinants (from different loci)
   //   Ciprofloxacin = ≥1 determinant (combined label, used by marker-oriented views)
   if (drug.computed) {
@@ -2600,7 +2614,7 @@ function getECOLIDrugClassData({ drugKey, dataToFilter }) {
       // MarkerTrendsGraph, BubbleMarkersHeatmapGraph, and
       // BubbleGeographicGraph (determinant mode) have something to plot.
       dataToFilter.forEach(x => {
-        const markers = extractQuinoloneMarkers(x['Quinolone']);
+        const markers = extractQuinoloneMarkers(x['Quinolone'], organism);
         if (markers.length === 0) return;
         resistantCount++;
         markers.forEach(g => {
@@ -2608,9 +2622,9 @@ function getECOLIDrugClassData({ drugKey, dataToFilter }) {
         });
       });
     } else if (drugKey === 'Ciprofloxacin NS') {
-      resistantCount = dataToFilter.filter(x => countQuinoloneMarkers(x['Quinolone']) >= 1).length;
+      resistantCount = dataToFilter.filter(x => countQuinoloneMarkers(x['Quinolone'], organism) >= 1).length;
     } else if (drugKey === 'Ciprofloxacin R') {
-      resistantCount = dataToFilter.filter(x => countQuinoloneMarkers(x['Quinolone']) >= 2).length;
+      resistantCount = dataToFilter.filter(x => countQuinoloneMarkers(x['Quinolone'], organism) >= 2).length;
     }
     drugClass['None'] = dataToFilter.length - resistantCount;
     drugClass.resistantCount = resistantCount;

--- a/client/src/components/Elements/Graphs/StratifiedResistanceGraph/StratifiedResistanceGraph.js
+++ b/client/src/components/Elements/Graphs/StratifiedResistanceGraph/StratifiedResistanceGraph.js
@@ -40,20 +40,27 @@ function translateShigeLINcode(rawValue) {
 }
 
 // Quinolone marker regexes (mirrors filters.js — kept local to avoid an
-// extra cross-component import dependency). Only gyrA/parC QRDR mutations count
-// (not gyrB/parE); aac(6')-Ib-cr is excluded: on its own it does not meet the
-// CipNS threshold (wildtype + S, ECO1001).
-const QRDR_RE = /gyrA|parC/i;
+// extra cross-component import dependency). For E. coli / Shigella / decoli the
+// reviewer's strict rule applies: only gyrA/parC QRDR mutations + qnr genes
+// count (gyrB/parE and aac(6')-Ib-cr excluded). Salmonella (senterica /
+// sentericaints), which also reaches this graph, keeps the prior broader
+// matcher until a Salmonella-specific spec is provided.
+const QRDR_STRICT_RE = /gyrA|parC/i;
+const QRDR_LEGACY_RE = /gyr[AB]|par[CE]/i;
+const AAC_CR_RE = /aac.*Ib.*cr/i;
 const QNR_RE = /qnr[A-Z]/i;
-function countQuinoloneMarkers(raw) {
+const STRICT_CIP_ORGANISMS = ['ecoli', 'shige', 'decoli'];
+function countQuinoloneMarkers(raw, organism) {
   if (!raw || raw === '-' || raw === 'ND') return 0;
+  const strict = STRICT_CIP_ORGANISMS.includes(organism);
   let n = 0;
   String(raw)
     .split(';')
     .forEach(e => {
       const g = e.trim();
       if (!g) return;
-      if (QRDR_RE.test(g) || QNR_RE.test(g)) n++;
+      if (QNR_RE.test(g)) n++;
+      else if (strict ? QRDR_STRICT_RE.test(g) : QRDR_LEGACY_RE.test(g) || AAC_CR_RE.test(g)) n++;
     });
   return n;
 }
@@ -66,13 +73,13 @@ function hasResColumn(item, col) {
 
 // Resistance evaluator for the ECOLI-family Enterobase schema. Keys match
 // the canonical drug names exposed by statKeysSalmonella.
-function isResistant(item, drugKey) {
+function isResistant(item, drugKey, organism) {
   switch (drugKey) {
     case 'Ciprofloxacin':
     case 'Ciprofloxacin NS':
-      return countQuinoloneMarkers(item['Quinolone']) >= 1;
+      return countQuinoloneMarkers(item['Quinolone'], organism) >= 1;
     case 'Ciprofloxacin R':
-      return countQuinoloneMarkers(item['Quinolone']) >= 2;
+      return countQuinoloneMarkers(item['Quinolone'], organism) >= 2;
     case 'Aminoglycosides':
       return hasResColumn(item, 'Aminoglycoside');
     case 'Carbapenems':
@@ -181,7 +188,7 @@ export const StratifiedResistanceGraph = ({ mode = 'source' }) => {
         groups[v] = { name: v, label, total: 0, resistant: 0 };
       }
       groups[v].total++;
-      if (isResistant(item, drug)) groups[v].resistant++;
+      if (isResistant(item, drug, organism)) groups[v].resistant++;
     });
 
     const allRows = Object.values(groups)

--- a/client/src/util/drugClassesRules.js
+++ b/client/src/util/drugClassesRules.js
@@ -1360,16 +1360,18 @@ const ECOLI_PAN_RULE = {
 };
 
 // All ECOLI-family organisms (ecoli / decoli / shige / senterica /
-// sentericaints) share the same Ciprofloxacin definition — the Quinolone
+// sentericaints) share this Ciprofloxacin definition list — the Quinolone
 // column is parsed gene-by-gene via countQuinoloneMarkers:
-// - CipNS (non-susceptible) = ≥1 quinolone determinant: a gyrA or parC QRDR
-//   mutation OR any qnr gene (qnrA/B/C/D/S). Genotype equivalent of the ECOFF
-//   NWT threshold; a single determinant is enough.
+// - CipNS (non-susceptible) = ≥1 quinolone determinant (QRDR mutation OR qnr).
+//   Genotype equivalent of the ECOFF NWT threshold; one determinant is enough.
 // - CipR  (resistant)       = ≥2 determinants from different loci (e.g. gyrA+parC,
 //   two gyrA mutations at different codons, gyrA+qnr).
-// Only gyrA/parC QRDR mutations count (not gyrB/parE), per the reviewer's
-// genotype-only logic. aac(6')-Ib-cr is EXCLUDED — alone it does not meet the
-// threshold (wildtype + S, ECO1001), so it counts toward neither CipNS nor CipR.
+// IMPORTANT — the determinant matcher is organism-scoped (in countQuinoloneMarkers):
+//   • E. coli / Shigella / decoli (reviewer's strict rule): count gyrA & parC QRDR
+//     mutations + qnr genes; gyrB/parE and aac(6')-Ib-cr are EXCLUDED (aac(6')-Ib-cr
+//     alone is wildtype + S, ECO1001).
+//   • Salmonella (senterica / sentericaints): unchanged broader matcher (gyrA/B +
+//     parC/E + aac(6')-Ib-cr) until a Salmonella-specific spec is provided.
 // Both are computed per-record in getECOLIDrugClassData via that helper.
 export const statKeysSalmonella = [
   ...[


### PR DESCRIPTION
## Context
The reviewer's genotype-only CipNS/CipR logic is **for E. coli, Shigella and decoli only**. #449 implemented it in the shared `countQuinoloneMarkers`, which is also used by **non-typhoidal Salmonella** (senterica/sentericaints share `statKeysSalmonella`) — so it leaked there too.

## Fix
Make the determinant matcher **organism-scoped**:
| Organism | Matcher |
|---|---|
| ecoli / shige / decoli | **strict** (reviewer): gyrA & parC QRDR + qnr; gyrB/parE and aac(6')-Ib-cr **excluded** |
| senterica / sentericaints | **legacy** (unchanged): gyrA/B + parC/E + qnr + aac(6')-Ib-cr |

`organism` is threaded through `countQuinoloneMarkers` / `extractQuinoloneMarkers`, `getECOLIDrugClassData` (+ all 7 call sites), and StratifiedResistanceGraph's local copy.

## Verified (incl. decoli)
| field | ecoli/shige/decoli | salmonella |
|---|---|---|
| aac(6')-Ib-cr | 0 | 1 |
| gyrB_S464F | 0 | 1 |
| parE_D420N (decoli) | 0 | 1 |
| aac(6')-Ib-cr; gyrA_S83F | 1 (CipNS) | 2 |
| gyrA+parC | 2 (CipR) | 2 |
| gyrA+qnrB19 (decoli) | 2 (CipR) | — |

Tests updated for both matchers. `craco build` passes.