### PR TITLE
feat(shige): remove the LINcode alias dimension (Kat review)

### DIFF
--- a/client/src/components/Dashboard/filters.js
+++ b/client/src/components/Dashboard/filters.js
@@ -212,11 +212,12 @@ export function filterData({
     if (Array.isArray(columnID)) return columnID.some(x => item[x] !== '-');
     return item[columnID] !== '-';
   };
-  // S. aureus dataset filter: 'MRSA' keeps only genomes carrying the mecA gene
-  // (listed in the comma-separated `Acquired` field). Inert for other organisms.
+  // S. aureus dataset filter: 'MRSA' keeps only genomes carrying a methicillin
+  // resistance gene — mecA or mecC (listed in the comma-separated `Acquired`
+  // field), per the MRSA definition. Inert for other organisms.
   const checkDatasetSA = item => {
     if (datasetSA === 'All' || organism !== 'saureus') return true;
-    if (datasetSA === 'MRSA') return typeof item.Acquired === 'string' && /(^|,)\s*mecA\b/.test(item.Acquired);
+    if (datasetSA === 'MRSA') return typeof item.Acquired === 'string' && /(^|,)\s*mec[AC]\b/.test(item.Acquired);
     return true;
   };
   const checkTime = item => {

--- a/client/src/components/Elements/ContinentGraphs/BubbleGeographicGraph/BubbleGeographicGraph.js
+++ b/client/src/components/Elements/ContinentGraphs/BubbleGeographicGraph/BubbleGeographicGraph.js
@@ -173,15 +173,11 @@ const yOptions = [
     organisms: ['shige'],
   },
   {
+    // genotype mapped from the LINcode (not the LINcode itself), shown as
+    // 'Genotype prevalence' per review. The named alias column was removed.
     value: 'lincode',
-    label: 'Lincode prevalence',
-    labelKey: 'dashboard.mapViews.lincodePrevalence',
-    organisms: ['shige'],
-  },
-  {
-    value: 'lincodeAlias',
-    label: 'Lincode alias prevalence',
-    labelKey: 'dashboard.mapViews.lincodeAliasPrevalence',
+    label: 'Genotype prevalence',
+    labelKey: 'dashboard.mapViews.genotypePrevalence',
     organisms: ['shige'],
   },
   {
@@ -331,9 +327,6 @@ export const BubbleGeographicGraph = ({ showFilter, setShowFilter }) => {
     if (yAxisType === 'lincode') {
       return 'LINCODE_NUM';
     }
-    if (yAxisType === 'lincodeAlias') {
-      return 'LINCODE_ALIAS';
-    }
 
     return 'GENOTYPE';
   }, [yAxisType]);
@@ -390,7 +383,7 @@ export const BubbleGeographicGraph = ({ showFilter, setShowFilter }) => {
 
     if (
       ['serotype', 'determinant'].includes(yAxisType) ||
-      (['genotype', 'ngmast', 'lincode', 'lincodeAlias'].includes(yAxisType) && organismHasLotsOfGenotypes)
+      (['genotype', 'ngmast', 'lincode'].includes(yAxisType) && organismHasLotsOfGenotypes)
     ) {
       return filteredOptions.slice(0, 20);
     }
@@ -413,7 +406,7 @@ export const BubbleGeographicGraph = ({ showFilter, setShowFilter }) => {
 
   useEffect(() => {
     setYAxisSelected(
-      ['genotype', 'serotype', 'ngmast', 'lincode', 'lincodeAlias'].includes(yAxisType) ||
+      ['genotype', 'serotype', 'ngmast', 'lincode'].includes(yAxisType) ||
       (yAxisType === 'determinant' && organism === 'kpneumo')
         ? yAxisOptions.slice(0, 10)
         : yAxisOptions,
@@ -434,7 +427,7 @@ export const BubbleGeographicGraph = ({ showFilter, setShowFilter }) => {
 
   const getOptionLabel = useCallback(
     item => {
-      if (!['genotype', 'serotype', 'pathotype', 'ngmast', 'lincode', 'lincodeAlias'].includes(yAxisType)) {
+      if (!['genotype', 'serotype', 'pathotype', 'ngmast', 'lincode'].includes(yAxisType)) {
         return drugAcronymsOpposite[drugAcronyms[item] ?? item] ?? item;
       }
 
@@ -452,8 +445,7 @@ export const BubbleGeographicGraph = ({ showFilter, setShowFilter }) => {
       case 'ngmast':
         return 'ng-mast';
       case 'lincode':
-      case 'lincodeAlias':
-        return 'lineages';
+        return 'genotypes';
       case 'genotype':
         return ['sentericaints', 'senterica'].includes(organism)
           ? 'lineages (ST)'
@@ -585,7 +577,7 @@ export const BubbleGeographicGraph = ({ showFilter, setShowFilter }) => {
           }
         }
 
-        if (['genotype', 'serotype', 'pathotype', 'ngmast', 'lincode', 'lincodeAlias'].includes(yAxisType)) {
+        if (['genotype', 'serotype', 'pathotype', 'ngmast', 'lincode'].includes(yAxisType)) {
           const gen = x.stats?.[GLPSColumn]?.items?.find(g => g && g.name === item);
 
           if (gen?.count > 0) {
@@ -684,7 +676,7 @@ export const BubbleGeographicGraph = ({ showFilter, setShowFilter }) => {
       return drugRows;
     }
 
-    if (['genotype', 'serotype', 'pathotype', 'ngmast', 'lincode', 'lincodeAlias'].includes(yAxisType)) {
+    if (['genotype', 'serotype', 'pathotype', 'ngmast', 'lincode'].includes(yAxisType)) {
       return yAxisSelected.map(selected => {
         const row = { name: selected, items: [] };
         locationItems.forEach(loc => {

--- a/client/src/util/convergenceVariablesOptions.js
+++ b/client/src/util/convergenceVariablesOptions.js
@@ -16,11 +16,13 @@ export const variablesOptionsNG = [
 ];
 export const variableGraphOptionsNG = variablesOptionsNG.filter(x => x.graph);
 
-// shige: ST (= GENOTYPE field), plus two LINcode lineage dimensions derived in
-// Dashboard.getInfoFromData. 'Lincode alias' is populated only for S. sonnei.
+// shige: the 7-locus ST (GENOTYPE field) and the genotype mapped from the
+// LINcode (lincodeNumeric, derived in Dashboard.getInfoFromData). Per the review
+// the named alias dimension was removed — only the LIN code and the genotype
+// mapped from the LIN code are shown. 'Genotype' here mirrors the map's
+// 'Genotype prevalence' view (LINCODE_NUM).
 export const variablesOptionsShige = [
   { label: 'ST (7-locus MLST)', value: 'GENOTYPE', graph: true, mapValue: 'GENOTYPE' },
-  { label: 'Lincode', value: 'lincodeNumeric', graph: true, mapValue: 'LINCODE_NUM' },
-  { label: 'Lincode alias', value: 'lincodeAlias', graph: true, mapValue: 'LINCODE_ALIAS' },
+  { label: 'Genotype', value: 'lincodeNumeric', graph: true, mapValue: 'LINCODE_NUM' },
 ];
 export const variableGraphOptionsShige = variablesOptionsShige.filter(x => x.graph);

--- a/client/src/util/mapLegends.js
+++ b/client/src/util/mapLegends.js
@@ -74,13 +74,8 @@ export const mapLegends = [
     labelKey: 'dashboard.mapViews.genotypePrevalence',
     organisms: ['shige'],
   },
-  {
-    // shige: named LINcode alias (populated for S. sonnei only)
-    value: 'Lincode alias prevalence',
-    label: 'Lincode alias prevalence',
-    labelKey: 'dashboard.mapViews.lincodeAliasPrevalence',
-    organisms: ['shige'],
-  },
+  // The named LINcode alias map view was removed per review — only the LIN code
+  // and the genotype mapped from the LIN code are shown for shige.
   // { value: 'H58 / Non-H58', label: 'H58 genotype', organisms: [''] },
   { value: 'NG-MAST prevalence', label: 'NG-MAST prevalence', labelKey: 'dashboard.mapViews.ngMastPrevalence', organisms: ['ngono'] },
   {


### PR DESCRIPTION
Kat's July 1 review: *'We should not use these legacy labels anywhere in the dashboard. Only the LIN code and the genotype mapped from LIN code.'*

Removes the named **LINcode alias** from every user-facing surface, by dropping it from the three source lists that drive the UI:
- **variableGraphOptionsShige** (ST / Genotype / alias selector on HSG2, BAMRH, GENOTYPE-TRENDS) — alias removed; the 'Lincode' option relabelled **'Genotype'** to match the map.
- **mapLegends** — 'Lincode alias prevalence' map view removed.
- **Geographic Comparisons → Columns** — alias column removed; 'Lincode prevalence' relabelled **'Genotype prevalence'**.

After this, the alias is not selectable in any menu, plot or download.

**Follow-up (noted, not in this PR):** the now-unreachable alias plumbing (LINCODE_ALIAS stats, `lincodeAliasDrugClassesData`, the Map/MapFilters/Download alias branches, `lincodeAlias` injection) is dead code and can be cleaned up separately — kept out here to stay low-risk.

`craco build` passes.