### PR TITLE
fix: labelling and map-view fixes from the July 1 review

### DIFF
--- a/client/src/components/Elements/Graphs/BubbleMarkersPathotypeHeatmapGraph/BubbleMarkersPathotypeHeatmapGraph.js
+++ b/client/src/components/Elements/Graphs/BubbleMarkersPathotypeHeatmapGraph/BubbleMarkersPathotypeHeatmapGraph.js
@@ -385,7 +385,7 @@ export const BubbleMarkersPathotypeHeatmapGraph = ({ showFilter, setShowFilter }
                 <div className={classes.selectPreWrapper}>
                   <div className={classes.selectWrapper}>
                     <div className={classes.labelWrapper}>
-                      <Typography variant="caption">{t('common.selectPathotype')}</Typography>
+                      <Typography variant="caption">{t('common.selectPathotypes')}</Typography>
                       <Tooltip title="If there are too many pathotypes, only the first 20 are shown" placement="top">
                         <InfoOutlined color="action" fontSize="small" className={classes.labelTooltipIcon} />
                       </Tooltip>

--- a/client/src/components/Elements/Map/MapFilters/MapFilters.js
+++ b/client/src/components/Elements/Map/MapFilters/MapFilters.js
@@ -313,6 +313,11 @@ export const MapFilters = ({ showFilter, setShowFilter }) => {
       return 'lineages';
     }
 
+    // 'ST prevalence' plots the 7-locus MLST sequence type — say so explicitly.
+    if (mapView === 'ST prevalence') {
+      return 'sequenceType';
+    }
+
     if (['sentericaints', 'senterica'].includes(organism)) {
       return 'STs';
     }
@@ -328,6 +333,7 @@ export const MapFilters = ({ showFilter, setShowFilter }) => {
     isNGMASTPrevalence,
     isLincodePrevalence,
     isLincodeAliasPrevalence,
+    mapView,
     organism,
   ]);
 

--- a/client/src/components/Home/Home.js
+++ b/client/src/components/Home/Home.js
@@ -18,7 +18,7 @@ const NEXT_PATHOGEN_FORM_URL = 'https://forms.gle/BPw8JMzpvhQzs7Y98';
 // with connecting rungs. Uses currentColor so `sx={{ color }}` applies.
 const DnaIcon = props => (
   <SvgIcon {...props} viewBox="0 0 24 24">
-    <g fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round">
+    <g fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
       <path d="M8 2c0 5 8 5 8 10s-8 5-8 10" />
       <path d="M16 2c0 5-8 5-8 10s8 5 8 10" />
       <path d="M8.6 5h6.8M7.2 9h9.6M7.2 15h9.6M8.6 19h6.8" />
@@ -171,7 +171,7 @@ export const HomePage = () => {
                       background: 'linear-gradient(135deg, #1b1b2f 0%, #0f3460 100%)',
                     }}
                   >
-                    <DnaIcon sx={{ fontSize: matches600 ? 36 : 72, color: 'rgba(255, 255, 255, 0.9)' }} />
+                    <DnaIcon sx={{ fontSize: matches600 ? 40 : 80, color: '#ffffff' }} />
                   </div>
                   <div
                     className={classes.organismLegend}

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -49,7 +49,8 @@
           "NGMAST": "NG-MAST",
           "lineages": "lineages",
           "STs": "STs",
-          "genotypes": "genotypes"
+          "genotypes": "genotypes",
+          "sequenceType": "sequence type"
         },
         "definitions": {
           "XDR": {
@@ -545,7 +546,8 @@
     "selectDrugsToCompare": "Select drugs to compare",
     "allCountries": "All countries",
     "allCountriesInRegion": "All countries in region",
-    "selectACountry": "Select a country"
+    "selectACountry": "Select a country",
+    "selectPathotypes": "Select pathotypes"
   },
   "pdf": {
     "reportInformation": "Report Information",

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -49,7 +49,8 @@
           "NGMAST": "NG-MAST",
           "lineages": "linajes",
           "STs": "STs",
-          "genotypes": "genotipos"
+          "genotypes": "genotipos",
+          "sequenceType": "tipo de secuencia"
         },
         "definitions": {
           "XDR": {
@@ -492,7 +493,8 @@
     "selectDrugsToCompare": "Seleccionar medicamentos para comparar",
     "allCountries": "Todos los países",
     "allCountriesInRegion": "Todos los países de la región",
-    "selectACountry": "Seleccionar un país"
+    "selectACountry": "Seleccionar un país",
+    "selectPathotypes": "Seleccionar patotipos"
   },
   "pdf": {
     "reportInformation": "Información del informe",

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -49,7 +49,8 @@
           "NGMAST": "NG-MAST",
           "lineages": "lignées",
           "STs": "STs",
-          "genotypes": "génotypes"
+          "genotypes": "génotypes",
+          "sequenceType": "type de séquence"
         },
         "definitions": {
           "XDR": {
@@ -492,7 +493,8 @@
     "selectDrugsToCompare": "Sélectionner des antibiotiques à comparer",
     "allCountries": "Tous les pays",
     "allCountriesInRegion": "Tous les pays de la région",
-    "selectACountry": "Sélectionner un pays"
+    "selectACountry": "Sélectionner un pays",
+    "selectPathotypes": "Sélectionner les pathotypes"
   },
   "pdf": {
     "reportInformation": "Informations du rapport",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -49,7 +49,8 @@
           "NGMAST": "NG-MAST",
           "lineages": "linhagens",
           "STs": "STs",
-          "genotypes": "genótipos"
+          "genotypes": "genótipos",
+          "sequenceType": "tipo de sequência"
         },
         "definitions": {
           "XDR": {
@@ -532,7 +533,8 @@
     "selectDrugsToCompare": "Selecionar medicamentos para comparar",
     "allCountries": "Todos os países",
     "allCountriesInRegion": "Todos os países da região",
-    "selectACountry": "Selecionar um país"
+    "selectACountry": "Selecionar um país",
+    "selectPathotypes": "Selecionar patotipos"
   },
   "pdf": {
     "reportInformation": "Informações do relatório",

--- a/client/src/util/mapLegends.js
+++ b/client/src/util/mapLegends.js
@@ -66,10 +66,12 @@ export const mapLegends = [
     organisms: ['sentericaints', 'senterica'],
   },
   {
-    // shige: numeric LINcode lineage (all species)
+    // shige: the genotype mapped from the LINcode (not the LINcode itself), so
+    // it is presented as 'Genotype prevalence'. The internal value is kept as
+    // 'Lincode prevalence' because it keys the LINCODE_NUM stats column.
     value: 'Lincode prevalence',
-    label: 'Lincode prevalence',
-    labelKey: 'dashboard.mapViews.lincodePrevalence',
+    label: 'Genotype prevalence',
+    labelKey: 'dashboard.mapViews.genotypePrevalence',
     organisms: ['shige'],
   },
   {
@@ -94,16 +96,17 @@ export const mapLegends = [
     organisms: ['ecoli', 'decoli'],
   },
   {
+    // shige removed per review — O/H prevalence are not shown on the Shigella map.
     value: 'O prevalence',
     label: 'O prevalence',
     labelKey: 'dashboard.mapViews.oPrevalence',
-    organisms: ['ecoli', 'decoli', 'shige'],
+    organisms: ['ecoli', 'decoli'],
   },
   {
     value: 'H prevalence',
     label: 'H prevalence',
     labelKey: 'dashboard.mapViews.hPrevalence',
-    organisms: ['ecoli', 'decoli', 'shige'],
+    organisms: ['ecoli', 'decoli'],
   },
   {
     value: 'No. Samples',


### PR DESCRIPTION
Low-risk items from Kat's July 1 feedback (the ones that don't change plot design).

| # | Feedback | Change |
|---|---|---|
| 4a | "not displaying lincodes, it is displaying genotypes mapped from LINcodes — change label to 'Genotype prevalence'" | Shigella map view now **labelled 'Genotype prevalence'**; internal value stays `Lincode prevalence` (keys the `LINCODE_NUM` stats) and reuses the existing `genotypePrevalence` translations, so plot titles and downloads follow automatically |
| 8 | "remove 'O prevalence' and 'H prevalence' from the Shigella map" | Removed `shige` from both entries |
| 7 | "When viewing ST prevalence, the menu label should say 'Select sequence type'" | New `labels.sequenceType` key (en/es/fr/pt); used for the `ST prevalence` view |
| 4c | "label should say 'Select pathotypes' not 'common.selectPathotype'" | The key lived under `topLeftControls`, so the raw key was rendered. Added `common.selectPathotypes` in all four locales and used it |
| — | "the DNA icon is blurry to me" | Thicker strokes + full white on the Surprise tile icon |

**Not included** (need your sign-off first, as they change design): removing the alias view, the new real 'LIN code prevalence' plot with starts-with search, species prefixes on labels (Ss/Sd/Sb/Sf), and the TSV download rework.

`craco build` passes.