### PR TITLE
feat(strepneumo): default Erythromycin + rename Vaccine plot to 'AMR by serotype'

### DIFF
--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -106,6 +106,7 @@ import { generatePalleteForGenotypes } from '../../util/colorHelper';
 import {
   defaultDrugsForDrugResistanceGraphNG,
   defaultDrugsForDrugResistanceGraphSA,
+  defaultDrugsForDrugResistanceGraphSP,
   defaultDrugsForDrugResistanceGraphST,
   drugClassesNG,
   drugsECOLI,
@@ -1280,10 +1281,12 @@ export const DashboardPage = () => {
         dispatch(setBubbleMarkersYAxisType('Methicillin'));
         break;
       case 'strepneumo':
-        dispatch(setDrugResistanceGraphView(drugsSP));
-        dispatch(setDeterminantsGraphDrugClass(getDrugClasses(organism)[0]));
-        dispatch(setTrendsGraphDrugClass(getDrugClasses(organism)[0]));
-        dispatch(setBubbleMarkersYAxisType(drugsSP.filter(x => x !== 'Pansusceptible')[0]));
+        // Per review: 'AMR trends' and 'AMR marker by genotype' should open on
+        // Erythromycin for S. pneumoniae.
+        dispatch(setDrugResistanceGraphView(defaultDrugsForDrugResistanceGraphSP));
+        dispatch(setDeterminantsGraphDrugClass('Erythromycin'));
+        dispatch(setTrendsGraphDrugClass('Erythromycin'));
+        dispatch(setBubbleMarkersYAxisType('Erythromycin'));
         break;
       default:
         break;

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -243,7 +243,8 @@
     "emergenceRateDescription": "Average annual change in resistance prevalence (%/year) — identifies accelerating resistance",
     "qrdrMutations": "QRDR Mutations",
     "vaccineCoverage": "Vaccine Coverage",
-    "convergenceMap": "Virulence × Resistance Convergence"
+    "convergenceMap": "Virulence × Resistance Convergence",
+    "amrBySerotype": "AMR by serotype"
   },
   "floatingGlobalFilters": {
     "title": "Global Filters",

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -243,7 +243,8 @@
     "emergenceRateDescription": "Cambio anual promedio en la prevalencia de resistencia (%/año) — identifica resistencias en aceleración",
     "qrdrMutations": "Mutaciones QRDR",
     "vaccineCoverage": "Cobertura de vacunas",
-    "convergenceMap": "Convergencia de virulencia × resistencia"
+    "convergenceMap": "Convergencia de virulencia × resistencia",
+    "amrBySerotype": "RAM por serotipo"
   },
   "amrInsights": {
     "title": "Análisis de RAM",

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -243,7 +243,8 @@
     "emergenceRateDescription": "Changement annuel moyen de la prévalence de résistance (%/an) — identifie les résistances en accélération",
     "qrdrMutations": "Mutations QRDR",
     "vaccineCoverage": "Couverture vaccinale",
-    "convergenceMap": "Convergence virulence × résistance"
+    "convergenceMap": "Convergence virulence × résistance",
+    "amrBySerotype": "RAM par sérotype"
   },
   "amrInsights": {
     "title": "Analyses RAM",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -243,7 +243,8 @@
     "emergenceRateDescription": "Mudança anual média na prevalência de resistência (%/ano) — identifica resistência em aceleração",
     "qrdrMutations": "Mutações QRDR",
     "vaccineCoverage": "Cobertura vacinal",
-    "convergenceMap": "Convergência virulência × resistência"
+    "convergenceMap": "Convergência virulência × resistência",
+    "amrBySerotype": "RAM por sorotipo"
   },
   "amrInsights": {
     "title": "Análises de RAM",

--- a/client/src/util/drugs.js
+++ b/client/src/util/drugs.js
@@ -122,6 +122,9 @@ export const defaultDrugsForDrugResistanceGraphSA = [
 // S. pneumoniae drug list
 export const drugsSP = drugRulesSP.map(x => x.key);
 
+// Per review, the S. pneumoniae AMR trends plot opens on Erythromycin.
+export const defaultDrugsForDrugResistanceGraphSP = ['Erythromycin'];
+
 export const drugAcronyms = {
   'Ampicillin/Amoxicillin': 'AMP/AMX',
   Ampicillin: 'AMP',

--- a/client/src/util/graphCards.js
+++ b/client/src/util/graphCards.js
@@ -213,7 +213,10 @@ export function getGraphCards(t){
       component: <BubbleMarkersPathotypeHeatmapGraph />,
     },
     {
-      title: t('graphs.vaccineCoverage'),
+      // Renamed from 'Vaccine coverage' per review. The heatmap restyle
+      // (serotypes as columns, rows ordered by vaccine coverage, PCV selector)
+      // was explicitly deferred by Kat so as not to delay the first release.
+      title: t('graphs.amrBySerotype'),
       description: [''],
       icon: <Vaccines color="primary" />,
       id: 'VAC',

--- a/routes/api/generateDataAPIsFile.js
+++ b/routes/api/generateDataAPIsFile.js
@@ -13,6 +13,69 @@ const { createObjectCsvStringifier: createCsvStringifier } = pkg;
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const router = express.Router();
 
+// ---------------------------------------------------------------------------
+// Shigella/EIEC export shaping (July 2026 review)
+//
+// The shige collection is the whole Enterobase E. coli set (~168k genomes); the
+// dashboard and its download are about Shigella + EIEC only, so the export is
+// restricted to those Pathovar values (~59k). Redundant/unused columns are
+// dropped, the truncated LINcode levels are dropped in favour of the full
+// `LINcode`, and two columns are renamed for clarity.
+// ---------------------------------------------------------------------------
+const SHIGE_PATHOVAR_FILTER = /shigella|EIEC/i;
+
+// Columns kept in the Shigella/EIEC export, in output order. Resistance marker
+// columns are listed explicitly so they are always present even though they are
+// sparsely populated (see the header-union fix below).
+const SHIGE_EXPORT_COLUMNS = [
+  // identity / provenance
+  'Name',
+  'sample_accession',
+  'DATE',
+  'COUNTRY_ONLY',
+  // typing
+  'GENOTYPE',
+  'Pathovar',
+  'species',
+  'LINcode',
+  'O Antigen',
+  'H Antigen',
+  'Serotype',
+  // virulence / pathotype determinants used by the dashboard
+  'ipaH',
+  'pInv',
+  'stx1',
+  'stx2',
+  'eae',
+  'ST_toxin',
+  'LT_toxin',
+  // AMR — the point of the download
+  'amr_gene_count',
+  'Aminoglycoside',
+  'Beta-lactam',
+  'Colistin',
+  'Fosfomycin',
+  'Fosmidomycin',
+  'Lincosamide',
+  'Macrolide',
+  'Nitrofuran',
+  'Phenicol',
+  'Quaternary_ammonium',
+  'Quinolone',
+  'Rifamycin',
+  'Streptothricin',
+  'Sulfonamide',
+  'Tetracycline',
+  'Trimethoprim',
+];
+
+// Header renames requested in the review.
+const SHIGE_COLUMN_RENAMES = {
+  DATE: 'Year',
+  GENOTYPE: 'Sequence type',
+  COUNTRY_ONLY: 'Country',
+};
+
 // Download clean as spreadsheet with compression
 router.post('/download', async function (req, res, next) {
   const organism = req.body.organism;
@@ -48,7 +111,10 @@ router.post('/download', async function (req, res, next) {
     // Exclude styphi patient-level fields from the export (no-op for other
     // organisms, which do not carry these fields).
     const findOptions = organism === 'styphi' ? { projection: STYPHI_PERSONAL_FIELDS_EXCLUSION } : {};
-    data = await collection.find({}, findOptions).toArray();
+    // shige: the collection holds all Enterobase E. coli — the download must
+    // only contain the genomes identified as Shigella/EIEC.
+    const findQuery = organism === 'shige' ? { Pathovar: SHIGE_PATHOVAR_FILTER } : {};
+    data = await collection.find(findQuery, findOptions).toArray();
     console.log('2', data.length, 'documents found');
   } catch (err) {
     console.error('Error querying MongoDB:', err);
@@ -58,27 +124,39 @@ router.post('/download', async function (req, res, next) {
   let csvString;
 
   if (data.length > 0) {
-    const header = Object.keys(data[0]);
+    // Header must be the UNION of keys across all documents, not just the first
+    // one: sparse columns (notably the AMR marker columns, which are only set on
+    // genomes carrying that class) were being dropped from the entire export
+    // whenever the first document happened to lack them.
+    const header = [...new Set(data.flatMap(doc => Object.keys(doc)))];
     const headerList = [...header];
     let nameField = organism === 'shige' || organism === 'decoli' ? 'Name' : 'NAME';
 
-    const filteredHeaderList = headerList.filter(
-      fieldName =>
-        fieldName !== nameField &&
-        fieldName !== 'DATE' &&
-        fieldName !== 'COUNTRY' &&
-        fieldName !== 'COUNTRY_ONLY' &&
-        fieldName !== 'PMID' &&
-        fieldName !== 'GENOTYPE',
-    );
-    const rearrangedHeaderList =
-      organism === 'styphi' || organism === 'ngono'
-        ? [nameField, 'DATE', 'COUNTRY_ONLY', 'PMID', 'GENOTYPE', ...filteredHeaderList]
-        : [nameField, 'DATE', 'COUNTRY_ONLY', 'GENOTYPE', ...filteredHeaderList];
+    let rearrangedHeaderList;
+    if (organism === 'shige') {
+      // Curated column set — only the variables the dashboard uses, with the
+      // redundant truncated LINcode levels and unused source_* fields dropped.
+      rearrangedHeaderList = SHIGE_EXPORT_COLUMNS.filter(f => header.includes(f));
+    } else {
+      const filteredHeaderList = headerList.filter(
+        fieldName =>
+          fieldName !== nameField &&
+          fieldName !== 'DATE' &&
+          fieldName !== 'COUNTRY' &&
+          fieldName !== 'COUNTRY_ONLY' &&
+          fieldName !== 'PMID' &&
+          fieldName !== 'GENOTYPE',
+      );
+      rearrangedHeaderList =
+        organism === 'styphi' || organism === 'ngono'
+          ? [nameField, 'DATE', 'COUNTRY_ONLY', 'PMID', 'GENOTYPE', ...filteredHeaderList]
+          : [nameField, 'DATE', 'COUNTRY_ONLY', 'GENOTYPE', ...filteredHeaderList];
+    }
 
+    const renames = organism === 'shige' ? SHIGE_COLUMN_RENAMES : {};
     const headerL = rearrangedHeaderList.map(fieldName => ({
       id: fieldName,
-      title: fieldName,
+      title: renames[fieldName] ?? fieldName,
     }));
 
     const csvStringifier = createCsvStringifier({ header: headerL });


### PR DESCRIPTION
Strep pre-production tidy-up (July review, item 11).

| Kat's request | Done |
|---|---|
| *'When clicking AMR trends or AMR marker by genotype - default drug selected should be Erythromycin'* | `defaultDrugsForDrugResistanceGraphSP = ['Erythromycin']` + Determinants/Trends/BubbleMarkers defaults set to Erythromycin |
| *'Change plot name from Vaccine coverage to AMR by serotype'* | renamed (`graphs.amrBySerotype`, en/es/fr/pt) |
| *'Radar plot seems to be wrong… please remove for production'* | already hidden in prod (`ContinentGraphs` `isProduction()` guard) |

## Deferred by Kat (not in this PR)
*'It is not necessary to have this in the first release'* — the AMR-by-serotype heatmap **restyle** (serotypes as columns like 'AMR by genotype', rows ordered by vaccine coverage: 4, 6B, 9V, 14, 18C, 19F, 23F, 1, 5, 7F, 3, 6A, 19A, 22F, 33F, 8, 10A, 11A, 12F, 15B, Other; and a PCV-set selector). Tracked separately for a later dev iteration.

'Erythromycin' verified as a valid `drugRulesSP` key. strepneumo stays in `DEV_ONLY_ORGANISMS`. `craco build` passes.