### PR TITLE
fix(map): multi-drug resistance combinations (CipR+CipNS, trim+trim-sulfa)

### DIFF
--- a/client/src/components/Dashboard/filters.js
+++ b/client/src/components/Dashboard/filters.js
@@ -491,13 +491,21 @@ function getMapStatsData({
   const allDashNames = [];
   let resistantGenomeCount = 0; // direct count of genomes passing resistance check
 
-  for (const item of itemData) {
+  for (const [idx, item] of itemData.entries()) {
+    // Stable per-genome identifier. The fallback MUST be deterministic for a
+    // given record: the map combines multiple drugs by intersecting these name
+    // sets, and getMapStatsData is called once per drug over the same itemData.
+    // The previous fallback (`g${resistantGenomeCount}`) was a running counter,
+    // so the same genome got a different id under each drug and the
+    // intersection was meaningless — e.g. CipR + CipNS did not return CipR even
+    // though CipR is a subset of CipNS. Using the array index keeps the id
+    // stable across drugs.
     const name =
       item.Uberstrain ||
       item.Name ||
       item.NAME ||
       item['Genome Name'] ||
-      String(item._id || `g${resistantGenomeCount}`);
+      String(item._id ?? `g${idx}`);
 
     // Special handling for ECOLI-like organisms which use rule sets instead of
     // direct column values. In those cases `statsKey` is the rule name and


### PR DESCRIPTION
Addresses Kat's point 9 in the July 1 feedback.

## Symptom
CipR is a subset of CipNS, so selecting **CipR + CipNS** on the map should return the same as **CipR** alone — it didn't. Same for **trimethoprim + trimethoprim-sulfamethoxazole**, and the same behaviour in **Klebsiella** (trimR vs trimR & trimsulfaR).

## Root cause
The map combines selected drugs by **intersecting each drug's genome-name set** (`countryStats[key].names`). `getMapStatsData` builds those sets once per drug over the same `itemData`, but for records without `NAME`/`_id` the fallback identifier was:

```js
String(item._id || `g${resistantGenomeCount}`)
```

`resistantGenomeCount` is a **running counter**, so the same genome got a *different* id on the CipNS pass than on the CipR pass. The intersection was therefore meaningless (and far too small). Single-drug selections were unaffected because they use `count`, not `names` — which is exactly why one drug looked right and two drugs did not.

## Fix
Use the record's **index in `itemData`** as the fallback id. It is deterministic for a given record and identical across drugs, so the intersection is now correct.

## Test
- `craco build` passes.
- To verify on dev: Shigella map → Resistance prevalence → select CipR alone, then CipR + CipNS; the two should now match. Same check for trimethoprim-sulfamethoxazole vs trimethoprim + trimethoprim-sulfamethoxazole, and on Klebsiella.