### PR TITLE
fix(shige): LIN code select-all button reads 'Select all'

### DIFF
--- a/client/src/components/Elements/Map/MapFilters/MapFilters.js
+++ b/client/src/components/Elements/Map/MapFilters/MapFilters.js
@@ -700,9 +700,7 @@ export const MapFilters = ({ showFilter, setShowFilter }) => {
                           >
                             {allTargetSelected
                               ? t('dashboard.filters.plotOptions.clearAll')
-                              : isLinCodePrevalence && genotypeSearch
-                                ? t('dashboard.filters.plotOptions.selectAllMatching', 'Select all matching')
-                                : t('dashboard.filters.plotOptions.selectAll')}
+                              : t('dashboard.filters.plotOptions.selectAll')}
                           </Button>
                         }
                         inputProps={{ className: classes.multipleSelectInput }}

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -68,8 +68,7 @@
           "kpneumo": "Sequence type are labelled as 7-locus MLST",
           "shige": "Lineages are labelled as Species + HC400 cluster",
           "sentericaints": "Lineages are labelled as 7-locus MLST and HC150(305,1547,48,9882,728,12675,2452) cluster"
-        },
-        "selectAllMatching": "Select all matching"
+        }
       }
     },
     "mapViews": {

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -68,8 +68,7 @@
           "kpneumo": "Los tipos de secuencia se etiquetan como MLST de 7 loci",
           "shige": "Los linajes se etiquetan como Especie + clúster HC400",
           "sentericaints": "Los linajes se etiquetan como MLST de 7 loci y clúster HC150(305,1547,48,9882,728,12675,2452)"
-        },
-        "selectAllMatching": "Seleccionar todos los coincidentes"
+        }
       }
     },
     "mapViews": {

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -68,8 +68,7 @@
           "kpneumo": "Les types de séquence sont étiquetés comme MLST sur 7 loci",
           "shige": "Les lignées sont étiquetées comme Espèce + cluster HC400",
           "sentericaints": "Les lignées sont étiquetées comme MLST sur 7 loci et cluster HC150(305,1547,48,9882,728,12675,2452)"
-        },
-        "selectAllMatching": "Tout sélectionner (correspondants)"
+        }
       }
     },
     "mapViews": {

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -68,8 +68,7 @@
           "kpneumo": "Os tipos de sequência são rotulados como MLST de 7 loci",
           "shige": "As linhagens são rotuladas como Espécie + cluster HC400",
           "sentericaints": "As linhagens são rotuladas como MLST de 7 loci e cluster HC150(305,1547,48,9882,728,12675,2452)"
-        },
-        "selectAllMatching": "Selecionar todos correspondentes"
+        }
       }
     },
     "mapViews": {


### PR DESCRIPTION
Per feedback: keep the button label as **'Select all'** rather than 'Select all matching'. Behaviour is unchanged — on the LIN code view it still selects every LIN code matching the current prefix search. Removed the unused `selectAllMatching` locale keys. `craco build` passes.