### PR TITLE
feat(strepneumo): restyle 'AMR by serotype' as a serotype heatmap (dev)

### DIFF
--- a/client/src/components/Elements/Graphs/SerotypeResistanceGraph/SerotypeResistanceGraph.js
+++ b/client/src/components/Elements/Graphs/SerotypeResistanceGraph/SerotypeResistanceGraph.js
@@ -1,82 +1,84 @@
-import { InfoOutlined } from '@mui/icons-material';
-import { Box, Card, CardContent, MenuItem, Select, Tooltip, Typography } from '@mui/material';
-import { useMemo, useState } from 'react';
+import { Clear, InfoOutlined } from '@mui/icons-material';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Checkbox,
+  Divider,
+  IconButton,
+  ListItemText,
+  MenuItem,
+  Select,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Cell,
+  Tooltip as ChartTooltip,
+  LabelList,
+  ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  XAxis,
+  YAxis,
+  ZAxis,
+} from 'recharts';
 import { useAppSelector } from '../../../../stores/hooks';
+import { darkGrey, hoverColor } from '../../../../util/colorHelper';
 import { drugsSP } from '../../../../util/drugs';
-import { PlottingOptionsHeader } from '../../Shared/PlottingOptionsHeader';
+import { longestVisualWidth, truncateWord } from '../../../../util/helpers';
+import { isTouchDevice } from '../../../../util/isTouchDevice';
+import { heatmapLegendGradient, heatmapTextColor, mixColorScale } from '../../Map/mapColorHelper';
 import { SelectCountry } from '../../SelectCountry';
+import { PlottingOptionsHeader } from '../../Shared/PlottingOptionsHeader';
 import { useStyles } from './SerotypeResistanceGraphMUI';
 
-const MIN_SEROTYPE_COUNT = 10;
-const MAX_SEROTYPES = 30;
+// Top axis area reserved for the rotated -45deg serotype column labels on the
+// first chart. Allocated via XAxis height so the cell row stays at the bottom
+// of the first chart, immediately adjacent to the next drug row below it.
+const FIRST_ROW_AXIS_HEIGHT = 90;
 
-/** Strip leading zeros from serotype numeric prefix: "06B"→"6B", "09V"→"9V", "03"→"3" */
-function normalizeSerotype(st) {
-  if (!st) return st;
-  return st
-    .toString()
-    .trim()
-    .replace(/^0+(\d)/, '$1');
-}
-
-// PCV vaccine coverage — canonical (non-zero-padded) serotype lists
-const PCV7_SEROTYPES = ['4', '6B', '9V', '14', '18C', '19F', '23F'];
-const PCV10_SEROTYPES = ['1', '4', '5', '6B', '7F', '9V', '14', '18C', '19F', '23F'];
-const PCV13_SEROTYPES = ['1', '3', '4', '5', '6A', '6B', '7F', '9V', '14', '18C', '19A', '19F', '23F'];
-const PCV15_SEROTYPES = ['1', '3', '4', '5', '6A', '6B', '7F', '9V', '14', '18C', '19A', '19F', '22F', '23F', '33F'];
-const PCV20_EXTRA = ['8', '10A', '11A', '12F', '15B', '22F', '33F'];
-const PCV20_SEROTYPES = [...PCV13_SEROTYPES, ...PCV20_EXTRA];
-
-// Sets for "first introduced in" coloring (canonical forms only)
-const PCV7_FIRST = new Set(PCV7_SEROTYPES);
-const PCV10_FIRST = new Set(PCV10_SEROTYPES.filter(s => !PCV7_FIRST.has(s)));
-const PCV13_FIRST = new Set(PCV13_SEROTYPES.filter(s => !PCV10_SEROTYPES.includes(s)));
-const PCV15_FIRST = new Set(['22F', '33F']);
-const PCV20_FIRST = new Set(['8', '10A', '11A', '12F', '15B']);
-
-const VACCINE_COLORS = {
-  pcv7: '#e65c00',
-  pcv10: '#00796b',
-  pcv13: '#1565c0',
-  pcv15: '#2e7d32',
-  pcv20: '#7b1fa2',
-};
-
-function getVaccineColor(st) {
-  const n = normalizeSerotype(st);
-  if (PCV7_FIRST.has(n)) return VACCINE_COLORS.pcv7;
-  if (PCV10_FIRST.has(n)) return VACCINE_COLORS.pcv10;
-  if (PCV13_FIRST.has(n)) return VACCINE_COLORS.pcv13;
-  if (PCV15_FIRST.has(n)) return VACCINE_COLORS.pcv15;
-  if (PCV20_FIRST.has(n)) return VACCINE_COLORS.pcv20;
-  return null;
-}
-
-const VACCINE_LEGEND = [
-  { key: 'pcv7', label: 'PCV7' },
-  { key: 'pcv10', label: 'PCV10+' },
-  { key: 'pcv13', label: 'PCV13+' },
-  { key: 'pcv15', label: 'PCV15+' },
-  { key: 'pcv20', label: 'PCV20+' },
+// Fixed serotype column order, by vaccine coverage (Kat's spec). Any serotype
+// not in this list is bucketed into 'Other', which is always rendered last.
+const SEROTYPE_ORDER = [
+  '4',
+  '6B',
+  '9V',
+  '14',
+  '18C',
+  '19F',
+  '23F',
+  '1',
+  '5',
+  '7F',
+  '3',
+  '6A',
+  '19A',
+  '22F',
+  '33F',
+  '8',
+  '10A',
+  '11A',
+  '12F',
+  '15B',
 ];
+const OTHER_LABEL = 'Other';
 
-function getPrevalenceColor(value) {
-  if (value === null || value === undefined) return '#f5f5f5';
-  if (value === 0) return '#e8f5e9';
-  if (value <= 10) return '#fff9c4';
-  if (value <= 30) return '#ffcc80';
-  if (value <= 60) return '#ef6c00';
-  return '#b71c1c';
-}
-
-function getTextColor(value) {
-  return value > 30 ? '#fff' : '#333';
+/** Strip leading zeros from a serotype's numeric prefix: "06B"→"6B", "09V"→"9V", "03"→"3". */
+function normalizeSerotype(st) {
+  if (st === null || st === undefined) return '';
+  return st.toString().trim().replace(/^0+(\d)/, '$1');
 }
 
 export const SerotypeResistanceGraph = ({ showFilter, setShowFilter }) => {
   const classes = useStyles();
-  const [sortBy, setSortBy] = useState('count');
-  const [vaccineFilter, setVaccineFilter] = useState('all');
+  const { t } = useTranslation();
+  const [drugsSelected, setDrugsSelected] = useState([]);
+  const [drugSearch, setDrugSearch] = useState('');
 
   const organism = useAppSelector(state => state.dashboard.organism);
   const canGetData = useAppSelector(state => state.dashboard.canGetData);
@@ -84,10 +86,10 @@ export const SerotypeResistanceGraph = ({ showFilter, setShowFilter }) => {
   const actualCountry = useAppSelector(state => state.dashboard.actualCountry);
   const actualRegion = useAppSelector(state => state.dashboard.actualRegion);
   const economicRegions = useAppSelector(state => state.dashboard.economicRegions);
+  const loadingPDF = useAppSelector(state => state.dashboard.loadingPDF);
 
-  // Filter rawData by selected country / region from the floating
-  // plotting-options panel. The SelectCountry component writes
-  // actualCountry / actualRegion into Redux on user selection.
+  // Filter rawData by the country / region chosen in the floating plotting-options
+  // panel. SelectCountry writes actualCountry / actualRegion into Redux.
   const rawData = useMemo(() => {
     if (!Array.isArray(rawDataAll) || rawDataAll.length === 0) return [];
     if (actualCountry && actualCountry !== 'All') {
@@ -101,331 +103,242 @@ export const SerotypeResistanceGraph = ({ showFilter, setShowFilter }) => {
     return rawDataAll;
   }, [rawDataAll, actualCountry, actualRegion, economicRegions]);
 
-  const drugs = useMemo(() => drugsSP.filter(d => d !== 'Pansusceptible'), []);
+  // Available drug rows for S. pneumoniae (Pansusceptible is not a resistance row).
+  const drugOptions = useMemo(() => drugsSP.filter(d => d !== 'Pansusceptible'), []);
 
-  // Compute serotype × resistance from raw data
-  const { serotypes, serotypeData } = useMemo(() => {
+  const filteredDrugOptions = useMemo(() => {
+    return drugOptions.filter(option => option.toLowerCase().includes(drugSearch.toLowerCase()));
+  }, [drugOptions, drugSearch]);
+
+  // Default to showing every drug as a row.
+  useEffect(() => {
+    setDrugsSelected(drugOptions);
+  }, [drugOptions]);
+
+  // Build the serotype × drug matrix from the raw genome data.
+  // Columns = serotypes present, ordered by SEROTYPE_ORDER, with 'Other' last.
+  const { columns, columnTotals, resistanceByColumn } = useMemo(() => {
     if (rawData.length === 0 || organism !== 'strepneumo') {
-      return { serotypes: [], serotypeData: {} };
+      return { columns: [], columnTotals: {}, resistanceByColumn: {} };
     }
 
-    // Group by serotype
-    const bySerotype = {};
-    rawData.forEach(item => {
-      const st = item.Serotype || 'Unknown';
-      if (!bySerotype[st]) bySerotype[st] = [];
-      bySerotype[st].push(item);
-    });
+    const totals = {};
+    const resistant = {};
 
-    // Compute resistance per serotype per drug
-    const data = {};
-    Object.entries(bySerotype).forEach(([st, items]) => {
-      if (items.length < MIN_SEROTYPE_COUNT) return;
-
-      // Apply vaccine filter — normalize before comparing
-      const nst = normalizeSerotype(st);
-      if (vaccineFilter === 'pcv7' && !PCV7_SEROTYPES.includes(nst)) return;
-      if (vaccineFilter === 'pcv10' && !PCV10_SEROTYPES.includes(nst)) return;
-      if (vaccineFilter === 'pcv13' && !PCV13_SEROTYPES.includes(nst)) return;
-      if (vaccineFilter === 'pcv15' && !PCV15_SEROTYPES.includes(nst)) return;
-      if (vaccineFilter === 'pcv20' && !PCV20_SEROTYPES.includes(nst)) return;
-      if (vaccineFilter === 'non-vaccine' && PCV20_SEROTYPES.includes(nst)) return;
-
-      data[st] = { count: items.length, drugs: {} };
-
-      drugs.forEach(drug => {
-        const resistant = items.filter(x => x[drug] === '1' || x[drug] === 1).length;
-        data[st].drugs[drug] = {
-          count: resistant,
-          prevalence: Number(((resistant / items.length) * 100).toFixed(1)),
-        };
+    const bump = (col, item) => {
+      totals[col] = (totals[col] || 0) + 1;
+      if (!resistant[col]) resistant[col] = {};
+      drugOptions.forEach(drug => {
+        if (item[drug] === '1' || item[drug] === 1) {
+          resistant[col][drug] = (resistant[col][drug] || 0) + 1;
+        }
       });
-
-      // Compute multi-drug resistance (resistant to ≥3 drugs)
-      const mdrCount = items.filter(item => {
-        const resistantDrugs = drugs.filter(d => item[d] === '1' || item[d] === 1).length;
-        return resistantDrugs >= 3;
-      }).length;
-      data[st].mdr = Number(((mdrCount / items.length) * 100).toFixed(1));
-    });
-
-    // Build "Others" aggregate row when a specific vaccine filter is active
-    const VACCINE_FILTER_SETS = {
-      pcv7: PCV7_SEROTYPES,
-      pcv10: PCV10_SEROTYPES,
-      pcv13: PCV13_SEROTYPES,
-      pcv15: PCV15_SEROTYPES,
-      pcv20: PCV20_SEROTYPES,
     };
-    const activeSet = VACCINE_FILTER_SETS[vaccineFilter];
-    if (activeSet) {
-      const otherItems = rawData.filter(item => !activeSet.includes(normalizeSerotype(item.Serotype)));
-      if (otherItems.length > 0) {
-        const otherCount = otherItems.length;
-        const otherDrugs = {};
-        drugs.forEach(drug => {
-          const resistant = otherItems.filter(x => x[drug] === '1' || x[drug] === 1).length;
-          otherDrugs[drug] = {
-            count: resistant,
-            prevalence: Number(((resistant / otherCount) * 100).toFixed(1)),
-          };
-        });
-        const otherMdr = otherItems.filter(item => {
-          return drugs.filter(d => item[d] === '1' || item[d] === 1).length >= 3;
-        }).length;
-        data['__OTHERS__'] = {
-          count: otherCount,
-          drugs: otherDrugs,
-          mdr: Number(((otherMdr / otherCount) * 100).toFixed(1)),
-          isOthers: true,
+
+    const orderSet = new Set(SEROTYPE_ORDER);
+    rawData.forEach(item => {
+      const st = normalizeSerotype(item.Serotype);
+      const col = orderSet.has(st) ? st : OTHER_LABEL;
+      bump(col, item);
+    });
+
+    // Keep the fixed order, dropping serotypes with no genomes, then append
+    // 'Other' when there are any off-list genomes.
+    const presentColumns = SEROTYPE_ORDER.filter(st => totals[st] > 0);
+    if (totals[OTHER_LABEL] > 0) presentColumns.push(OTHER_LABEL);
+
+    return { columns: presentColumns, columnTotals: totals, resistanceByColumn: resistant };
+  }, [rawData, organism, drugOptions]);
+
+  // One row per selected drug; within a row, one square per serotype column.
+  const chartRows = useMemo(() => {
+    if (columns.length === 0 || drugsSelected.length === 0) return [];
+
+    return drugsSelected.map(drug => ({
+      name: drug,
+      items: columns.map(col => {
+        const total = columnTotals[col] || 0;
+        const count = resistanceByColumn[col]?.[drug] || 0;
+        const percentage = total ? Number(((count / total) * 100).toFixed(2)) : 0;
+        return {
+          itemName: col,
+          typeName: drug,
+          count,
+          total,
+          percentage,
+          index: 1,
         };
-      }
+      }),
+    }));
+  }, [columns, drugsSelected, columnTotals, resistanceByColumn]);
+
+  const yAxisWidth = useMemo(() => longestVisualWidth(drugsSelected ?? []), [drugsSelected]);
+
+  function handleChangeDrugsSelected({ event = null, all = false }) {
+    const value = event?.target.value;
+
+    if (value?.length === 1 && value[0] === undefined) return;
+
+    if (!all) {
+      setDrugsSelected(value);
+      return;
     }
 
-    // Sort serotypes (exclude __OTHERS__ — always goes last)
-    const sorted = Object.keys(data).filter(k => k !== '__OTHERS__');
-    if (sortBy === 'count') {
-      sorted.sort((a, b) => data[b].count - data[a].count);
-    } else if (sortBy === 'resistance') {
-      sorted.sort((a, b) => {
-        const aAvg = drugs.reduce((s, d) => s + (data[a].drugs[d]?.prevalence || 0), 0) / drugs.length;
-        const bAvg = drugs.reduce((s, d) => s + (data[b].drugs[d]?.prevalence || 0), 0) / drugs.length;
-        return bAvg - aAvg;
-      });
-    } else if (sortBy === 'mdr') {
-      sorted.sort((a, b) => data[b].mdr - data[a].mdr);
-    } else {
-      sorted.sort((a, b) => a.localeCompare(b));
+    if (drugsSelected.length === filteredDrugOptions.length) {
+      setDrugsSelected([]);
+      return;
     }
+    setDrugsSelected(filteredDrugOptions);
+  }
 
-    const finalList = sorted.slice(0, MAX_SEROTYPES);
-    if (data['__OTHERS__']) finalList.push('__OTHERS__');
+  function handleChangeDrugSearch(event) {
+    event.stopPropagation();
+    setDrugSearch(event.target.value);
+  }
 
-    return { serotypes: finalList, serotypeData: data };
-  }, [rawData, organism, drugs, sortBy, vaccineFilter]);
+  function clearDrugSearch(event) {
+    event.stopPropagation();
+    setDrugSearch('');
+  }
 
   if (!canGetData || organism !== 'strepneumo') return null;
 
   return (
     <CardContent className={classes.serotypeResistanceGraph}>
-      <Box className={classes.controlsRow}>
-        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-          <Box className={classes.legendBar} sx={{ padding: 0, paddingBottom: '4px' }}>
-            <Typography variant="body2" fontWeight={600}>
-              Serotype × Resistance
-            </Typography>
-            <Tooltip title="Shows resistance prevalence for each S. pneumoniae serotype across all drugs. Critical for evaluating vaccine impact on AMR — PCV13/PCV20 coverage is highlighted.">
-              <InfoOutlined fontSize="small" sx={{ cursor: 'pointer', color: 'rgba(0,0,0,0.5)' }} />
-            </Tooltip>
-          </Box>
-        </Box>
-        {/* Vaccine filter and Sort by dropdowns moved to the right-hand
-            floating plotting-options panel (see end of return). */}
-      </Box>
-
-      {/* Legend */}
-      <Box className={classes.legendBar}>
-        <Typography variant="caption">0%</Typography>
-        <Box
-          className={classes.legendGradient}
-          sx={{
-            background: 'linear-gradient(to right, #e8f5e9 0%, #fff9c4 15%, #ffcc80 35%, #ef6c00 65%, #b71c1c 100%)',
-          }}
-        />
-        <Typography variant="caption">60%+</Typography>
-        <Box sx={{ marginLeft: '12px', display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-          {VACCINE_LEGEND.map(({ key, label }) => (
-            <Box key={key} sx={{ display: 'flex', alignItems: 'center', gap: '3px' }}>
-              <Box sx={{ width: 8, height: 8, backgroundColor: VACCINE_COLORS[key], borderRadius: '1px' }} />
-              <Typography variant="caption" sx={{ fontSize: '9px' }}>
-                {label}
-              </Typography>
-            </Box>
-          ))}
-        </Box>
-      </Box>
-
-      <Box className={classes.graphWrapper}>
-        <Box className={classes.heatmapArea}>
-          {serotypes.length === 0 ? (
-            <Box className={classes.noSelection}>
-              <Typography variant="body2" color="textSecondary">
-                {organism !== 'strepneumo'
-                  ? 'Serotype analysis available for S. pneumoniae only'
-                  : `No serotypes with N≥${MIN_SEROTYPE_COUNT}`}
-              </Typography>
-            </Box>
-          ) : (
-            <Box>
-              {/* Header */}
-              <Box className={classes.headerRow}>
-                <Box className={classes.serotypeLabel}>
-                  <Typography variant="caption" fontWeight={600}>
-                    Serotype
-                  </Typography>
-                </Box>
-                {drugs.map(drug => (
-                  <Box key={drug} className={classes.drugLabel}>
-                    <Typography
-                      variant="caption"
-                      sx={{
-                        fontSize: '9px',
-                        fontWeight: 600,
-                        writingMode: 'vertical-rl',
-                        transform: 'rotate(180deg)',
-                        whiteSpace: 'nowrap',
-                      }}
-                    >
-                      {drug}
-                    </Typography>
-                  </Box>
-                ))}
-                <Box className={classes.drugLabel}>
-                  <Typography
-                    variant="caption"
-                    sx={{
-                      fontSize: '9px',
-                      fontWeight: 700,
-                      writingMode: 'vertical-rl',
-                      transform: 'rotate(180deg)',
-                      color: '#d32f2f',
-                    }}
-                  >
-                    MDR
-                  </Typography>
-                </Box>
-              </Box>
-
-              {/* Data rows */}
-              {serotypes.map(st => {
-                const data = serotypeData[st];
-                if (!data) return null;
-                const isOthers = st === '__OTHERS__';
-                const vaccineColor = isOthers ? null : getVaccineColor(st);
-
-                return (
-                  <Box
-                    key={st}
-                    className={classes.dataRow}
-                    sx={
-                      isOthers
-                        ? { borderTop: '2px dashed #bbb', marginTop: '4px', backgroundColor: 'rgba(0,0,0,0.03)' }
-                        : {}
-                    }
-                  >
-                    <Box
-                      className={classes.serotypeLabel}
-                      sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: '4px' }}
-                    >
-                      {vaccineColor && (
-                        <Box
-                          sx={{
-                            width: 6,
-                            height: 6,
-                            backgroundColor: vaccineColor,
-                            borderRadius: '1px',
-                            flexShrink: 0,
-                          }}
-                        />
-                      )}
-                      <Typography
-                        variant="caption"
-                        sx={{
-                          fontSize: '11px',
-                          fontWeight: isOthers ? 600 : vaccineColor ? 600 : 400,
-                          fontStyle: isOthers ? 'italic' : 'normal',
-                        }}
-                        noWrap
-                      >
-                        {isOthers ? 'Others' : st}
-                      </Typography>
-                      <Typography variant="caption" sx={{ fontSize: '9px', color: '#999' }}>
-                        ({data.count})
-                      </Typography>
-                    </Box>
-                    {drugs.map(drug => {
-                      const cellData = data.drugs[drug];
-                      const value = cellData?.prevalence ?? 0;
-                      return (
-                        <Tooltip
-                          key={`${st}-${drug}`}
-                          title={
-                            <Box>
-                              <Typography variant="caption" fontWeight={600}>
-                                {isOthers ? 'Others' : `Serotype ${st}`} — {drug}
-                              </Typography>
-                              <br />
-                              <Typography variant="caption">
-                                Resistance: {value}% ({cellData?.count || 0}/{data.count})
-                              </Typography>
-                            </Box>
-                          }
-                          arrow
-                          placement="top"
-                        >
-                          <Box className={classes.cell} sx={{ backgroundColor: getPrevalenceColor(value) }}>
-                            {value > 0 && (
-                              <Typography
-                                variant="caption"
-                                sx={{ fontSize: '8px', color: getTextColor(value), fontWeight: value > 30 ? 600 : 400 }}
+      <div className={classes.graphWrapper}>
+        <div className={classes.graph} style={loadingPDF ? { overflow: 'visible' } : undefined} id="VAC">
+          {chartRows.map((row, index) => (
+            <ResponsiveContainer
+              key={`serotype-heatmap-${index}`}
+              width={yAxisWidth + 65 * columns.length}
+              height={index === 0 ? 65 + FIRST_ROW_AXIS_HEIGHT : 65}
+            >
+              <ScatterChart cursor={isTouchDevice() ? 'default' : 'pointer'} margin={{ top: 0, bottom: 0 }}>
+                <XAxis
+                  type="category"
+                  dataKey="itemName"
+                  interval={0}
+                  height={index === 0 ? FIRST_ROW_AXIS_HEIGHT : 0}
+                  tick={
+                    index === 0
+                      ? props => {
+                          const title = props.payload.value;
+                          return (
+                            <Tooltip title={title} placement="top">
+                              <text
+                                x={props.x}
+                                y={props.y}
+                                fontSize="14px"
+                                dy={-10}
+                                textAnchor="start"
+                                transform={`rotate(-45, ${props.x}, ${props.y})`}
+                                fill="rgb(128,128,128)"
                               >
-                                {Math.round(value)}
-                              </Typography>
-                            )}
-                          </Box>
-                        </Tooltip>
-                      );
-                    })}
-                    {/* MDR column */}
-                    <Tooltip title={`MDR (≥3 drugs): ${data.mdr}%`} arrow placement="top">
-                      <Box className={classes.cell} sx={{ backgroundColor: getPrevalenceColor(data.mdr) }}>
-                        <Typography
-                          variant="caption"
-                          sx={{ fontSize: '8px', color: getTextColor(data.mdr), fontWeight: 600 }}
-                        >
-                          {Math.round(data.mdr)}
-                        </Typography>
-                      </Box>
-                    </Tooltip>
-                  </Box>
-                );
-              })}
-            </Box>
-          )}
-        </Box>
+                                {truncateWord(title)}
+                              </text>
+                            </Tooltip>
+                          );
+                        }
+                      : false
+                  }
+                  axisLine={false}
+                  orientation="top"
+                />
 
-        <Box className={classes.rightSide}>
-          <Typography variant="body2" fontWeight={600}>
-            Vaccine Coverage
-          </Typography>
-          <Box className={classes.tooltipWrapper}>
-            <Typography variant="caption" sx={{ lineHeight: 1.6 }}>
-              <strong>PCV7:</strong> {PCV7_SEROTYPES.join(', ')}
-              <br />
-              <br />
-              <strong>PCV10 additional:</strong> {PCV10_SEROTYPES.filter(s => !PCV7_SEROTYPES.includes(s)).join(', ')}
-              <br />
-              <br />
-              <strong>PCV13 additional:</strong> {PCV13_SEROTYPES.filter(s => !PCV10_SEROTYPES.includes(s)).join(', ')}
-              <br />
-              <br />
-              <strong>PCV15 additional:</strong> {PCV15_SEROTYPES.filter(s => !PCV13_SEROTYPES.includes(s)).join(', ')}
-              <br />
-              <br />
-              <strong>PCV20 additional:</strong> {PCV20_EXTRA.filter(s => !PCV15_SEROTYPES.includes(s)).join(', ')}
-              <br />
-              <br />
-              <strong>Clinical significance:</strong> If vaccine-type serotypes carry high resistance, vaccination
-              programs could reduce AMR burden by preventing resistant infections. Non-vaccine serotypes with high
-              resistance may indicate serotype replacement risk.
-              <br />
-              <br />
-              <strong>MDR:</strong> Resistant to ≥3 drug classes. Serotypes with high MDR rates are priority targets for
-              prevention strategies.
-            </Typography>
-          </Box>
+                <YAxis
+                  type="number"
+                  dataKey="index"
+                  name={row.name.toLowerCase()}
+                  tick={false}
+                  tickLine={false}
+                  axisLine={false}
+                  domain={[1, 1]}
+                  label={{ value: row.name, position: 'insideRight' }}
+                  width={yAxisWidth}
+                />
+
+                <ZAxis type="number" dataKey="percentage" range={[3500, 3500]} />
+
+                <ChartTooltip
+                  cursor={{ fill: hoverColor }}
+                  wrapperStyle={{ zIndex: 100 }}
+                  offset={40}
+                  content={({ payload, active }) => {
+                    if (payload !== null && active && payload.length) {
+                      const point = payload[0]?.payload;
+                      const serotypeLabel = point.itemName === OTHER_LABEL ? OTHER_LABEL : `Serotype ${point.itemName}`;
+                      return (
+                        <div
+                          className={classes.chartTooltipLabel}
+                          style={{ marginTop: index + 1 === chartRows.length ? -40 : 0 }}
+                        >
+                          <Typography variant="body1" fontWeight="500">
+                            {serotypeLabel}
+                          </Typography>
+                          <Typography variant="caption" fontWeight="500">
+                            Total: {point.total}
+                          </Typography>
+                          <Typography variant="body2">
+                            {`${point.typeName}: ${point.count} (${point.percentage}%)`}
+                          </Typography>
+                        </div>
+                      );
+                    }
+                    return null;
+                  }}
+                />
+
+                <Scatter data={row.items} shape="square">
+                  {row.items.map((option, cellIndex) => (
+                    <Cell
+                      key={`serotype-cell-${cellIndex}`}
+                      fill={option.percentage === 0 ? darkGrey : mixColorScale(option.percentage)}
+                    />
+                  ))}
+                  <LabelList
+                    dataKey="percentage"
+                    fontSize={12}
+                    content={({ x, y, value }) => {
+                      return (
+                        <text
+                          x={x + 33}
+                          y={y + 38}
+                          textAnchor="middle"
+                          fontSize={15}
+                          fontWeight={600}
+                          fill={heatmapTextColor(value)}
+                          pointerEvents="none"
+                        >
+                          {value}
+                        </text>
+                      );
+                    }}
+                  />
+                </Scatter>
+              </ScatterChart>
+            </ResponsiveContainer>
+          ))}
+        </div>
+      </div>
+
+      {(columns.length === 0 || drugsSelected.length === 0) && (
+        <Box className={classes.nothingSelected}>
+          <Typography fontWeight={600}>{t('common.noDataToShow')}</Typography>
         </Box>
-      </Box>
+      )}
+
+      <Divider className={classes.divider} />
+      <div className={classes.bottomLegend}>
+        <div className={classes.legend}>
+          <Typography fontSize="0.75rem">0%</Typography>
+          <Box className={classes.singleBox} sx={{ backgroundColor: darkGrey }} />
+        </div>
+        <div className={classes.legend}>
+          <Typography fontSize="0.75rem">1%</Typography>
+          <Box className={classes.gradientBox} style={{ backgroundImage: heatmapLegendGradient() }} />
+          <Typography fontSize="0.75rem">100%</Typography>
+        </div>
+      </div>
 
       {showFilter && (
         <Box className={classes.floatingFilter}>
@@ -435,44 +348,77 @@ export const SerotypeResistanceGraph = ({ showFilter, setShowFilter }) => {
                 onClose={() => setShowFilter && setShowFilter(false)}
                 className={classes.titleWrapper}
               />
-              <SelectCountry />
-              <Box className={classes.panelSelectWrapper}>
-                <Typography variant="caption" className={classes.panelLabel}>
-                  Vaccine filter
-                </Typography>
-                <Select
-                  value={vaccineFilter}
-                  onChange={e => setVaccineFilter(e.target.value)}
-                  size="small"
-                  fullWidth
-                  sx={{ fontSize: '13px' }}
-                >
-                  <MenuItem value="all">All serotypes</MenuItem>
-                  <MenuItem value="pcv7">PCV7 only</MenuItem>
-                  <MenuItem value="pcv10">PCV10 only</MenuItem>
-                  <MenuItem value="pcv13">PCV13 only</MenuItem>
-                  <MenuItem value="pcv15">PCV15 only</MenuItem>
-                  <MenuItem value="pcv20">PCV20 only</MenuItem>
-                  <MenuItem value="non-vaccine">Non-vaccine types</MenuItem>
-                </Select>
-              </Box>
-              <Box className={classes.panelSelectWrapper}>
-                <Typography variant="caption" className={classes.panelLabel}>
-                  Sort by
-                </Typography>
-                <Select
-                  value={sortBy}
-                  onChange={e => setSortBy(e.target.value)}
-                  size="small"
-                  fullWidth
-                  sx={{ fontSize: '13px' }}
-                >
-                  <MenuItem value="count">Sample count</MenuItem>
-                  <MenuItem value="resistance">Avg. resistance</MenuItem>
-                  <MenuItem value="mdr">MDR rate</MenuItem>
-                  <MenuItem value="alphabetical">Alphabetical</MenuItem>
-                </Select>
-              </Box>
+              <div className={classes.selectsWrapper}>
+                <SelectCountry />
+                <div className={classes.selectPreWrapper}>
+                  <div className={classes.selectWrapper}>
+                    <div className={classes.labelWrapper}>
+                      <Typography variant="caption">{t('common.selectDrug')}</Typography>
+                      <Tooltip title="Serotype columns are fixed and ordered by vaccine coverage." placement="top">
+                        <InfoOutlined color="action" fontSize="small" className={classes.labelTooltipIcon} />
+                      </Tooltip>
+                    </div>
+                    <Select
+                      multiple
+                      value={drugsSelected}
+                      onChange={event => handleChangeDrugsSelected({ event })}
+                      displayEmpty
+                      disabled={organism === 'none'}
+                      endAdornment={
+                        <Button
+                          variant="outlined"
+                          className={classes.selectButton}
+                          onClick={() => handleChangeDrugsSelected({ all: true })}
+                          disabled={organism === 'none'}
+                          color={drugsSelected.length === filteredDrugOptions.length ? 'error' : 'primary'}
+                        >
+                          {drugsSelected.length === filteredDrugOptions.length
+                            ? t('common.clearAll')
+                            : t('common.selectAll')}
+                        </Button>
+                      }
+                      inputProps={{ className: classes.multipleSelectInput }}
+                      MenuProps={{
+                        disableAutoFocusItem: true,
+                        classes: { paper: classes.menuPaper, list: classes.selectMenu },
+                      }}
+                      renderValue={selected => <div>{`${selected?.length} of ${drugOptions.length} selected`}</div>}
+                      onClose={clearDrugSearch}
+                    >
+                      <Box
+                        className={classes.selectSearch}
+                        onClick={e => e.stopPropagation()}
+                        onKeyDown={e => e.stopPropagation()}
+                      >
+                        <TextField
+                          variant="standard"
+                          placeholder={'Search for more...'}
+                          fullWidth
+                          value={drugSearch}
+                          onChange={handleChangeDrugSearch}
+                          InputProps={
+                            drugSearch === ''
+                              ? undefined
+                              : {
+                                  endAdornment: (
+                                    <IconButton size="small" onClick={clearDrugSearch}>
+                                      <Clear />
+                                    </IconButton>
+                                  ),
+                                }
+                          }
+                        />
+                      </Box>
+                      {filteredDrugOptions.map((option, index) => (
+                        <MenuItem key={`serotype-drug-option-${index}`} value={option}>
+                          <Checkbox checked={drugsSelected.indexOf(option) > -1} />
+                          <ListItemText primary={option} />
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </div>
+                </div>
+              </div>
             </CardContent>
           </Card>
         </Box>

--- a/client/src/components/Elements/Graphs/SerotypeResistanceGraph/SerotypeResistanceGraphMUI.js
+++ b/client/src/components/Elements/Graphs/SerotypeResistanceGraph/SerotypeResistanceGraphMUI.js
@@ -1,120 +1,139 @@
 import { makeStyles } from '@mui/styles';
 
-const useStyles = makeStyles((_theme) => ({
+const useStyles = makeStyles(() => ({
   serotypeResistanceGraph: {
     display: 'flex',
     flexDirection: 'column',
     borderTop: '1px solid rgba(0, 0, 0, 0.12)',
+    padding: '0px 0px 24px 0px !important',
+  },
+  selectsWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+  },
+  selectPreWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    width: '100%',
+  },
+  selectWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    flex: 1,
+    width: '100%',
+  },
+  selectInput: {
+    fontSize: '14px !important',
+    fontWeight: '600 !important',
+    padding: '8px 32px 8px 8px !important',
+  },
+  multipleSelectInput: {
+    fontSize: '14px !important',
+    fontWeight: '600 !important',
+    padding: '8px 32px 8px 8px !important',
+    marginRight: '-80px !important',
+  },
+  selectButton: {
+    height: '20px',
+    fontSize: '10px !important',
+    padding: '3px 5px !important',
+    whiteSpace: 'nowrap',
+    position: 'absolute',
+    right: '18px',
+  },
+  menuPaper: {
+    maxHeight: '350px !important',
+  },
+  selectMenu: {
+    '& .MuiMenuItem-root': {
+      fontSize: '14px',
+    },
+    '& .MuiCheckbox-root': {
+      padding: '0px 8px 0px 0px',
+    },
   },
   graphWrapper: {
-    paddingTop: '16px',
+    padding: '16px 16px 0px',
     display: 'flex',
     flexDirection: 'row',
     gap: '16px',
 
     '@media (max-width: 1000px)': {
       flexDirection: 'column',
+      height: '100%',
     },
   },
-  heatmapArea: {
-    flex: 1,
+  graph: {
+    height: '100%',
+    width: '100%',
     overflowX: 'auto',
-    overflowY: 'auto',
-    maxHeight: '550px',
-  },
-  rightSide: {
-    display: 'flex',
-    flexDirection: 'column',
-    width: '250px',
-    minWidth: '250px',
-    rowGap: '8px',
+    overflowY: 'hidden',
 
     '@media (max-width: 1000px)': {
       width: '100%',
-      minWidth: 'unset',
+    },
+
+    '@media (max-width: 500px)': {
+      width: '100%',
+    },
+
+    '& .recharts-surface': {
+      overflow: 'visible',
     },
   },
-  headerRow: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    borderBottom: '1px solid #ddd',
-    paddingBottom: '4px',
-    marginBottom: '2px',
-    position: 'sticky',
-    top: 0,
+  chartTooltipLabel: {
     backgroundColor: '#fff',
-    zIndex: 1,
+    padding: '8px',
+    border: 'solid rgba(0, 0, 0, 0.25) 1px',
   },
-  serotypeLabel: {
-    width: '100px',
-    minWidth: '100px',
-    paddingRight: '8px',
-    textAlign: 'right',
-    flexShrink: 0,
-  },
-  drugLabel: {
-    flex: '1 1 0',
-    minWidth: 0,
-    textAlign: 'center',
-  },
-  dataRow: {
+  bottomLegend: {
+    padding: '16px 16px 0px',
     display: 'flex',
     flexDirection: 'row',
-    alignItems: 'center',
-    '&:hover': {
-      backgroundColor: 'rgba(0,0,0,0.03)',
-    },
-  },
-  cell: {
-    flex: '1 1 0',
-    minWidth: 0,
-    height: '24px',
-    display: 'flex',
-    alignItems: 'center',
     justifyContent: 'center',
-    margin: '0 0.5px',
-    borderRadius: '2px',
-    cursor: 'pointer',
-    '&:hover': {
-      opacity: 0.8,
-      outline: '1px solid #333',
-    },
-  },
-  legendBar: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: '8px',
-    padding: '8px 0',
-  },
-  legendGradient: {
-    width: '160px',
-    height: '14px',
-    borderRadius: '2px',
-    border: '1px solid #ccc',
-  },
-  tooltipWrapper: {
-    borderRadius: '6px',
-    backgroundColor: '#E5E5E5',
-    overflowY: 'auto',
-    padding: '12px',
-    height: '100%',
-  },
-  noSelection: {
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-    height: '120px',
-  },
-  controlsRow: {
-    display: 'flex',
     gap: '16px',
-    flexWrap: 'wrap',
-    alignItems: 'flex-end',
-    paddingTop: '8px',
   },
-  // ── Floating plotting-options panel (matches DrugResistanceGraph pattern) ──
+  legend: {
+    display: 'flex',
+    flexDirection: 'row',
+    gap: '8px',
+    alignItems: 'center',
+  },
+  singleBox: {
+    height: '15px',
+    width: '15px',
+  },
+  gradientBox: {
+    height: '15px',
+    width: '100px',
+    backgroundImage: `linear-gradient(to right,
+      #D3D3D3 0%,
+      #0288D1 1%,
+      #FFE0B2 20%,
+      #DD2C24 100%)`,
+  },
+  divider: {
+    paddingTop: '16px',
+  },
+  labelWrapper: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    columnGap: '8px',
+    paddingBottom: '4px',
+  },
+  labelTooltipIcon: {
+    cursor: 'pointer',
+  },
+  nothingSelected: {
+    padding: '24px 8px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'lightgoldenrodyellow',
+  },
   floatingFilter: {
     position: 'absolute',
     top: 16,
@@ -133,14 +152,8 @@ const useStyles = makeStyles((_theme) => ({
     alignItems: 'center',
     justifyContent: 'space-between',
   },
-  panelSelectWrapper: {
-    display: 'flex',
-    flexDirection: 'column',
-    paddingTop: '8px',
-  },
-  panelLabel: {
-    fontWeight: 600,
-    paddingBottom: '4px',
+  selectSearch: {
+    padding: '0px 16px !important',
   },
 }));
 


### PR DESCRIPTION
July review, Strep item: *'This should be changed to match the style of all other heatmaps… like AMR by genotype. It should look the same but have serotypes instead of ST as columns.'*

## What
Restyles the S. pneumoniae **AMR by serotype** plot (card `VAC`) to match the **AMR marker by genotype** bubble heatmap:
- columns = **serotypes**, rows = drugs, bubble/heatmap cells, gradient legend, floating 'Select drug' plotting-options panel (with SelectCountry).
- serotype columns ordered by **vaccine coverage**: 4, 6B, 9V, 14, 18C, 19F, 23F, 1, 5, 7F, 3, 6A, 19A, 22F, 33F, 8, 10A, 11A, 12F, 15B, then **Other** (matches Kat's exact list).
- serotype × drug matrix computed from `rawOrganismData` grouped by `Serotype` (normalised, e.g. 06B→6B), respecting the country/region filter.

## Deferred (per Kat)
The **PCV serotype-set selector** (PCV7/PCV13…) was explicitly *'not necessary in the first release'* — not included; can be added in a later dev iteration. strepneumo stays dev-only.

## To confirm on visual QA
- Orientation (serotypes as columns / drugs as rows) matches Kat's mental model.
- Whether to keep a min-N gate on serotype columns (old code used N≥10; this shows every listed serotype with ≥1 genome to preserve the exact ordering).

Built on current development. `craco build` passes.