### PR TITLE
fix(shige): Kat feedback — Genotype view genotype-only, title, LIN code select-all

### DIFF
--- a/client/src/components/Elements/Map/MapFilters/MapFilters.js
+++ b/client/src/components/Elements/Map/MapFilters/MapFilters.js
@@ -457,6 +457,21 @@ export const MapFilters = ({ showFilter, setShowFilter }) => {
     [filteredNonResistanceOptions, nonResistanceOptions, organismHasLotsOfGenotypes],
   );
 
+  // For the 'LIN code prevalence' view, "Select all" targets every LIN code that
+  // matches the current prefix search (all of them, not just the 20 shown), so
+  // the user can colour a whole prefix at once (Kat's request). For other views
+  // it keeps the previous behaviour (the full option set).
+  const selectAllOptions = useMemo(() => {
+    if (!isLinCodePrevalence) return currentOptions;
+    const s = genotypeSearch.toLowerCase();
+    return nonResistanceOptions.filter(o => o.toLowerCase().startsWith(s));
+  }, [isLinCodePrevalence, genotypeSearch, nonResistanceOptions, currentOptions]);
+
+  const allTargetSelected = useMemo(
+    () => selectAllOptions.length > 0 && selectAllOptions.every(o => optionsSelected.includes(o)),
+    [selectAllOptions, optionsSelected],
+  );
+
   function handleNonResistanceChange({ event = null, all = false }) {
     const value = event?.target.value;
 
@@ -474,16 +489,14 @@ export const MapFilters = ({ showFilter, setShowFilter }) => {
       return;
     }
 
-    if (currentOptions.length === optionsSelected.length) {
-      dispatch(isNGMASTPrevalence ? setCustomDropdownMapViewNG([]) : setPrevalenceMapViewOptionsSelected([]));
-      return;
-    }
+    // "Select all" toggle: if the whole target set is already selected, remove
+    // it; otherwise add it (union with the existing selection, so multiple
+    // prefixes can be accumulated on the LIN code view).
+    const next = allTargetSelected
+      ? optionsSelected.filter(o => !selectAllOptions.includes(o))
+      : [...new Set([...optionsSelected, ...selectAllOptions])];
 
-    dispatch(
-      isNGMASTPrevalence
-        ? setCustomDropdownMapViewNG(currentOptions)
-        : setPrevalenceMapViewOptionsSelected(currentOptions),
-    );
+    dispatch(isNGMASTPrevalence ? setCustomDropdownMapViewNG(next) : setPrevalenceMapViewOptionsSelected(next));
   }
 
   function hangleChangeSearch(event) {
@@ -683,11 +696,13 @@ export const MapFilters = ({ showFilter, setShowFilter }) => {
                             className={classes.selectButton}
                             onClick={() => handleNonResistanceChange({ all: true })}
                             disabled={organism === 'none'}
-                            color={currentOptions.length === optionsSelected.length ? 'error' : 'primary'}
+                            color={allTargetSelected ? 'error' : 'primary'}
                           >
-                            {currentOptions.length === optionsSelected.length
+                            {allTargetSelected
                               ? t('dashboard.filters.plotOptions.clearAll')
-                              : t('dashboard.filters.plotOptions.selectAll')}
+                              : isLinCodePrevalence && genotypeSearch
+                                ? t('dashboard.filters.plotOptions.selectAllMatching', 'Select all matching')
+                                : t('dashboard.filters.plotOptions.selectAll')}
                           </Button>
                         }
                         inputProps={{ className: classes.multipleSelectInput }}

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -68,7 +68,8 @@
           "kpneumo": "Sequence type are labelled as 7-locus MLST",
           "shige": "Lineages are labelled as Species + HC400 cluster",
           "sentericaints": "Lineages are labelled as 7-locus MLST and HC150(305,1547,48,9882,728,12675,2452) cluster"
-        }
+        },
+        "selectAllMatching": "Select all matching"
       }
     },
     "mapViews": {

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -68,7 +68,8 @@
           "kpneumo": "Los tipos de secuencia se etiquetan como MLST de 7 loci",
           "shige": "Los linajes se etiquetan como Especie + clúster HC400",
           "sentericaints": "Los linajes se etiquetan como MLST de 7 loci y clúster HC150(305,1547,48,9882,728,12675,2452)"
-        }
+        },
+        "selectAllMatching": "Seleccionar todos los coincidentes"
       }
     },
     "mapViews": {

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -68,7 +68,8 @@
           "kpneumo": "Les types de séquence sont étiquetés comme MLST sur 7 loci",
           "shige": "Les lignées sont étiquetées comme Espèce + cluster HC400",
           "sentericaints": "Les lignées sont étiquetées comme MLST sur 7 loci et cluster HC150(305,1547,48,9882,728,12675,2452)"
-        }
+        },
+        "selectAllMatching": "Tout sélectionner (correspondants)"
       }
     },
     "mapViews": {

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -68,7 +68,8 @@
           "kpneumo": "Os tipos de sequência são rotulados como MLST de 7 loci",
           "shige": "As linhagens são rotuladas como Espécie + cluster HC400",
           "sentericaints": "As linhagens são rotuladas como MLST de 7 loci e cluster HC150(305,1547,48,9882,728,12675,2452)"
-        }
+        },
+        "selectAllMatching": "Selecionar todos correspondentes"
       }
     },
     "mapViews": {

--- a/client/src/util/mapViewTranslationKeys.js
+++ b/client/src/util/mapViewTranslationKeys.js
@@ -4,7 +4,9 @@ export const mapViewToTranslationKey = {
   'Genotype prevalence': 'genotypePrevalence',
   'ST prevalence': 'stPrevalence',
   'Lineage prevalence (ST)': 'lineagePrevalence',
-  'Lincode prevalence': 'lincodePrevalence',
+  // shige: the 'Lincode prevalence' view is presented as 'Genotype prevalence'
+  // (it is the genotype mapped from the LINcode) — keep the plot title consistent.
+  'Lincode prevalence': 'genotypePrevalence',
   'LIN code prevalence': 'linCodePrevalence',
   'NG-MAST prevalence': 'ngmastPrevalence',
   'Serotype prevalence': 'serotypePrevalence',

--- a/client/src/util/shigeLincode.js
+++ b/client/src/util/shigeLincode.js
@@ -117,15 +117,16 @@ export function shigeSpeciesCode(pathovar) {
 export function shigeGenotypeLabel(item) {
   if (!item) return null;
   const code = shigeSpeciesCode(item.Pathovar);
-  const st = item.GENOTYPE && item.GENOTYPE !== '-' ? item.GENOTYPE : null;
+  // EIEC has no fine genotype in the (Shigella-centric) LINcode scheme — it is
+  // shown by ST in the 'ST prevalence' view, not here.
+  if (code === 'EIEC') return null;
 
-  if (code === 'EIEC') return st ? `EIEC ${st}` : null;
-
+  // 'Genotype prevalence' shows genotypes only — never an ST. Genomes with no
+  // LINcode-mapped genotype are simply absent from this view (they appear under
+  // 'ST prevalence'); we do NOT fall back to a species+ST label, which would
+  // mix STs and genotypes in the same dropdown.
   const { numeric } = deriveShigeLincode(resolveShigeLincode(item));
-  if (numeric) {
-    if (!code) return numeric;
-    return numeric.toLowerCase().startsWith(code.toLowerCase()) ? numeric : `${code} ${numeric}`;
-  }
-  // Shigella species with no genotype match — fall back to the species-prefixed ST.
-  return code && st ? `${code} ${st}` : null;
+  if (!numeric) return null;
+  if (!code) return numeric;
+  return numeric.toLowerCase().startsWith(code.toLowerCase()) ? numeric : `${code} ${numeric}`;
 }


### PR DESCRIPTION
Addresses Kat's three points from her dashboard review.

**Genotype prevalence**
1. *'I see a mix of STs and genotypes, e.g. Ss ST152, Ss 3.725 — it should be either an ST or a genotype.'* → the view now shows **genotypes only**: the species+ST fallback is removed and EIEC is excluded (it has no fine genotype). Un-genotyped genomes appear under **ST prevalence** instead. Verified on the DB: S. sonnei yields genotype labels only (no ' ST'); EIEC → none here.
2. *'The map plot title says Lincode prevalence, it should be Genotype prevalence.'* → `mapViewToTranslationKey` maps the view to `genotypePrevalence`, so the title matches.

**LIN code prevalence**
3. *'add the functionality to select ALL the LIN codes that match the prefix.'* → **Select all** now targets every LIN code matching the current prefix search (not just the 20 displayed), unioned with the existing selection so multiple prefixes accumulate; the button reads **'Select all matching'** when a prefix is entered. e.g. searching `0-2-0-0-0-0-0-1-0-1-0-2` then Select all matching colours every LIN code under that prefix.

## Note for Kat (follow-up)
With genotype-only enforced, EIEC no longer surfaces the 'EIEC ST270' alias anywhere — it now shows as the plain ST (ST6/ST270/ST99) under **ST prevalence**. If you'd like the species prefix on the ST-prevalence view (so it reads 'EIEC ST270', 'Ss ST152'), that's a small follow-up — let us know.

`craco build` passes.