### PR TITLE
feat(shige): species-prefixed labels + EIEC ST-based aliases

### DIFF
--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -116,7 +116,7 @@ import {
   markersDrugsSH,
 } from '../../util/drugs';
 import { isProduction } from '../../util/env';
-import { deriveShigeLincode, resolveShigeLincode } from '../../util/shigeLincode';
+import { shigeGenotypeLabel } from '../../util/shigeLincode';
 import { getContinentGraphCard } from '../../util/graphCards';
 import { DEV_ONLY_ORGANISMS } from '../../util/organismsCards';
 import { AMRInsights } from '../Elements/AMRInsights';
@@ -316,10 +316,10 @@ export const DashboardPage = () => {
     // 'Lincode prevalence' map views can group/aggregate by them.
     if (organism === 'shige' && Array.isArray(responseData)) {
       responseData = responseData.map(item => {
-        const { numeric } = deriveShigeLincode(resolveShigeLincode(item));
-        // null (not '-') so unmatched genomes are skipped by the stats grouping
-        // (which ignores falsy values) rather than forming a spurious '-' group.
-        return { ...item, lincodeNumeric: numeric ?? null };
+        // Species-prefixed lineage label ('Ss 3.7.25'); EIEC keyed by ST
+        // ('EIEC ST270'). null (not '-') so unmatched genomes are skipped by
+        // the stats grouping rather than forming a spurious '-' group.
+        return { ...item, lincodeNumeric: shigeGenotypeLabel(item) ?? null };
       });
     }
 
@@ -1678,8 +1678,7 @@ export const DashboardPage = () => {
     if (organism === 'shige') {
       storeData = storeData.map(item => {
         if (item.lincodeNumeric !== undefined) return item;
-        const { numeric } = deriveShigeLincode(resolveShigeLincode(item));
-        return { ...item, lincodeNumeric: numeric ?? null };
+        return { ...item, lincodeNumeric: shigeGenotypeLabel(item) ?? null };
       });
     }
 

--- a/client/src/util/shigeLincode.js
+++ b/client/src/util/shigeLincode.js
@@ -80,3 +80,52 @@ export function deriveShigeLincode(lincode) {
   if (!entry) return { numeric: null, species: null };
   return { numeric: entry.numeric, species: entry.species };
 }
+
+// Two-letter species code from the Pathovar field, per Kat's July 2026 review
+// ('Ss 3.7.25', and EIEC lineages keyed by ST). Shigella species map to
+// Ss/Sf/Sb/Sd; enteroinvasive E. coli maps to EIEC. Other pathotypes and
+// non-target genomes return '' (no lineage label).
+const SPECIES_CODES = [
+  [/sonnei/i, 'Ss'],
+  [/flexneri/i, 'Sf'],
+  [/boydii/i, 'Sb'],
+  [/dysenteriae/i, 'Sd'],
+  [/EIEC/i, 'EIEC'],
+];
+export function shigeSpeciesCode(pathovar) {
+  if (!pathovar) return '';
+  for (const [re, code] of SPECIES_CODES) {
+    if (re.test(pathovar)) return code;
+  }
+  return '';
+}
+
+/**
+ * Lineage label for the 'Genotype prevalence' dimension, per the July 2026
+ * review:
+ *   - Shigella with a LINcode-mapped genotype -> species-prefixed genotype
+ *     ('Ss 3.7.25'); labels that already carry the species code (e.g. 'Sb20')
+ *     are left as-is to avoid doubling.
+ *   - EIEC -> always an ST-based alias ('EIEC ST270'), since the LINcode
+ *     genotype scheme is Shigella-centric and EIEC/Shigella share prefixes.
+ *   - Shigella without a genotype match -> species-prefixed ST fallback.
+ * Returns null for non-target genomes (no lineage label).
+ *
+ * @param {object} item - a genome record (needs Pathovar, GENOTYPE, LINcode*)
+ * @returns {string|null}
+ */
+export function shigeGenotypeLabel(item) {
+  if (!item) return null;
+  const code = shigeSpeciesCode(item.Pathovar);
+  const st = item.GENOTYPE && item.GENOTYPE !== '-' ? item.GENOTYPE : null;
+
+  if (code === 'EIEC') return st ? `EIEC ${st}` : null;
+
+  const { numeric } = deriveShigeLincode(resolveShigeLincode(item));
+  if (numeric) {
+    if (!code) return numeric;
+    return numeric.toLowerCase().startsWith(code.toLowerCase()) ? numeric : `${code} ${numeric}`;
+  }
+  // Shigella species with no genotype match — fall back to the species-prefixed ST.
+  return code && st ? `${code} ${st}` : null;
+}


### PR DESCRIPTION
Implements Kat's July review for the Shigella 'Genotype prevalence' dimension (items on species prefix + EIEC ST aliases). Dev only until she validates in September.

## Rules
- **Species prefix** on the LINcode-mapped genotype labels: `Ss 3.7.25` (Ss/Sf/Sb/Sd from Pathovar); labels already carrying the code (e.g. `Sb20`) are left as-is.
- **EIEC** keyed by ST: `EIEC ST270` / `EIEC ST99` / `EIEC ST6` (the LINcode genotype scheme is Shigella-centric and EIEC shares prefixes, so ST is the right backbone — matches Kat's Slack).
- Shigella with no genotype match → species-prefixed ST fallback (`Ss ST152`).

## Verified on the live DB (8,000 Shigella/EIEC sampled)
- 99.98% labelled.
- EIEC → `EIEC ST6` / `ST270` / `ST99` (Kat's three emergences).
- Examples: `Ss 3.7.25`, `Sf 3.2.1.3.1`, `Sf 2.3.5`, `Sb ST243`, `Sd ST148`.

## Implementation
`shigeSpeciesCode()` + `shigeGenotypeLabel(item)` in shigeLincode.js; used for the `lincodeNumeric` injection at both sites. Label flows to the map 'Genotype prevalence' view, graph selectors and downloads automatically.

## Note for review (Kat, September)
Fine genotype-name coverage (`Ss 3.7.25`) is limited by the current lookup (93 entries) — most genomes fall back to the species-prefixed ST for now; this improves automatically when the fuller ST/genotype table (Ebenezer / the DB-derived `shige_st_lineage_lookup.tsv` from #465) is adopted. `craco build` passes.