### PR TITLE
feat(cooccurrence): move to Summary Plots (dev-only)

### DIFF
--- a/client/src/components/Elements/AMRInsights/AMRInsights.js
+++ b/client/src/components/Elements/AMRInsights/AMRInsights.js
@@ -19,19 +19,14 @@ import { isTouchDevice } from '../../../util/isTouchDevice';
 import { ChartErrorBoundary } from '../Graphs/../Shared/ChartErrorBoundary';
 import { InsightsActions } from './InsightsActions';
 import { ATBCorrelationGraph } from '../Graphs/ATBCorrelationGraph';
-import { CooccurrenceGraph } from '../Graphs/CooccurrenceGraph';
 import { GeneMapGraph } from '../Graphs/GeneMapGraph';
 import { GenomicVsPhenotypicGraph } from '../Graphs/GenomicVsPhenotypicGraph';
 import { useStyles } from './AMRInsightsMUI';
 
+// NOTE: AMR Co-occurrence was moved to the Summary Plots section (it is a
+// genome-only plot, not a genomic-vs-other-data comparison). See graphCards.js
+// id 'COO'.
 const TABS = [
-  {
-    labelKey: 'amrInsights.tabs.cooccurrence',
-    value: 'COO',
-    component: <CooccurrenceGraph />,
-    onlyFor: null,
-    hasFilter: false,
-  },
   {
     labelKey: 'amrInsights.tabs.genomicVsPhenotypic',
     value: 'GVP',
@@ -58,7 +53,7 @@ const TABS = [
 export const AMRInsights = () => {
   const classes = useStyles();
   const matches500 = useMediaQuery('(max-width:500px)');
-  const [currentTab, setCurrentTab] = useState('COO');
+  const [currentTab, setCurrentTab] = useState('GVP');
   const [showFilter, setShowFilter] = useState(!matches500);
   const { t } = useTranslation();
 
@@ -81,7 +76,7 @@ export const AMRInsights = () => {
   // Reset to first visible tab when organism changes and current tab is no longer visible
   useEffect(() => {
     if (!filteredTabs.find(tab => tab.value === currentTab)) {
-      setCurrentTab(filteredTabs[0]?.value ?? 'COO');
+      setCurrentTab(filteredTabs[0]?.value ?? 'GVP');
     }
   }, [filteredTabs, currentTab]);
 

--- a/client/src/components/Elements/Graphs/CooccurrenceGraph/CooccurrenceGraph.js
+++ b/client/src/components/Elements/Graphs/CooccurrenceGraph/CooccurrenceGraph.js
@@ -193,7 +193,8 @@ export const CooccurrenceGraph = ({ showFilter, setShowFilter }) => {
   if (!canGetData) return null;
 
   return (
-    <CardContent className={classes.cooccurrenceGraph}>
+    // id used by the Summary Plots PNG capture (graphCards.js id 'COO').
+    <CardContent id="COO" className={classes.cooccurrenceGraph}>
       <Box className={classes.controlsRow}>
         <Box className={classes.selectWrapper}>
           <Box className={classes.labelWrapper}>

--- a/client/src/util/graphCards.js
+++ b/client/src/util/graphCards.js
@@ -5,6 +5,7 @@ import { BubbleMarkersHeatmapGraph } from '../components/Elements/Graphs/BubbleM
 import { BubbleMarkersPathotypeHeatmapGraph } from '../components/Elements/Graphs/BubbleMarkersPathotypeHeatmapGraph';
 import { ConvergenceGraph } from '../components/Elements/Graphs/ConvergenceGraph';
 import { ConvergenceMapGraph } from '../components/Elements/Graphs/ConvergenceMapGraph';
+import { CooccurrenceGraph } from '../components/Elements/Graphs/CooccurrenceGraph';
 import { DeterminantsGraph } from '../components/Elements/Graphs/DeterminantsGraph';
 import { DistributionGraph } from '../components/Elements/Graphs/DistributionGraph';
 import { DrugResistanceGraph } from '../components/Elements/Graphs/DrugResistanceGraph';
@@ -48,6 +49,20 @@ export function getGraphCards(t){
       id: 'DRT',
       organisms: organismsCards.map(x => x.value),
       component: <DrugResistanceGraph />,
+    },
+    {
+      // Moved here from AMR Insights: it is a genome-only plot (not genomic-vs-
+      // other-data), computed from all genomes passing the current filters
+      // (including country) — so it belongs with the summary plots.
+      title: t('amrInsights.tabs.cooccurrence'),
+      description: [
+        'Genome-only: pairwise co-occurrence of resistances across all genomes passing the current filters (including country). Repeat-isolate de-duplication can be toggled in the plot.',
+      ],
+      icon: <GridOn color="primary" />,
+      id: 'COO',
+      // Dev-only until validated — hidden in production.
+      organisms: isProduction() ? [] : organismsCards.map(x => x.value),
+      component: <CooccurrenceGraph />,
     },
     {
       title: t('graphs.temporalHeatmap'),


### PR DESCRIPTION
## Feedback (item 2)
The AMR co-occurrence plot is **genome-only** (not a genomic-vs-other-data comparison) and is computed from **all genomes passing the current filters, including country** — so per the reviewer it belongs in **Summary Plots**, not grouped with GVP/ATB under AMR Insights. Also: it should appear **only in the development version, not production**.

## Changes
- **graphCards.js**: new Summary Plots card (id `COO`) with a clear method description; **gated to development only** (`isProduction() ? [] : …`) like the CVM card.
- **AMRInsights.js**: removed the Co-occurrence tab; default tab is now GVP.
- **CooccurrenceGraph.js**: added `id='COO'` on the root so the Summary Plots PNG capture targets it.

## Already in place (reviewer points 2c)
- Repeat-isolate **de-duplication toggle** (default ON), keyed by (lineage, country, year).
- **Kpn** uses `Sublineage` (the LIN-derived lineage) — confirmed correct, no change.

Dev-only. `craco build` passes.